### PR TITLE
Make interval between posts configurable

### DIFF
--- a/js/src/admin/components/AdminNav.js
+++ b/js/src/admin/components/AdminNav.js
@@ -73,6 +73,13 @@ export default class AdminNav extends Component {
       description: app.translator.trans('core.admin.nav.extensions_text')
     }));
 
+    items.add('advanced', AdminLinkButton.component({
+      href: app.route('advanced'),
+      icon: 'fas fa-cogs',
+      children: app.translator.trans('core.admin.nav.advanced_button'),
+      description: app.translator.trans('core.admin.nav.advanced_text')
+    }));
+
     return items;
   }
 }

--- a/js/src/admin/components/AdvancedPage.js
+++ b/js/src/admin/components/AdvancedPage.js
@@ -1,0 +1,87 @@
+import Page from "./Page";
+import Button from "../../common/components/Button";
+import saveSettings from "../utils/saveSettings";
+import Alert from "../../common/components/Alert";
+import FieldSet from "../../common/components/FieldSet";
+
+export default class AdvancedPage extends Page {
+  init() {
+    super.init();
+
+    this.loading = false;
+    this.fields = [
+      'post_flood_interval',
+    ];
+    this.values = {};
+
+    const settings = app.data.settings;
+    this.fields.forEach(key => this.values[key] = m.prop(settings[key]));
+
+  }
+
+  view() {
+    return (
+      <div className="AdvancedPage">
+        <div className="container">
+          <form onsubmit={this.onsubmit.bind(this)}>
+            <h2>{app.translator.trans('core.admin.advanced.heading_security')}</h2>
+            <div className="helpText">
+              {app.translator.trans('core.admin.advanced.help_text')}
+            </div>
+            <br/>
+
+            {FieldSet.component({
+              label: app.translator.trans('core.admin.advanced.post_flood_interval'),
+              children: [
+                <div className="helpText">
+                  {app.translator.trans('core.admin.advanced.post_flood_interval_text')}
+                </div>,
+                <input type="number" className="FormControl" value={this.values.post_flood_interval()} oninput={m.withAttr('value', this.values.post_flood_interval)}/>
+              ]
+            })}
+
+            {Button.component({
+              type: 'submit',
+              className: 'Button Button--primary',
+              children: app.translator.trans('core.admin.basics.submit_button'),
+              loading: this.loading,
+              disabled: !this.changed()
+            })}
+          </form>
+        </div>
+      </div>
+    )
+  }
+
+  changed() {
+    return this.fields.some(key => this.values[key]() !== app.data.settings[key]);
+  }
+
+  onsubmit(e) {
+    e.preventDefault();
+
+    const positiveInteger = /^\+?(0|[1-9]\d*)$/;
+    if(!positiveInteger.test(this.values.post_flood_interval()) || this.values.post_flood_interval().length === 0) {
+      alert(app.translator.trans('core.admin.advanced.enter_positive_number'));
+      return;
+    }
+
+    if (this.loading) return;
+
+    this.loading = true;
+    app.alerts.dismiss(this.successAlert);
+
+    const settings = {};
+    this.fields.forEach(key => settings[key] = this.values[key]());
+
+    saveSettings(settings)
+      .then(() => {
+        app.alerts.show(this.successAlert = new Alert({type: 'success', children: app.translator.trans('core.admin.basics.saved_message')}));
+      })
+      .catch(() => {})
+      .then(() => {
+        this.loading = false;
+        m.redraw();
+      });
+  }
+}

--- a/js/src/admin/components/AdvancedPage.js
+++ b/js/src/admin/components/AdvancedPage.js
@@ -36,7 +36,7 @@ export default class AdvancedPage extends Page {
                 <div className="helpText">
                   {app.translator.trans('core.admin.advanced.post_flood_interval_text')}
                 </div>,
-                <input type="number" className="FormControl" value={this.values.post_flood_interval()} oninput={m.withAttr('value', this.values.post_flood_interval)}/>
+                <input type="number" min="0" className="FormControl" value={this.values.post_flood_interval()} oninput={m.withAttr('value', this.values.post_flood_interval)}/>
               ]
             })}
 

--- a/js/src/admin/routes.js
+++ b/js/src/admin/routes.js
@@ -4,6 +4,7 @@ import PermissionsPage from './components/PermissionsPage';
 import AppearancePage from './components/AppearancePage';
 import ExtensionsPage from './components/ExtensionsPage';
 import MailPage from './components/MailPage';
+import AdvancedPage from "./components/AdvancedPage";
 
 /**
  * The `routes` initializer defines the forum app's routes.
@@ -17,6 +18,7 @@ export default function(app) {
     'permissions': {path: '/permissions', component: PermissionsPage.component()},
     'appearance': {path: '/appearance', component: AppearancePage.component()},
     'extensions': {path: '/extensions', component: ExtensionsPage.component()},
-    'mail': {path: '/mail', component: MailPage.component()}
+    'mail': {path: '/mail', component: MailPage.component()},
+    'advanced': {path: '/advanced', component: AdvancedPage.component()}
   };
 }

--- a/less/admin.less
+++ b/less/admin.less
@@ -8,3 +8,4 @@
 @import "admin/ExtensionsPage";
 @import "admin/AppearancePage";
 @import "admin/MailPage";
+@import "admin/AdvancedPage";

--- a/less/admin/AdvancedPage.less
+++ b/less/admin/AdvancedPage.less
@@ -1,0 +1,20 @@
+.AdvancedPage {
+  padding: 20px 0;
+
+  @media @desktop-up {
+    .container {
+      max-width: 600px;
+      margin: 0;
+    }
+  }
+
+  fieldset {
+    margin-bottom: 20px;
+
+    > ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
+}

--- a/src/Install/Steps/WriteSettings.php
+++ b/src/Install/Steps/WriteSettings.php
@@ -73,6 +73,7 @@ class WriteSettings implements Step
             'theme_secondary_color' => '#4D698E',
             'welcome_message' => 'This is beta software and you should not use it in production.',
             'welcome_title' => 'Welcome to Flarum',
+            'post_flood_interval' => '15'
         ];
     }
 }

--- a/src/Post/Floodgate.php
+++ b/src/Post/Floodgate.php
@@ -12,6 +12,7 @@ namespace Flarum\Post;
 use DateTime;
 use Flarum\Post\Event\CheckingForFlooding;
 use Flarum\Post\Exception\FloodingException;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
 
@@ -22,9 +23,15 @@ class Floodgate
      */
     protected $events;
 
-    public function __construct(Dispatcher $events)
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(Dispatcher $events, SettingsRepositoryInterface $settings)
     {
         $this->events = $events;
+        $this->settings = $settings;
     }
 
     /**
@@ -52,6 +59,8 @@ class Floodgate
             new CheckingForFlooding($actor)
         );
 
-        return $isFlooding ?? Post::where('user_id', $actor->id)->where('created_at', '>=', new DateTime('-10 seconds'))->exists();
+        $floodtime = $this->settings->get('post_flood_interval', 15);
+
+        return $isFlooding ?? Post::where('user_id', $actor->id)->where('created_at', '>=', new DateTime("-$floodtime seconds"))->exists();
     }
 }

--- a/src/Post/Floodgate.php
+++ b/src/Post/Floodgate.php
@@ -61,6 +61,9 @@ class Floodgate
 
         $floodtime = $this->settings->get('post_flood_interval', 15);
 
-        return $isFlooding ?? Post::where('user_id', $actor->id)->where('created_at', '>=', new DateTime("-$floodtime seconds"))->exists();
+        return $isFlooding ??
+            Post::where('user_id', $actor->id)
+                ->where('created_at', '>=', new DateTime('-' . $floodtime . ' seconds'))
+                ->exists();
     }
 }

--- a/src/Post/Floodgate.php
+++ b/src/Post/Floodgate.php
@@ -63,7 +63,7 @@ class Floodgate
 
         return $isFlooding ??
             Post::where('user_id', $actor->id)
-                ->where('created_at', '>=', new DateTime('-' . $floodtime . ' seconds'))
+                ->where('created_at', '>=', new DateTime('-'.$floodtime.' seconds'))
                 ->exists();
     }
 }

--- a/tests/integration/api/posts/CreateTest.php
+++ b/tests/integration/api/posts/CreateTest.php
@@ -87,7 +87,6 @@ class CreateTest extends TestCase
             return $mock;
         });
 
-
         $response = $this->sendTestRequest();
         $this->assertEquals(201, $response->getStatusCode());
 

--- a/tests/integration/api/posts/CreateTest.php
+++ b/tests/integration/api/posts/CreateTest.php
@@ -101,6 +101,7 @@ class CreateTest extends TestCase
                 if ($arg == 'post_flood_interval') {
                     return '-1'; // -1 due to consecutive requests being instantaneous
                 }
+
                 return $settings->get($arg);
             });
         $this->app()->getContainer()->bind(SettingsRepositoryInterface::class, function () use ($mock) {

--- a/tests/integration/api/posts/CreateTest.php
+++ b/tests/integration/api/posts/CreateTest.php
@@ -17,6 +17,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Mockery;
+use Psr\Http\Message\ResponseInterface;
 
 class CreateTest extends TestCase
 {
@@ -51,7 +52,54 @@ class CreateTest extends TestCase
      */
     public function can_create_reply()
     {
-        $response = $this->send(
+        $response = $this->sendTestRequest();
+
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function cant_flood_posts()
+    {
+        $response = $this->sendTestRequest();
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = $this->sendTestRequest();
+        $this->assertEquals(429, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function can_flood_posts_interval_set_to_0()
+    {
+        /** @var SettingsRepositoryInterface $settings */
+        $settings = $this->app()->getContainer()->make(SettingsRepositoryInterface::class);
+        $mock = Mockery::mock(SettingsRepositoryInterface::class)->makePartial();
+        $mock->shouldReceive('get')
+            ->atLeast()->once()
+            ->andReturnUsing(function ($arg) use ($settings) {
+                if ($arg == 'post_flood_interval') {
+                    return '-1'; // -1 due to consecutive requests being instantaneous
+                }
+
+                return $settings->get($arg);
+            });
+        $this->app()->getContainer()->bind(SettingsRepositoryInterface::class, function () use ($mock) {
+            return $mock;
+        });
+
+
+        $response = $this->sendTestRequest();
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = $this->sendTestRequest();
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    private function sendTestRequest() : ResponseInterface {
+        return $this->send(
             $this->request('POST', '/api/posts', [
                 'authenticatedAs' => 2,
                 'json' => [
@@ -66,58 +114,5 @@ class CreateTest extends TestCase
                 ],
             ])
         );
-
-        $this->assertEquals(201, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
-    public function cant_flood_posts()
-    {
-        $this->actor = User::find(2);
-
-        $body = [];
-        Arr::set($body, 'data.attributes', $this->data);
-        Arr::set($body, 'data.relationships.discussion.data.id', 1);
-
-        $response = $this->callWith($body);
-        $this->assertEquals(201, $response->getStatusCode());
-
-        $response = $this->callWith($body);
-        $this->assertEquals(429, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
-    public function can_flood_posts_interval_set_to_0()
-    {
-        /** @var SettingsRepositoryInterface $settings */
-        $settings = $this->app()->getContainer()->make(SettingsRepositoryInterface::class);
-        $mock = Mockery::mock(SettingsRepositoryInterface::class)->makePartial();
-        $mock->shouldReceive('get')
-            ->andReturnUsing(function ($arg) use ($settings) {
-                if ($arg == 'post_flood_interval') {
-                    return '-1'; // -1 due to consecutive requests being instantaneous
-                }
-
-                return $settings->get($arg);
-            });
-        $this->app()->getContainer()->bind(SettingsRepositoryInterface::class, function () use ($mock) {
-            return $mock;
-        });
-
-        $this->actor = User::find(2);
-
-        $body = [];
-        Arr::set($body, 'data.attributes', $this->data);
-        Arr::set($body, 'data.relationships.discussion.data.id', 1);
-
-        $response = $this->callWith($body);
-        $this->assertEquals(201, $response->getStatusCode());
-
-        $response = $this->callWith($body);
-        $this->assertEquals(201, $response->getStatusCode());
     }
 }

--- a/tests/integration/api/posts/CreateTest.php
+++ b/tests/integration/api/posts/CreateTest.php
@@ -10,12 +10,9 @@
 namespace Flarum\Tests\integration\api\posts;
 
 use Carbon\Carbon;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tests\integration\RetrievesAuthorizedUsers;
 use Flarum\Tests\integration\TestCase;
-use Flarum\Api\Controller\CreatePostController;
-use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\User;
-use Illuminate\Support\Arr;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
 
@@ -98,7 +95,8 @@ class CreateTest extends TestCase
         $this->assertEquals(201, $response->getStatusCode());
     }
 
-    private function sendTestRequest() : ResponseInterface {
+    private function sendTestRequest(): ResponseInterface
+    {
         return $this->send(
             $this->request('POST', '/api/posts', [
                 'authenticatedAs' => 2,

--- a/tests/integration/setup.php
+++ b/tests/integration/setup.php
@@ -53,8 +53,8 @@ $pipeline = $installation
         env('DB_HOST', 'localhost'),
         intval(env('DB_PORT', 3306)),
         env('DB_DATABASE', 'flarum_test'),
-        env('DB_USERNAME', 'root'),
-        env('DB_PASSWORD', ''),
+        env('DB_USERNAME', 'homestead'),
+        env('DB_PASSWORD', 'secret'),
         env('DB_PREFIX', '')
     ))
     ->adminUser(new AdminUser(

--- a/tests/integration/setup.php
+++ b/tests/integration/setup.php
@@ -53,8 +53,8 @@ $pipeline = $installation
         env('DB_HOST', 'localhost'),
         intval(env('DB_PORT', 3306)),
         env('DB_DATABASE', 'flarum_test'),
-        env('DB_USERNAME', 'homestead'),
-        env('DB_PASSWORD', 'secret'),
+        env('DB_USERNAME', 'root'),
+        env('DB_PASSWORD', ''),
         env('DB_PREFIX', '')
     ))
     ->adminUser(new AdminUser(


### PR DESCRIPTION
**Fixes flarum/issue-archive#302**

**Changes proposed in this pull request:**
- Add `post_flood_interval` setting to manually configure the interval users have to wait before posting again
- Add integration tests for both this feature and flarum/framework#1938 
- Add `Advanced` settings page with a `Security` section to contain this and possibly further settings 

**Reviewers should focus on:**
Use of Mockery: It was already required but hasn't been used anywhere else. I didn't found any guidelines regarding this.

**Screenshot**
![flarum_advanced_settings](https://user-images.githubusercontent.com/20999486/77158772-44392d00-6aa4-11ea-84a7-0f63ef15f50d.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related core extension PRs: [flarum/lang-english](https://github.com/flarum/lang-english/pull/161)

