### PR TITLE
Add confirmation dialog when hiding and deleting comments (#1966)

### DIFF
--- a/js/src/forum/components/ConfirmModal.js
+++ b/js/src/forum/components/ConfirmModal.js
@@ -3,29 +3,20 @@ import Button from "../../common/components/Button";
 
 /**
  * A basic confirm modal.
+ * The special props are:
+ * * `translation` Translation path for some of the elements. It'll be used like this:
+ *   `${translation}.title`
+ * * `save` Callback called when pressing positive button.
  */
 export default class ConfirmModal extends Modal {
-  /**
-   * Initialize the modal.
-   * @param {String} title Modal title
-   * @param {String} message Message, shown above buttons
-   * @param {String} positiveButton Text to show on positive button
-   * @param {String} negativeButton Text to show on negative button
-   * @param {Function} callback Callback called when 
-   */
-  init(title, message, positiveButton, negativeButton, callback) {
-    super.init();
+  constructor(props, children) {
+    super(props, children);
 
-    this.titleProp = title;
-    this.message = message;
-    this.positiveButton = positiveButton;
-    this.negativeButton = negativeButton;
-    this.positiveCallback = callback;
     this.loading = false;
   }
 
   title() {
-    return this.titleProp;
+    return app.translator.trans(`${this.props.translation}.title`);
   }
 
   className() {
@@ -36,11 +27,11 @@ export default class ConfirmModal extends Modal {
     return (
       <div className="Modal-body">
         <div className="Form Form--centered">
-          <p>{this.message}</p>
+          <p>{app.translator.trans(`${this.props.translation}.message`)}</p>
           <div className="Form-group">
             {Button.component({
               className: 'Button Button--primary Button--block',
-              children: this.positiveButton,
+              children: app.translator.trans(`${this.props.translation}.positive`),
               type: 'submit',
               loading: this.loading
             })}
@@ -48,7 +39,7 @@ export default class ConfirmModal extends Modal {
           <div className="Form-group">
             {Button.component({
               className: 'Button Button--block',
-              children: this.negativeButton,
+              children: app.translator.trans(`${this.props.translation}.negative`),
               onclick: this.hide.bind(this),  
               disabled: this.loading // Disable negative button when loading
             })}
@@ -60,7 +51,7 @@ export default class ConfirmModal extends Modal {
 
   onsubmit(e) {
     this.loading = true;
-    this.positiveCallback().then((() => {
+    this.props.save().then((() => {
       this.loading = false;
       this.hide();
     }).bind(this));

--- a/js/src/forum/components/ConfirmModal.js
+++ b/js/src/forum/components/ConfirmModal.js
@@ -1,0 +1,70 @@
+import Modal from "../../common/components/Modal";
+import Button from "../../common/components/Button";
+
+/**
+ * A basic confirm modal.
+ */
+export default class ConfirmModal extends Modal {
+  /**
+   * Initialize the modal.
+   * @param {String} title Modal title
+   * @param {String} message Message, shown above buttons
+   * @param {String} positiveButton Text to show on positive button
+   * @param {String} negativeButton Text to show on negative button
+   * @param {Function} callback Callback called when 
+   */
+  init(title, message, positiveButton, negativeButton, callback) {
+    super.init();
+
+    this.titleProp = title;
+    this.message = message;
+    this.positiveButton = positiveButton;
+    this.negativeButton = negativeButton;
+    this.positiveCallback = callback;
+    this.loading = false;
+  }
+
+  title() {
+    return this.titleProp;
+  }
+
+  className() {
+    return 'ConfirmModal Modal--small';
+  }
+
+  content() {
+    return (
+      <div className="Modal-body">
+        <div className="Form Form--centered">
+          <p>{this.message}</p>
+          <div className="Form-group">
+            {Button.component({
+              className: 'Button Button--primary Button--block',
+              children: this.positiveButton,
+              type: 'submit',
+              loading: this.loading
+            })}
+          </div>
+          <div className="Form-group">
+            {Button.component({
+              className: 'Button Button--block',
+              children: this.negativeButton,
+              onclick: this.hide.bind(this),  
+              disabled: this.loading // Disable negative button when loading
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  onsubmit(e) {
+    this.loading = true;
+    this.positiveCallback().then((() => {
+      this.loading = false;
+      this.hide();
+    }).bind(this));
+
+    return false;
+  }
+}

--- a/js/src/forum/utils/DiscussionControls.js
+++ b/js/src/forum/utils/DiscussionControls.js
@@ -6,6 +6,7 @@ import Separator from '../../common/components/Separator';
 import RenameDiscussionModal from '../components/RenameDiscussionModal';
 import ItemList from '../../common/utils/ItemList';
 import extractText from '../../common/utils/extractText';
+import ConfirmModal from '../components/ConfirmModal';
 
 /**
  * The `DiscussionControls` utility constructs a list of buttons for a
@@ -181,13 +182,16 @@ export default {
 
   /**
    * Hide a discussion.
-   *
-   * @return {Promise}
    */
   hideAction() {
-    this.pushAttributes({ hiddenAt: new Date(), hiddenUser: app.session.user });
-
-    return this.save({ isHidden: true });
+    app.modal.show(new ConfirmModal({
+      translation: "core.forum.discussion_controls.hide_discussion_modal",
+      save: () => {
+        this.pushAttributes({ hiddenAt: new Date(), hiddenUser: app.session.user });
+    
+        return this.save({ isHidden: true });
+      }
+    }));
   },
 
   /**
@@ -203,25 +207,26 @@ export default {
 
   /**
    * Delete the discussion after confirming with the user.
-   *
-   * @return {Promise}
    */
   deleteAction() {
-    if (confirm(extractText(app.translator.trans('core.forum.discussion_controls.delete_confirmation')))) {
-      // If we're currently viewing the discussion that was deleted, go back
-      // to the previous page.
-      if (app.viewingDiscussion(this)) {
-        app.history.back();
-      }
-
-      return this.delete().then(() => {
-        // If there is a discussion list in the cache, remove this discussion.
-        if (app.cache.discussionList) {
-          app.cache.discussionList.removeDiscussion(this);
-          m.redraw();
+    app.modal.show(new ConfirmModal({
+      translation: "core.forum.discussion_controls.hide_discussion_modal",
+      save: () => {
+        // If we're currently viewing the discussion that was deleted, go back
+        // to the previous page.
+        if (app.viewingDiscussion(this)) {
+          app.history.back();
         }
-      });
-    }
+
+        return this.delete().then(() => {
+          // If there is a discussion list in the cache, remove this discussion.
+          if (app.cache.discussionList) {
+            app.cache.discussionList.removeDiscussion(this);
+            m.redraw();
+          }
+        });
+      }
+    }));
   },
 
   /**

--- a/js/src/forum/utils/PostControls.js
+++ b/js/src/forum/utils/PostControls.js
@@ -132,19 +132,16 @@ export default {
    * Hide a post. (aka soft delete)
    */
   hideAction() {
-    const confirmModal = new ConfirmModal();
-    confirmModal.init(
-      app.translator.trans('core.forum.post_controls.hide_post_modal.title'),
-      app.translator.trans('core.forum.post_controls.hide_post_modal.message'),
-      app.translator.trans('core.forum.post_controls.hide_post_modal.positive'),
-      app.translator.trans('core.forum.post_controls.hide_post_modal.negative'),
-      () => {
-        this.pushAttributes({ hiddenAt: new Date(), hiddenUser: app.session.user });
-  
-        return this.save({ isHidden: true }).then(() => m.redraw());
-      }
+    app.modal.show(
+      new ConfirmModal({
+        translation: "core.forum.post_controls.hide_post_modal",
+        save: () => {
+          this.pushAttributes({ hiddenAt: new Date(), hiddenUser: app.session.user });
+    
+          return this.save({ isHidden: true }).then(() => m.redraw());
+        }
+      })
     );
-    app.modal.show(confirmModal);
   },
 
   /**
@@ -162,40 +159,38 @@ export default {
    * Delete a post.
    */
   deleteAction(context) {
-    const confirmModal = new ConfirmModal();
-    confirmModal.init(
-      app.translator.trans('core.forum.post_controls.delete_post_modal.title'),
-      app.translator.trans('core.forum.post_controls.delete_post_modal.message'),
-      app.translator.trans('core.forum.post_controls.delete_post_modal.positive'),
-      app.translator.trans('core.forum.post_controls.delete_post_modal.negative'),
-      () => {
-        if (context) context.loading = true;
-
-        return this.delete()
-          .then(() => {
-            const discussion = this.discussion();
-
-            discussion.removePost(this.id());
-
-            // If this was the last post in the discussion, then we will assume that
-            // the whole discussion was deleted too.
-            if (!discussion.postIds().length) {
-              // If there is a discussion list in the cache, remove this discussion.
-              if (app.cache.discussionList) {
-                app.cache.discussionList.removeDiscussion(discussion);
+    app.modal.show(
+      new ConfirmModal({
+        translation: "core.forum.post_controls.delete_post_modal",
+        save: () => {
+          if (context) context.loading = true;
+  
+          return this.delete()
+            .then(() => {
+              const discussion = this.discussion();
+  
+              discussion.removePost(this.id());
+  
+              // If this was the last post in the discussion, then we will assume that
+              // the whole discussion was deleted too.
+              if (!discussion.postIds().length) {
+                // If there is a discussion list in the cache, remove this discussion.
+                if (app.cache.discussionList) {
+                  app.cache.discussionList.removeDiscussion(discussion);
+                }
+  
+                if (app.viewingDiscussion(discussion)) {
+                  app.history.back();
+                }
               }
-
-              if (app.viewingDiscussion(discussion)) {
-                app.history.back();
-              }
-            }
-          })
-          .catch(() => {})
-          .then(() => {
-            if (context) context.loading = false;
-            m.redraw();
-          });
-    });
-    app.modal.show(confirmModal);
+            })
+            .catch(() => {})
+            .then(() => {
+              if (context) context.loading = false;
+              m.redraw();
+            });
+        }
+      })
+    );
   }
 };


### PR DESCRIPTION
**Closes flarum/framework#1966**

**Changes proposed in this pull request:**
- Added `ConfirmModal` for creating simple confirmation modals.

**Reviewers should focus on:**
My shitcoding, please fix it.

**Screenshot**
![flarumFeaturev2](https://user-images.githubusercontent.com/20511387/77824689-90741500-7115-11ea-931d-32fc80284d30.gif)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] No backend changes.

**Required changes:**

- [x] Related documentation PR: (Add docs for `ConfirmModal` component?)
- [x] Related core extension PRs: (flarum/lang-english#162)
