### PR TITLE
Add updating 'page' parameter in discussion list

### DIFF
--- a/less/forum/DiscussionList.less
+++ b/less/forum/DiscussionList.less
@@ -7,7 +7,7 @@
   list-style-type: none;
   position: relative;
 }
-.DiscussionList-loadMore, .DiscussionList-loadPrev {
+.DiscussionList-loadMore {
   text-align: center;
   margin-top: 10px;
 }

--- a/less/forum/DiscussionList.less
+++ b/less/forum/DiscussionList.less
@@ -7,7 +7,7 @@
   list-style-type: none;
   position: relative;
 }
-.DiscussionList-loadMore {
+.DiscussionList-loadMore, .DiscussionList-loadPrev {
   text-align: center;
   margin-top: 10px;
 }


### PR DESCRIPTION
**Refs flarum/framework#1820** (pts 2 & 4)

**Changes proposed in this pull request:**
- Add/update `page` query param when loading more discussions
    - Keeps track of current page & offset
    - Works with tags extension

The logic that adds the parameter looks a bit ugly, but it is to make sure existing query parameters remain (and not only those added through JS).

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
