### PR TITLE
Don't resolve services when binding listeners

### DIFF
--- a/src/Discussion/DiscussionRenamedLogger.php
+++ b/src/Discussion/DiscussionRenamedLogger.php
@@ -15,7 +15,6 @@ use Flarum\Discussion\Event\Renamed;
 use Flarum\Notification\Blueprint\DiscussionRenamedBlueprint;
 use Flarum\Notification\NotificationSyncer;
 use Flarum\Post\DiscussionRenamedPost;
-use Illuminate\Contracts\Events\Dispatcher;
 
 class DiscussionRenamedLogger
 {
@@ -29,12 +28,7 @@ class DiscussionRenamedLogger
         $this->notifications = $notifications;
     }
 
-    public function subscribe(Dispatcher $events)
-    {
-        $events->listen(Renamed::class, [$this, 'whenDiscussionWasRenamed']);
-    }
-
-    public function whenDiscussionWasRenamed(Renamed $event)
+    public function handle(Renamed $event)
     {
         $post = DiscussionRenamedPost::reply(
             $event->discussion->id,

--- a/src/Discussion/DiscussionServiceProvider.php
+++ b/src/Discussion/DiscussionServiceProvider.php
@@ -11,6 +11,7 @@
 
 namespace Flarum\Discussion;
 
+use Flarum\Discussion\Event\Renamed;
 use Flarum\Foundation\AbstractServiceProvider;
 
 class DiscussionServiceProvider extends AbstractServiceProvider
@@ -24,6 +25,7 @@ class DiscussionServiceProvider extends AbstractServiceProvider
 
         $events->subscribe(DiscussionMetadataUpdater::class);
         $events->subscribe(DiscussionPolicy::class);
-        $events->subscribe(DiscussionRenamedLogger::class);
+
+        $events->listen(Renamed::class, DiscussionRenamedLogger::class);
     }
 }

--- a/src/Extension/DefaultLanguagePackGuard.php
+++ b/src/Extension/DefaultLanguagePackGuard.php
@@ -14,7 +14,6 @@ namespace Flarum\Extension;
 use Flarum\Extension\Event\Disabling;
 use Flarum\Http\Exception\ForbiddenException;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Illuminate\Contracts\Events\Dispatcher;
 
 class DefaultLanguagePackGuard
 {
@@ -29,18 +28,10 @@ class DefaultLanguagePackGuard
     }
 
     /**
-     * @param Dispatcher $events
-     */
-    public function subscribe(Dispatcher $events)
-    {
-        $events->listen(Disabling::class, [$this, 'whenExtensionWillBeDisabled']);
-    }
-
-    /**
      * @param Disabling $event
      * @throws ForbiddenException
      */
-    public function whenExtensionWillBeDisabled(Disabling $event)
+    public function handle(Disabling $event)
     {
         if (! in_array('flarum-locale', $event->extension->extra)) {
             return;

--- a/src/Extension/ExtensionServiceProvider.php
+++ b/src/Extension/ExtensionServiceProvider.php
@@ -11,6 +11,7 @@
 
 namespace Flarum\Extension;
 
+use Flarum\Extension\Event\Disabling;
 use Flarum\Foundation\AbstractServiceProvider;
 use Illuminate\Contracts\Container\Container;
 
@@ -38,8 +39,9 @@ class ExtensionServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $events = $this->app->make('events');
-
-        $events->subscribe(DefaultLanguagePackGuard::class);
+        $this->app->make('events')->listen(
+            Disabling::class,
+            DefaultLanguagePackGuard::class
+        );
     }
 }

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -30,6 +30,7 @@ use Flarum\Http\RouteHandlerFactory;
 use Flarum\Http\UrlGenerator;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\Event\Saved;
+use Flarum\Settings\Event\Saving;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Zend\Stratigility\MiddlewarePipe;
@@ -140,15 +141,26 @@ class ForumServiceProvider extends AbstractServiceProvider
                     $this->app->make(LocaleManager::class)
                 );
                 $recompile->whenSettingsSaved($event);
+
+                $validator = new ValidateCustomLess(
+                    $this->app->make('flarum.assets.forum'),
+                    $this->app->make('flarum.locales'),
+                    $this->app
+                );
+                $validator->whenSettingsSaved($event);
             }
         );
 
-        $events->subscribe(
-            new ValidateCustomLess(
-                $this->app->make('flarum.assets.forum'),
-                $this->app->make('flarum.locales'),
-                $this->app
-            )
+        $events->listen(
+            Saving::class,
+            function (Saving $event) {
+                $validator = new ValidateCustomLess(
+                    $this->app->make('flarum.assets.forum'),
+                    $this->app->make('flarum.locales'),
+                    $this->app
+                );
+                $validator->whenSettingsSaving($event);
+            }
         );
     }
 

--- a/src/Forum/ValidateCustomLess.php
+++ b/src/Forum/ValidateCustomLess.php
@@ -19,7 +19,6 @@ use Flarum\Settings\Event\Saving;
 use Flarum\Settings\OverrideSettingsRepository;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Filesystem\FilesystemAdapter;
 use League\Flysystem\Adapter\NullAdapter;
 use League\Flysystem\Filesystem;
@@ -52,12 +51,6 @@ class ValidateCustomLess
         $this->assets = $assets;
         $this->locales = $locales;
         $this->container = $container;
-    }
-
-    public function subscribe(Dispatcher $events)
-    {
-        $events->listen(Saving::class, [$this, 'whenSettingsSaving']);
-        $events->listen(Saved::class, [$this, 'whenSettingsSaved']);
     }
 
     public function whenSettingsSaving(Saving $event)

--- a/src/User/SelfDemotionGuard.php
+++ b/src/User/SelfDemotionGuard.php
@@ -14,24 +14,15 @@ namespace Flarum\User;
 use Flarum\Group\Group;
 use Flarum\User\Event\Saving;
 use Flarum\User\Exception\PermissionDeniedException;
-use Illuminate\Contracts\Events\Dispatcher;
 
 class SelfDemotionGuard
 {
-    /**
-     * @param Dispatcher $events
-     */
-    public function subscribe(Dispatcher $events)
-    {
-        $events->listen(Saving::class, [$this, 'whenUserWillBeSaved']);
-    }
-
     /**
      * Prevent an admin from removing their admin permission via the API.
      * @param Saving $event
      * @throws PermissionDeniedException
      */
-    public function whenUserWillBeSaved(Saving $event)
+    public function handle(Saving $event)
     {
         // Non-admin users pose no problem
         if (! $event->actor->isAdmin()) {

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -14,6 +14,9 @@ namespace Flarum\User;
 use Flarum\Event\ConfigureUserPreferences;
 use Flarum\Event\GetPermission;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\User\Event\EmailChangeRequested;
+use Flarum\User\Event\Registered;
+use Flarum\User\Event\Saving;
 use Illuminate\Contracts\Container\Container;
 use RuntimeException;
 
@@ -83,8 +86,10 @@ class UserServiceProvider extends AbstractServiceProvider
 
         $events = $this->app->make('events');
 
-        $events->subscribe(SelfDemotionGuard::class);
-        $events->subscribe(EmailConfirmationMailer::class);
+        $events->listen(Saving::class, SelfDemotionGuard::class);
+        $events->listen(Registered::class, AccountActivationMailer::class);
+        $events->listen(EmailChangeRequested::class, EmailConfirmationMailer::class);
+
         $events->subscribe(UserMetadataUpdater::class);
         $events->subscribe(UserPolicy::class);
 


### PR DESCRIPTION
**Next part of solving flarum/issue-archive#269**

**Changes proposed in this pull request:**
Replace event subscribers with event listeners in core, where it makes sense.

Exceptions:
- **Subscribers without constructor dependencies** - These have no cost of dependencies, and are useful for grouping a bunch of listeners that simply operate on models.
  - `Flarum\User\UserMetadataUpdater`
  - `Flarum\Discussion\DiscussionMetadataUpdater`
- **Policy subclasses** - These are a bit more complex, as a base class and lots of logic is involved - haven't thought about the best way to get rid of the subscriber model here.

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
