### PR TITLE
Make profile urls work with usernames only and not user IDs

### DIFF
--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -99,19 +99,13 @@ export default class UserPage extends Page {
     });
 
     if (!this.user) {
-      app
-        .request({
-          method: 'GET',
-          url: app.forum.attribute('apiUrl') + '/users',
-          data: {
-            filter: {
-              q: 'username:' + username,
-            },
+      app.store
+        .find('users', {
+          filter: {
+            q: 'username:' + username,
           },
         })
-        .then((payload) => {
-          const users = app.store.pushPayload(payload);
-
+        .then((users) => {
           if (users.length) {
             this.show(users[0]);
           } else {

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -21,6 +21,7 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\User\Search\Gambit\EmailGambit;
 use Flarum\User\Search\Gambit\FulltextGambit as UserFulltextGambit;
 use Flarum\User\Search\Gambit\GroupGambit;
+use Flarum\User\Search\Gambit\UsernameGambit;
 use Flarum\User\Search\UserSearcher;
 use Illuminate\Contracts\Container\Container;
 
@@ -48,6 +49,7 @@ class SearchServiceProvider extends AbstractServiceProvider
                 $gambits->setFulltextGambit(UserFulltextGambit::class);
                 $gambits->add(EmailGambit::class);
                 $gambits->add(GroupGambit::class);
+                $gambits->add(UsernameGambit::class);
 
                 $app->make('events')->dispatch(
                     new ConfigureUserGambits($gambits)

--- a/src/User/Search/Gambit/UsernameGambit.php
+++ b/src/User/Search/Gambit/UsernameGambit.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\Search\Gambit;
+
+use Flarum\Search\AbstractRegexGambit;
+use Flarum\Search\AbstractSearch;
+use Flarum\User\Search\UserSearch;
+use Flarum\User\UserRepository;
+use LogicException;
+
+class UsernameGambit extends AbstractRegexGambit
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $pattern = 'username:(.+)';
+
+    /**
+     * @var \Flarum\User\UserRepository
+     */
+    protected $users;
+
+    /**
+     * @param \Flarum\User\UserRepository $users
+     */
+    public function __construct(UserRepository $users)
+    {
+        $this->users = $users;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function conditions(AbstractSearch $search, array $matches, $negate)
+    {
+        if (! $search instanceof UserSearch) {
+            throw new LogicException('This gambit can only be applied on a UserSearch');
+        }
+
+        $username = trim($matches[1], '"');
+
+        $search->getQuery()->where('username', $negate ? '!=' : '=', $username);
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1356**

**Changes proposed in this pull request:**
Drop support for ID in profile urls. Only accept username.

**Reviewers should focus on:**
This is based on one of the proposal discussed in the issue. However I'm not sure how to handle errors, as "not found" is now an empty list instead of a native 404.

Also the fact that `apiDocument` is now a list could break some extensions that read the payload directly. I'm thinking of the SEO extension which I have not tested in combination with this.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
