### PR TITLE
Add Web App Compatible Meta Tags

### DIFF
--- a/views/app.blade.php
+++ b/views/app.blade.php
@@ -5,7 +5,10 @@
     <title>{{ $title }}</title>
     <meta name="description" content="{{ $description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="theme-color" content="{{ array_get($forum, 'attributes.themePrimaryColor') }}">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
 
     @foreach ($cssUrls as $url)
       <link rel="stylesheet" href="{{ $url }}">


### PR DESCRIPTION
This allows the app to be added to the homescreen for seamless integration with Chrome on Android and Safari on IOS.

[Android](https://developer.chrome.com/multidevice/android/installtohomescreen)
[IOS](https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html)
