### PR TITLE
Improved UX by displaying hamburger instead of back arrow in mobile header on all pages

### DIFF
--- a/js/src/admin/AdminApplication.js
+++ b/js/src/admin/AdminApplication.js
@@ -27,8 +27,8 @@ export default class AdminApplication extends Application {
    * @inheritdoc
    */
   mount() {
-    m.mount(document.getElementById('app-navigation'), Navigation.component({className: 'App-backControl', drawer: true}));
-    m.mount(document.getElementById('header-navigation'), Navigation.component());
+    m.mount(document.getElementById('app-navigation'), Navigation.component({back: false, className: 'App-backControl', drawer: true}));
+    m.mount(document.getElementById('header-navigation'), Navigation.component({back: true, drawer: false}));
     m.mount(document.getElementById('header-primary'), HeaderPrimary.component());
     m.mount(document.getElementById('header-secondary'), HeaderSecondary.component());
     m.mount(document.getElementById('admin-navigation'), AdminNav.component());

--- a/js/src/common/components/Navigation.js
+++ b/js/src/common/components/Navigation.js
@@ -26,7 +26,7 @@ export default class Navigation extends Component {
         onmouseenter={pane && pane.show.bind(pane)}
         onmouseleave={pane && pane.onmouseleave.bind(pane)}>
         {history.canGoBack()
-          ? [this.getBackButton(), this.getPaneButton()]
+          ? [this.getBackButton(), this.getPaneButton(), this.getDrawerButton()]
           : this.getDrawerButton()}
       </div>
     );
@@ -45,7 +45,9 @@ export default class Navigation extends Component {
    * @return {Object}
    * @protected
    */
-  getBackButton() {
+    getBackButton() {
+    if (!this.props.back) return '';
+
     const {history} = app;
     const previous = history.getPrevious() || {};
 

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -87,8 +87,8 @@ export default class ForumApplication extends Application {
     this.routes[defaultAction].path = '/';
     this.history.push(defaultAction, this.translator.trans('core.forum.header.back_to_index_tooltip'), '/');
 
-    m.mount(document.getElementById('app-navigation'), Navigation.component({className: 'App-backControl', drawer: true}));
-    m.mount(document.getElementById('header-navigation'), Navigation.component());
+    m.mount(document.getElementById('app-navigation'), Navigation.component({back: false, className: 'App-backControl', drawer: true}));
+    m.mount(document.getElementById('header-navigation'), Navigation.component({back: true, drawer: false}));
     m.mount(document.getElementById('header-primary'), HeaderPrimary.component());
     m.mount(document.getElementById('header-secondary'), HeaderSecondary.component());
 


### PR DESCRIPTION
**Fixes flarum/issue-archive#226 **

**Changes proposed in this pull request:**
As of right now, the mobile header displays a back arrow at the top right corner on some pages (specifically discussion pages). This adds no actual value to the user:

- While on non-mobile devices hovering here would bring out the discussion list pane, this is not supported on mobile (and rightly so as it would add unnecessary complexity).
- The only other hypothetical benefit of the back button on mobile is that the button brings the user to the homepage, as opposed to the browser's back button, which might close a window (if the page was opened via a link). However, the hamburger menu more than replaces this functionality: by convention, users know that clicking on the site logo/title in the slideout nav menu will bring them to the homepage (which it does).

In summary, this change makes it much more convenient for users to access their account info/other navbar items, removes a somewhat redundant element, and does not diminish aesthetic.


**Reviewers should focus on:**
If there's no logo, should we add a fontawesome home icon next to the forum title in the mobile navbar?

**Screenshot**
https://i.imgur.com/4MXvXQR.png
https://i.imgur.com/tdUw1vZ.png

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.