### PR TITLE
Add Content for User page, preload user & throw 404 accordingly

### DIFF
--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -94,7 +94,7 @@ export default class UserPage extends Page {
     app.preloadedApiDocument();
 
     app.store.all('users').some(user => {
-      if (user.username().toLowerCase() === lowercaseUsername && user.joinTime()) {
+      if ((user.username().toLowerCase() === lowercaseUsername || user.id() === username) && user.joinTime()) {
         this.show(user);
         return true;
       }

--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -88,6 +88,9 @@ export default class UserPage extends Page {
   loadUser(username) {
     const lowercaseUsername = username.toLowerCase();
 
+    // Load the preloaded user object, if any, into the global app store
+    // We don't use the output of the method because it returns raw JSON
+    // instead of the parsed models
     app.preloadedApiDocument();
 
     app.store.all('users').some(user => {

--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -88,6 +88,8 @@ export default class UserPage extends Page {
   loadUser(username) {
     const lowercaseUsername = username.toLowerCase();
 
+    app.preloadedApiDocument();
+
     app.store.all('users').some(user => {
       if (user.username().toLowerCase() === lowercaseUsername && user.joinTime()) {
         this.show(user);

--- a/src/Forum/Content/User.php
+++ b/src/Forum/Content/User.php
@@ -3,10 +3,8 @@
 /*
  * This file is part of Flarum.
  *
- * (c) Toby Zerner <toby.zerner@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace Flarum\Forum\Content;

--- a/src/Forum/Content/User.php
+++ b/src/Forum/Content/User.php
@@ -12,9 +12,9 @@ namespace Flarum\Forum\Content;
 use Flarum\Api\Client;
 use Flarum\Api\Controller\ShowUserController;
 use Flarum\Frontend\Document;
-use Flarum\Http\Exception\RouteNotFoundException;
 use Flarum\Http\UrlGenerator;
 use Flarum\User\User as FlarumUser;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -66,7 +66,7 @@ class User
      * @param FlarumUser $actor
      * @param array $params
      * @return object
-     * @throws RouteNotFoundException
+     * @throws ModelNotFoundException
      */
     protected function getApiDocument(FlarumUser $actor, array $params)
     {
@@ -74,7 +74,7 @@ class User
         $statusCode = $response->getStatusCode();
 
         if ($statusCode === 404) {
-            throw new RouteNotFoundException;
+            throw new ModelNotFoundException;
         }
 
         return json_decode($response->getBody());

--- a/src/Forum/Content/User.php
+++ b/src/Forum/Content/User.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Forum\Content;
+
+use Flarum\Api\Client;
+use Flarum\Api\Controller\ShowUserController;
+use Flarum\Frontend\Document;
+use Flarum\Http\Exception\RouteNotFoundException;
+use Flarum\Http\UrlGenerator;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class User
+{
+    /**
+     * @var Client
+     */
+    protected $api;
+
+    /**
+     * @var UrlGenerator
+     */
+    protected $url;
+
+    /**
+     * @param Client $api
+     * @param UrlGenerator $url
+     */
+    public function __construct(Client $api, UrlGenerator $url)
+    {
+        $this->api = $api;
+        $this->url = $url;
+    }
+
+    public function __invoke(Document $document, Request $request)
+    {
+        $queryParams = $request->getQueryParams();
+        $actor = $request->getAttribute('actor');
+        $userId = Arr::get($queryParams, 'username');
+
+        $params = [
+            'id' => $userId,
+        ];
+
+        $apiDocument = $this->getApiDocument($actor, $params);
+
+        $document->title = $apiDocument->data->attributes->title;
+        $document->canonicalUrl = $this->url->to('forum')->route('user', ['username' => $userId]);
+        $document->payload['apiDocument'] = $apiDocument;
+
+        return $document;
+    }
+
+    /**
+     * Get the result of an API request to show a discussion.
+     *
+     * @param \Flarum\User\User $actor
+     * @param array $params
+     * @return object
+     * @throws RouteNotFoundException
+     */
+    protected function getApiDocument(\Flarum\User\User $actor, array $params)
+    {
+        $response = $this->api->send(ShowUserController::class, $actor, $params);
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode === 404) {
+            throw new RouteNotFoundException;
+        }
+
+        return json_decode($response->getBody());
+    }
+}

--- a/src/Forum/Content/User.php
+++ b/src/Forum/Content/User.php
@@ -53,9 +53,10 @@ class User
         ];
 
         $apiDocument = $this->getApiDocument($actor, $params);
+        $user = $apiDocument->data->attributes;
 
-        $document->title = $apiDocument->data->attributes->title;
-        $document->canonicalUrl = $this->url->to('forum')->route('user', ['username' => $userId]);
+        $document->title = $user->displayName;
+        $document->canonicalUrl = $this->url->to('forum')->route('user', ['username' => $user->username]);
         $document->payload['apiDocument'] = $apiDocument;
 
         return $document;

--- a/src/Forum/Content/User.php
+++ b/src/Forum/Content/User.php
@@ -16,6 +16,7 @@ use Flarum\Api\Controller\ShowUserController;
 use Flarum\Frontend\Document;
 use Flarum\Http\Exception\RouteNotFoundException;
 use Flarum\Http\UrlGenerator;
+use Flarum\User\User as FlarumUser;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -61,14 +62,14 @@ class User
     }
 
     /**
-     * Get the result of an API request to show a discussion.
+     * Get the result of an API request to show a user.
      *
-     * @param \Flarum\User\User $actor
+     * @param FlarumUser $actor
      * @param array $params
      * @return object
      * @throws RouteNotFoundException
      */
-    protected function getApiDocument(\Flarum\User\User $actor, array $params)
+    protected function getApiDocument(FlarumUser $actor, array $params)
     {
         $response = $this->api->send(ShowUserController::class, $actor, $params);
         $statusCode = $response->getStatusCode();

--- a/src/Forum/routes.php
+++ b/src/Forum/routes.php
@@ -28,7 +28,7 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
     $map->get(
         '/u/{username}[/{filter:[^/]*}]',
         'user',
-        $route->toForum()
+        $route->toForum(Content\User::class)
     );
 
     $map->get(


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/framework#1846**

**Changes proposed in this pull request:**
- Preload user
  - Tested it works correctly, API call to /api/users/<username> no longer needed as `preloadedApiDocument()` call adds it to the forum payload
- Return 404 if user is not found

**Reviewers should focus on:**
Doesn't add a no-JS view. I assume we want one, not sure about what items to include though. Posts/discussions would be hard, and require backend handling of those routes as well.

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/66002686-3e0db080-e472-11e9-882b-533eb2f98572.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
