### PR TITLE
201 - Adding label next to discussion badges

### DIFF
--- a/js/lib/components/Badge.js
+++ b/js/lib/components/Badge.js
@@ -29,7 +29,7 @@ export default class Badge extends Component {
           <span {...attrs}>
             {iconName ? icon(iconName, {className: 'Badge-icon'}) : m.trust('&nbsp;')}
           </span>
-          <span className="Badge-label">{' ' + this.props.label + ' '}</span>
+          <span className="Badge-label">{this.props.label}</span>
         </div>
     );
   }

--- a/js/lib/components/Badge.js
+++ b/js/lib/components/Badge.js
@@ -25,9 +25,12 @@ export default class Badge extends Component {
     attrs.title = extract(attrs, 'label') || '';
 
     return (
-      <span {...attrs}>
-        {iconName ? icon(iconName, {className: 'Badge-icon'}) : m.trust('&nbsp;')}
-      </span>
+        <div>
+          <span {...attrs}>
+            {iconName ? icon(iconName, {className: 'Badge-icon'}) : m.trust('&nbsp;')}
+          </span>
+          <span className="Badge-label">{' ' + this.props.label + ' '}</span>
+        </div>
     );
   }
 

--- a/less/lib/Badge.less
+++ b/less/lib/Badge.less
@@ -6,9 +6,13 @@
   vertical-align: middle;
   text-align: center;
   .box-shadow(0 2px 4px @shadow-color);
+}
 
-  .Badge-label {
-    display: none;
+.Badge-label {
+  display: none;
+  .DiscussionHero &, .UserHero &{
+      display: inline-block;
+      margin: 0 10px 0 5px;
   }
 }
 


### PR DESCRIPTION
Adding labels next to the discussion badges, addressing https://github.com/flarum/core/issues/201 