### PR TITLE
Add ability to cancel "read all"

### DIFF
--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -1,4 +1,6 @@
 import Component from '../../common/Component';
+import ItemList from '../../common/utils/ItemList';
+import listItems from '../../common/helpers/listItems';
 import DiscussionListItem from './DiscussionListItem';
 import Button from '../../common/components/Button';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
@@ -38,6 +40,32 @@ export default class DiscussionList extends Component {
     this.refresh();
   }
 
+  aboveDiscussions() {
+    const items = new ItemList();
+
+    if (app.markedAllAsRead) {
+      items.add('cancel-read-all', Button.component({
+        className: 'Button Button--block',
+        onclick: () => {
+          app.request({
+            method: 'DELETE',
+            url: app.forum.attribute('apiUrl') + '/discussions/read'
+          }).then(payload => {
+            app.store.pushPayload(payload);
+            app.markedAllAsRead = false;
+            this.cancellingAllRead = false;
+            m.redraw();
+          });
+          this.cancellingAllRead = true;
+        },
+        loading: this.cancellingAllRead,
+        children: app.translator.trans('core.forum.index.mark_all_as_read_done')
+      }));
+    }
+
+    return items;
+  }
+
   view() {
     const params = this.props.params;
     let loading;
@@ -64,6 +92,7 @@ export default class DiscussionList extends Component {
     return (
       <div className={'DiscussionList'+(this.props.params.q ? ' DiscussionList--searchResults' : '')}>
         <ul className="DiscussionList-discussions">
+          {listItems(this.aboveDiscussions().toArray())}
           {this.discussions.map(discussion => {
             return (
               <li key={discussion.id()} data-id={discussion.id()}>

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -368,10 +368,18 @@ export default class IndexPage extends Page {
    * @return void
    */
   markAllAsRead() {
-    const confirmation = confirm(app.translator.trans('core.forum.index.mark_all_as_read_confirmation'));
+    app.request({
+      method: 'POST',
+      url: app.forum.attribute('apiUrl') + '/discussions/read'
+    }).then(payload => {
+      app.store.pushPayload(payload);
+      app.markedAllAsRead = true;
+      m.redraw();
 
-    if (confirmation) {
-      app.session.user.save({markedAllAsReadAt: new Date()});
-    }
+      setTimeout(() => {
+        app.markedAllAsRead = false;
+        m.redraw();
+      }, 10000);
+    });
   }
 }

--- a/src/Api/Controller/ReadAllDiscussionsCancelController.php
+++ b/src/Api/Controller/ReadAllDiscussionsCancelController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Flarum\Api\Controller;
+
+use Carbon\Carbon;
+use Flarum\Api\Serializer\CurrentUserSerializer;
+use Flarum\Foundation\ValidationException;
+use Flarum\User\User;
+use Flarum\User\UserRepository;
+use Illuminate\Session\Store;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Tobscure\JsonApi\Document;
+
+class ReadAllDiscussionsCancelController extends AbstractShowController
+{
+    /**
+     * {@inheritdoc}
+     */
+    public $serializer = CurrentUserSerializer::class;
+
+    /**
+     * @var \Flarum\User\UserRepository
+     */
+    protected $users;
+
+    /**
+     * @param \Flarum\User\UserRepository $users
+     */
+    public function __construct(UserRepository $users)
+    {
+        $this->users = $users;
+    }
+
+    /**
+     * Get the data to be serialized and assigned to the response document.
+     *
+     * @param ServerRequestInterface $request
+     * @param Document $document
+     * @return mixed
+     * @throws ValidationException
+     */
+    protected function data(ServerRequestInterface $request, Document $document)
+    {
+        /**
+         * @var $actor User
+         */
+        $actor = $request->getAttribute('actor');
+
+        /**
+         * @var $session Store
+         */
+        $session = $request->getAttribute('session');
+
+        if ($session->has('can_cancel_marked_all_until') && Carbon::now()->isBefore($session->get('can_cancel_marked_all_until'))) {
+            $actor->marked_all_as_read_at = $session->get('previous_marked_all_as_read_at');
+            $actor->save();
+        } else {
+            throw new ValidationException([
+                'something' => [
+                    app(TranslatorInterface::class)->trans('core.api.too_late_to_cancel_read_all'),
+                ],
+            ]);
+        }
+
+        return $this->users->findOrFail($actor->id, $actor);
+    }
+}

--- a/src/Api/Controller/ReadAllDiscussionsController.php
+++ b/src/Api/Controller/ReadAllDiscussionsController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Flarum\Api\Controller;
+
+use Carbon\Carbon;
+use Flarum\Api\Serializer\CurrentUserSerializer;
+use Flarum\User\User;
+use Flarum\User\UserRepository;
+use Illuminate\Session\Store;
+use Psr\Http\Message\ServerRequestInterface;
+use Tobscure\JsonApi\Document;
+
+class ReadAllDiscussionsController extends AbstractShowController
+{
+    /**
+     * {@inheritdoc}
+     */
+    public $serializer = CurrentUserSerializer::class;
+
+    /**
+     * @var \Flarum\User\UserRepository
+     */
+    protected $users;
+
+    /**
+     * @param \Flarum\User\UserRepository $users
+     */
+    public function __construct(UserRepository $users)
+    {
+        $this->users = $users;
+    }
+
+    /**
+     * Get the data to be serialized and assigned to the response document.
+     *
+     * @param ServerRequestInterface $request
+     * @param Document $document
+     * @return mixed
+     */
+    protected function data(ServerRequestInterface $request, Document $document)
+    {
+        /**
+         * @var $actor User
+         */
+        $actor = $request->getAttribute('actor');
+
+        /**
+         * @var $session Store
+         */
+        $session = $request->getAttribute('session');
+
+        $session->put('previous_marked_all_as_read_at', $actor->marked_all_as_read_at);
+        $session->put('can_cancel_marked_all_until', Carbon::now()->addSeconds(15));
+        $session->save();
+
+        $actor->markAllAsRead();
+        $actor->save();
+
+        return $this->users->findOrFail($actor->id, $actor);
+    }
+}

--- a/src/Api/routes.php
+++ b/src/Api/routes.php
@@ -144,6 +144,20 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\CreateDiscussionController::class)
     );
 
+    // Mark all discussions as read
+    $map->post(
+        '/discussions/read',
+        'discussions.readAll',
+        $route->toController(Controller\ReadAllDiscussionsController::class)
+    );
+
+    // Cancel marking all discussions as read
+    $map->delete(
+        '/discussions/read',
+        'discussions.cancelReadAll',
+        $route->toController(Controller\ReadAllDiscussionsCancelController::class)
+    );
+
     // Show a single discussion
     $map->get(
         '/discussions/{id}',

--- a/src/User/Command/EditUserHandler.php
+++ b/src/User/Command/EditUserHandler.php
@@ -98,11 +98,6 @@ class EditUserHandler
             $validate['password'] = $attributes['password'];
         }
 
-        if (! empty($attributes['markedAllAsReadAt'])) {
-            $this->assertPermission($isSelf);
-            $user->markAllAsRead();
-        }
-
         if (! empty($attributes['preferences'])) {
             $this->assertPermission($isSelf);
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/issue-archive#341**

**Changes proposed in this pull request:**
Remove confirmation and add ability to cancel "read all" within 10 seconds.

This PR was made during my "clark writes code" stream, I will check it back later for completion.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![image](https://user-images.githubusercontent.com/5264300/67523077-34145180-f6ae-11e9-82cb-a585e3ea7c38.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related core extension PRs: (Remove if irrelevant)
