### PR TITLE
Inform users that some posts/discussions are withheld from the profile (#1006)

### DIFF
--- a/js/forum/src/components/DiscussionsUserPage.js
+++ b/js/forum/src/components/DiscussionsUserPage.js
@@ -1,5 +1,5 @@
 import UserPage from 'flarum/components/UserPage';
-import DiscussionList from 'flarum/components/DiscussionList';
+import UserDiscussionList from 'flarum/components/UserDiscussionList';
 
 /**
  * The `DiscussionsUserPage` component shows a discussion list inside of a user
@@ -15,10 +15,11 @@ export default class DiscussionsUserPage extends UserPage {
   content() {
     return (
       <div className="DiscussionsUserPage">
-        {DiscussionList.component({
+        {UserDiscussionList.component({
           params: {
             q: 'author:' + this.user.username()
-          }
+          },
+          user: this.user
         })}
       </div>
     );

--- a/js/forum/src/components/PostsUserPage.js
+++ b/js/forum/src/components/PostsUserPage.js
@@ -2,6 +2,7 @@ import UserPage from 'flarum/components/UserPage';
 import LoadingIndicator from 'flarum/components/LoadingIndicator';
 import Button from 'flarum/components/Button';
 import CommentPost from 'flarum/components/CommentPost';
+import Placeholder from 'flarum/components/Placeholder';
 
 /**
  * The `PostsUserPage` component shows a user's activity feed inside of their
@@ -43,6 +44,7 @@ export default class PostsUserPage extends UserPage {
   }
 
   content() {
+    let posts_remaining = (this.user.data.attributes.commentsCount - this.posts.length);
     let footer;
 
     if (this.loading) {
@@ -59,6 +61,15 @@ export default class PostsUserPage extends UserPage {
       );
     }
 
+    if (this.posts.length === 0 && !this.loading && posts_remaining == 0) {
+      const text = app.translator.trans('core.forum.user.posts_empty_text');
+      return (
+        <div className="PostsUserPage">
+          {Placeholder.component({text})}
+        </div>
+      );
+    }
+
     return (
       <div className="PostsUserPage">
         <ul className="PostsUserPage-list">
@@ -70,6 +81,35 @@ export default class PostsUserPage extends UserPage {
               {CommentPost.component({post})}
             </li>
           ))}
+          {(posts_remaining > 0 && ! this.moreResults && !this.loading) ? (
+          <li>
+            <div class="PostsUserPage-discussion"></div>
+              <article class="Post CommentPost">
+                <div>
+                  <header class="Post-header">
+                    <ul>
+                      <li class="item-user">
+                        <div class="PostUser">
+                          <h3>
+                            <span>
+                              <span class="Avatar PostUser-avatar" style="background: rgb(255, 214, 108);">?</span>
+                              <span class="username">{app.translator.transChoice('core.forum.user.posts_missing_head', posts_remaining, {count: posts_remaining})}!</span>
+                            </span>
+                          </h3>
+                        </div>
+                      </li>
+                    </ul>
+                  </header>
+                <div class="Post-body">
+                  <p>{app.translator.trans('core.forum.user.content_missing_text')}</p>
+                </div>
+                <footer class="Post-footer">
+                  <ul></ul>
+                </footer>
+              </div>
+            </article>
+          </li>
+          ) : ''}
         </ul>
         {footer}
       </div>

--- a/js/forum/src/components/UserDiscussionList.js
+++ b/js/forum/src/components/UserDiscussionList.js
@@ -1,0 +1,81 @@
+import DiscussionList from 'flarum/components/DiscussionList';
+import DiscussionListItem from 'flarum/components/DiscussionListItem';
+import Button from 'flarum/components/Button';
+import LoadingIndicator from 'flarum/components/LoadingIndicator';
+import Placeholder from 'flarum/components/Placeholder';
+
+/**
+ * The `UserDiscussionList` component displays a list of discussions.
+ * This extends the `DiscussionList` component. The only difference being
+ * Placeholder posts are added in the place of discussions the actor
+ * cannot view.
+ *
+ * ### Props
+ *
+ * - `params` A map of parameters used to construct a refined parameter object
+ *   to send along in the API request to get discussion results.
+ */
+
+export default class UserDiscussionList extends DiscussionList {
+   view() {
+    const params = this.props.params;
+    let discussions_remaining = (this.props.user.data.attributes.discussionsCount - this.discussions.length);
+    let loading;
+
+    if (this.loading) {
+      loading = LoadingIndicator.component();
+    } else if (this.moreResults) {
+      loading = Button.component({
+        children: app.translator.trans('core.forum.discussion_list.load_more_button'),
+        className: 'Button',
+        onclick: this.loadMore.bind(this)
+      });
+    }
+
+    if (this.discussions.length === 0 && !this.loading && discussions_remaining == 0) {
+      const text = app.translator.trans('core.forum.discussion_list.empty_text');
+      return (
+        <div className="DiscussionList">
+          {Placeholder.component({text})}
+        </div>
+      );
+    }
+
+    return (
+      <div className="DiscussionList">
+        <ul className="DiscussionList-discussions">
+          {this.discussions.map(discussion => {
+            return (
+              <li key={discussion.id()} data-id={discussion.id()}>
+                {DiscussionListItem.component({discussion, params})}
+              </li>
+            );
+          })}
+          {(discussions_remaining > 0 && ! this.moreResults && !this.loading) ? (
+          <li>
+            <div class="DiscussionListItem">
+              <div class="DiscussionListItem-content">
+                <span class="DiscussionListItem-author" title="" data-original-title="{app.translator.transChoice('core.forum.user.discussions_missing_head', discussions_remaining, {count: discussions_remaining})}!">
+                  <span class="Avatar " style="background: rgb(255, 214, 108);">?</span>
+                </span>
+                <ul class="DiscussionListItem-badges badges"></ul>
+                <span class="DiscussionListItem-main">
+                  <h3 class="DiscussionListItem-title">{app.translator.transChoice('core.forum.user.discussions_missing_head', discussions_remaining, {count: discussions_remaining})}!</h3>
+                  <ul class="DiscussionListItem-info">
+                    <li class="item-terminalPost">
+                      <span>{app.translator.trans('core.forum.user.content_missing_text')}</span>
+                    </li>
+                  </ul>
+                </span>
+              </div>
+            </div>
+          </li>
+          ) : ''}
+        </ul>
+        <div className="DiscussionList-loadMore">
+          {loading}
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
This is the best fix I could think of for flarum/issue-archive#321. Here are some screenshots:

![discussions](http://i.imgur.com/jLexnwp.png)

![discussions2](http://i.imgur.com/P0FyFdN.png)

![posts](http://i.imgur.com/1UO9Ipv.png)

Here is the PR for the translations: https://github.com/flarum/flarum-ext-english/pull/84
