### PR TITLE
Do not resolve services in extenders

### DIFF
--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -16,6 +16,7 @@ use Flarum\Frontend\Assets;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
 use Flarum\Frontend\Frontend as ActualFrontend;
 use Flarum\Frontend\RecompileFrontendAssets;
+use Flarum\Http\RouteCollection;
 use Flarum\Http\RouteHandlerFactory;
 use Illuminate\Contracts\Container\Container;
 
@@ -122,15 +123,20 @@ class Frontend implements ExtenderInterface
             return;
         }
 
-        $routes = $container->make("flarum.$this->frontend.routes");
-        $factory = $container->make(RouteHandlerFactory::class);
+        $container->resolving(
+            "flarum.{$this->frontend}.routes",
+            function (RouteCollection $collection, Container $container) {
+                /** @var RouteHandlerFactory $factory */
+                $factory = $container->make(RouteHandlerFactory::class);
 
-        foreach ($this->routes as $route) {
-            $routes->get(
-                $route['path'], $route['name'],
-                $factory->toFrontend($this->frontend, $route['content'])
-            );
-        }
+                foreach ($this->routes as $route) {
+                    $collection->get(
+                        $route['path'], $route['name'],
+                        $factory->toFrontend($this->frontend, $route['content'])
+                    );
+                }
+            }
+        );
     }
 
     private function registerContent(Container $container)

--- a/src/Extend/LanguagePack.php
+++ b/src/Extend/LanguagePack.php
@@ -37,8 +37,16 @@ class LanguagePack implements ExtenderInterface, LifecycleInterface
             );
         }
 
-        /** @var LocaleManager $locales */
-        $locales = $container->make(LocaleManager::class);
+        $container->resolving(
+            LocaleManager::class,
+            function (LocaleManager $locales) use ($extension, $locale, $title) {
+                $this->registerLocale($locales, $extension, $locale, $title);
+            }
+        );
+    }
+
+    private function registerLocale(LocaleManager $locales, Extension $extension, $locale, $title)
+    {
         $locales->addLocale($locale, $title);
 
         $directory = $extension->getPath().'/locale';

--- a/src/Extend/Locales.php
+++ b/src/Extend/Locales.php
@@ -27,33 +27,35 @@ class Locales implements ExtenderInterface, LifecycleInterface
 
     public function extend(Container $container, Extension $extension = null)
     {
-        /** @var LocaleManager $locales */
-        $locales = $container->make(LocaleManager::class);
+        $container->resolving(
+            LocaleManager::class,
+            function (LocaleManager $locales) {
+                foreach (new DirectoryIterator($this->directory) as $file) {
+                    if (! $file->isFile()) {
+                        continue;
+                    }
 
-        foreach (new DirectoryIterator($this->directory) as $file) {
-            if (! $file->isFile()) {
-                continue;
+                    $extension = $file->getExtension();
+                    if (! in_array($extension, ['yml', 'yaml'])) {
+                        continue;
+                    }
+
+                    $locales->addTranslations(
+                        $file->getBasename(".$extension"),
+                        $file->getPathname()
+                    );
+                }
             }
-
-            $extension = $file->getExtension();
-            if (! in_array($extension, ['yml', 'yaml'])) {
-                continue;
-            }
-
-            $locales->addTranslations(
-                $file->getBasename(".$extension"),
-                $file->getPathname()
-            );
-        }
+        );
     }
 
     public function onEnable(Container $container, Extension $extension)
     {
-        $container->make('flarum.locales')->clearCache();
+        $container->make(LocaleManager::class)->clearCache();
     }
 
     public function onDisable(Container $container, Extension $extension)
     {
-        $container->make('flarum.locales')->clearCache();
+        $container->make(LocaleManager::class)->clearCache();
     }
 }

--- a/src/Extend/Routes.php
+++ b/src/Extend/Routes.php
@@ -12,6 +12,7 @@
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;
+use Flarum\Http\RouteCollection;
 use Flarum\Http\RouteHandlerFactory;
 use Illuminate\Contracts\Container\Container;
 
@@ -69,19 +70,21 @@ class Routes implements ExtenderInterface
             return;
         }
 
-        /** @var \Flarum\Http\RouteCollection $collection */
-        $collection = $container->make("flarum.{$this->appName}.routes");
+        $container->resolving(
+            "flarum.{$this->appName}.routes",
+            function (RouteCollection $collection, Container $container) {
+                /** @var RouteHandlerFactory $factory */
+                $factory = $container->make(RouteHandlerFactory::class);
 
-        /** @var RouteHandlerFactory $factory */
-        $factory = $container->make(RouteHandlerFactory::class);
-
-        foreach ($this->routes as $route) {
-            $collection->addRoute(
-                $route['method'],
-                $route['path'],
-                $route['name'],
-                $factory->toController($route['handler'])
-            );
-        }
+                foreach ($this->routes as $route) {
+                    $collection->addRoute(
+                        $route['method'],
+                        $route['path'],
+                        $route['name'],
+                        $factory->toController($route['handler'])
+                    );
+                }
+            }
+        );
     }
 }

--- a/src/Frontend/RecompileFrontendAssets.php
+++ b/src/Frontend/RecompileFrontendAssets.php
@@ -11,12 +11,8 @@
 
 namespace Flarum\Frontend;
 
-use Flarum\Extension\Event\Disabled;
-use Flarum\Extension\Event\Enabled;
-use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\Event\Saved;
-use Illuminate\Contracts\Events\Dispatcher;
 
 class RecompileFrontendAssets
 {
@@ -38,17 +34,6 @@ class RecompileFrontendAssets
     {
         $this->assets = $assets;
         $this->locales = $locales;
-    }
-
-    /**
-     * @param Dispatcher $events
-     */
-    public function subscribe(Dispatcher $events)
-    {
-        $events->listen(Saved::class, [$this, 'whenSettingsSaved']);
-        $events->listen(Enabled::class, [$this, 'flush']);
-        $events->listen(Disabled::class, [$this, 'flush']);
-        $events->listen(ClearingCache::class, [$this, 'flush']);
     }
 
     public function whenSettingsSaved(Saved $event)


### PR DESCRIPTION
**First shot at flarum/issue-archive#269** (however there's lots of work left)

**Changes proposed in this pull request:**
We want to avoid resolving services in extenders - instead we add closures that are executed when the relevant services are resolved by someone else.

**Reviewers should focus on:**
My change of `RecompileFrontendAssets` away from the "event subscriber" pattern - in order to only resolve its dependencies when the corresponding events are fired (very few requests), rather than at the time the event listeners are bound (every single request).

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
