### PR TITLE
Add search form to 404 page

### DIFF
--- a/views/error/not_found.blade.php
+++ b/views/error/not_found.blade.php
@@ -5,6 +5,12 @@
     {{ $message }}
   </p>
   <p>
+    <form class="form" method="GET" action="/">
+        <input type="text" name="q" placeholder="{{ $translator->trans('core.forum.header.search_placeholder') }}"/>
+        <button type="submit" class="button">Go</button>
+    </form>
+  </p>
+  <p>
     <a href="{{ $app->url() }}">
       {{ $translator->trans('core.views.error.not_found_return_link', ['{forum}' => $settings->get('forum_title')]) }}
     </a>


### PR DESCRIPTION
**Fixes flarum/framework#1305 **

**Changes proposed in this pull request:**
Implement search form on 404 page.

**Screenshot**
![image](https://user-images.githubusercontent.com/52821596/66517555-a1878600-eae3-11e9-9f7e-eb8e85d05e31.png)

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.



