### PR TITLE
Speed up Discussion Search FullTextGambit as it is too slow

### DIFF
--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -15,7 +15,6 @@ use Flarum\Discussion\Search\DiscussionSearch;
 use Flarum\Post\Post;
 use Flarum\Search\AbstractSearch;
 use Flarum\Search\GambitInterface;
-use Illuminate\Database\Query\Expression;
 use LogicException;
 
 class FulltextGambit implements GambitInterface
@@ -42,7 +41,7 @@ class FulltextGambit implements GambitInterface
         $subquery = Post::whereVisibleTo($search->getActor())
             ->select('posts.discussion_id')
             ->from('posts')
-            ->where('posts.content','like', '%' . $bit . '%')
+            ->where('posts.content', 'like', '%' . $bit . '%')
             ->where('posts.type', '=', 'comment')
             ->where('posts.is_private', '=', 0)
             ->orderBy('id');
@@ -50,7 +49,7 @@ class FulltextGambit implements GambitInterface
             ->where(function ($query) use ($subquery, $bit) {
                 $query
                     ->where('id', 'in', $subquery)
-                    ->orWhere('discussions.title', 'like', '%' . $bit . '%');
+                    ->orWhere('discussions.title', 'like', '%'.$bit.'%');
             })
             ->where('discussions.is_private', '=', 0)
             ->orderBy('discussions.last_posted_at', 'desc');

--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -43,29 +43,18 @@ class FulltextGambit implements GambitInterface
         // the ID of the most relevant post.
         $subquery = Post::whereVisibleTo($search->getActor())
             ->select('posts.discussion_id')
-            ->selectRaw('SUM(MATCH('.$grammar->wrap('posts.content').') AGAINST (?)) as score', [$bit])
-            ->selectRaw('SUBSTRING_INDEX(GROUP_CONCAT('.$grammar->wrap('posts.id').' ORDER BY MATCH('.$grammar->wrap('posts.content').') AGAINST (?) DESC, '.$grammar->wrap('posts.number').'), \',\', 1) as most_relevant_post_id', [$bit])
-            ->where('posts.type', 'comment')
-            ->whereRaw('MATCH('.$grammar->wrap('posts.content').') AGAINST (? IN BOOLEAN MODE)', [$bit])
-            ->groupBy('posts.discussion_id');
-
-        // Join the subquery into the main search query and scope results to
-        // discussions that have a relevant title or that contain relevant posts.
+            ->from('posts')
+            ->where('posts.content','like', '%' . $bit . '%')
+            ->where('posts.type', '=', 'comment')
+            ->where('posts.is_private', '=', 0)
+            ->orderBy('id');
         $query
-            ->addSelect('posts_ft.most_relevant_post_id')
-            ->leftJoin(
-                new Expression('('.$subquery->toSql().') '.$grammar->wrapTable('posts_ft')),
-                'posts_ft.discussion_id', '=', 'discussions.id'
-            )
-            ->addBinding($subquery->getBindings(), 'join')
-            ->where(function ($query) use ($grammar, $bit) {
-                $query->whereRaw('MATCH('.$grammar->wrap('discussions.title').') AGAINST (? IN BOOLEAN MODE)', [$bit])
-                      ->orWhereNotNull('posts_ft.score');
-            });
-
-        $search->setDefaultSort(function ($query) use ($grammar, $bit) {
-            $query->orderByRaw('MATCH('.$grammar->wrap('discussions.title').') AGAINST (?) desc', [$bit]);
-            $query->orderBy('posts_ft.score', 'desc');
-        });
+            ->where(function ($query) use ($subquery, $bit) {
+                $query
+                    ->where('id', 'in', $subquery)
+                    ->orWhere('discussions.title', 'like', '%' . $bit . '%');
+            })
+            ->where('discussions.is_private', '=', 0)
+            ->orderBy('discussions.last_posted_at', 'desc');
     }
 }

--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -41,7 +41,7 @@ class FulltextGambit implements GambitInterface
         $subquery = Post::whereVisibleTo($search->getActor())
             ->select('posts.discussion_id')
             ->from('posts')
-            ->where('posts.content', 'like', '%' . $bit . '%')
+            ->where('posts.content', 'like', '%'.$bit.'%')
             ->where('posts.type', '=', 'comment')
             ->where('posts.is_private', '=', 0)
             ->orderBy('id');

--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -38,9 +38,7 @@ class FulltextGambit implements GambitInterface
         $grammar = $query->getGrammar();
 
         // Construct a subquery to fetch discussions which contain relevant
-        // posts. Retrieve the collective relevance of each discussion's posts,
-        // which we will use later in the order by clause, and also retrieve
-        // the ID of the most relevant post.
+        // posts.
         $subquery = Post::whereVisibleTo($search->getActor())
             ->select('posts.discussion_id')
             ->from('posts')


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/issue-archive#240 (potentially)**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
The relevance based search in the original gambit has a huge performance impact (a negative one), so it actually makes Flarum unusable on large data sets. As an example, on our database, the original query took 105s to return results. The one in this PR takes 2-3s.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ x] Frontend changes: tested on a local Flarum installation and in production with 20m posts.
- [ x] Backend changes: tests are green (run `composer test`).

