### PR TITLE
Prevent Overwriting of User's Attributes on Register (#897)

### DIFF
--- a/src/Core/Command/RegisterUserHandler.php
+++ b/src/Core/Command/RegisterUserHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Flarum.
  *

--- a/src/Core/Command/RegisterUserHandler.php
+++ b/src/Core/Command/RegisterUserHandler.php
@@ -116,7 +116,7 @@ class RegisterUserHandler
         // from the get-go.
         if (isset($token)) {
             foreach ($token->payload as $k => $v) {
-                if ($user->$k == "" || ! isset($user->$k)) {
+                if ($user->$k == '' || ! isset($user->$k)) {
                     $user->$k = $v;
                 }
             }

--- a/src/Core/Command/RegisterUserHandler.php
+++ b/src/Core/Command/RegisterUserHandler.php
@@ -116,7 +116,7 @@ class RegisterUserHandler
         // from the get-go.
         if (isset($token)) {
             foreach ($token->payload as $k => $v) {
-                if ($user->$k == "" || !isset($user->$k)) {
+                if ($user->$k == "" || ! isset($user->$k)) {
                     $user->$k = $v;
                 }
             }

--- a/src/Core/Command/RegisterUserHandler.php
+++ b/src/Core/Command/RegisterUserHandler.php
@@ -116,7 +116,7 @@ class RegisterUserHandler
         // from the get-go.
         if (isset($token)) {
             foreach ($token->payload as $k => $v) {
-                if ($user->$k == '' || ! isset($user->$k)) {
+                if ($user->$k === '' || ! isset($user->$k)) {
                     $user->$k = $v;
                 }
             }

--- a/src/Core/Command/RegisterUserHandler.php
+++ b/src/Core/Command/RegisterUserHandler.php
@@ -115,7 +115,9 @@ class RegisterUserHandler
         // from the get-go.
         if (isset($token)) {
             foreach ($token->payload as $k => $v) {
-                $user->$k = $v;
+                if ($user->$k == "" || !isset($user->$k)) {
+                    $user->$k = $v;
+                }
             }
 
             if (isset($token->payload['email'])) {


### PR DESCRIPTION
I read through the entire SSO process and this is the only security issue I could even remotely find regarding to flarum/issue-archive#332. This will prevent any of the user's attributes to be overwritten. For example, if a SSO provider neglected to verify emails.
