### PR TITLE
Fix Mods being able to edit Admins, Split permissions

### DIFF
--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -312,15 +312,23 @@ export default class PermissionGrid extends Component {
       60
     );
 
-    items.add(
-      'userEdit',
-      {
-        icon: 'fas fa-user-cog',
-        label: app.translator.trans('core.admin.permissions.edit_users_label'),
-        permission: 'user.edit',
-      },
-      60
-    );
+    items.add('editCredentials', {
+      icon: 'fas fa-user-cog',
+      label: app.translator.trans('core.admin.permissions.edit_credentials_label'),
+      permission: 'edit.credentials'
+    }, 50);
+
+    items.add('editUsername', {
+      icon: 'fas fa-address-card',
+      label: app.translator.trans('core.admin.permissions.edit_username_label'),
+      permission: 'edit.username'
+    }, 50);
+
+    items.add('editGroups', {
+      icon: 'fas fa-users-cog',
+      label: app.translator.trans('core.admin.permissions.edit_groups_label'),
+      permission: 'edit.groups'
+    }, 50);
 
     return items;
   }

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -312,23 +312,35 @@ export default class PermissionGrid extends Component {
       60
     );
 
-    items.add('userEditCredentials', {
-      icon: 'fas fa-user-cog',
-      label: app.translator.trans('core.admin.permissions.user_edit_credentials_label'),
-      permission: 'user.edit.credentials'
-    }, 50);
+    items.add(
+      'userEditCredentials',
+      {
+        icon: 'fas fa-user-cog',
+        label: app.translator.trans('core.admin.permissions.user_edit_credentials_label'),
+        permission: 'user.edit.credentials',
+      },
+      50
+    );
 
-    items.add('userEditUsername', {
-      icon: 'fas fa-address-card',
-      label: app.translator.trans('core.admin.permissions.user_edit_username_label'),
-      permission: 'user.edit.username'
-    }, 50);
+    items.add(
+      'userEditUsername',
+      {
+        icon: 'fas fa-address-card',
+        label: app.translator.trans('core.admin.permissions.user_edit_username_label'),
+        permission: 'user.edit.username',
+      },
+      50
+    );
 
-    items.add('userEditGroups', {
-      icon: 'fas fa-users-cog',
-      label: app.translator.trans('core.admin.permissions.user_edit_groups_label'),
-      permission: 'user.edit.groups'
-    }, 50);
+    items.add(
+      'userEditGroups',
+      {
+        icon: 'fas fa-users-cog',
+        label: app.translator.trans('core.admin.permissions.user_edit_groups_label'),
+        permission: 'user.edit.groups',
+      },
+      50
+    );
 
     return items;
   }

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -312,22 +312,22 @@ export default class PermissionGrid extends Component {
       60
     );
 
-    items.add('editCredentials', {
+    items.add('userEditCredentials', {
       icon: 'fas fa-user-cog',
-      label: app.translator.trans('core.admin.permissions.edit_credentials_label'),
-      permission: 'edit.credentials'
+      label: app.translator.trans('core.admin.permissions.user_edit_credentials_label'),
+      permission: 'user.edit.credentials'
     }, 50);
 
-    items.add('editUsername', {
+    items.add('userEditUsername', {
       icon: 'fas fa-address-card',
-      label: app.translator.trans('core.admin.permissions.edit_username_label'),
-      permission: 'edit.username'
+      label: app.translator.trans('core.admin.permissions.user_edit_username_label'),
+      permission: 'user.edit.username'
     }, 50);
 
-    items.add('editGroups', {
+    items.add('userEditGroups', {
       icon: 'fas fa-users-cog',
-      label: app.translator.trans('core.admin.permissions.edit_groups_label'),
-      permission: 'edit.groups'
+      label: app.translator.trans('core.admin.permissions.user_edit_groups_label'),
+      permission: 'user.edit.groups'
     }, 50);
 
     return items;

--- a/js/src/common/models/User.js
+++ b/js/src/common/models/User.js
@@ -33,9 +33,6 @@ Object.assign(User.prototype, {
   canEditGroups: Model.attribute('canEditGroups'),
   canDelete: Model.attribute('canDelete'),
   canEdit: computed('canEditUsername', 'canEditCredentials', 'canEditGroups', function (canEditUsername, canEditCredentials, canEditGroups) {
-    console.log('Credentials: ' + canEditCredentials);
-    console.log('Groups: ' + canEditGroups);
-    console.log('Username: ' + canEditUsername);
     return (canEditCredentials || canEditGroups || canEditUsername);
   }),
 

--- a/js/src/common/models/User.js
+++ b/js/src/common/models/User.js
@@ -6,7 +6,8 @@ import ItemList from '../utils/ItemList';
 import computed from '../utils/computed';
 import GroupBadge from '../components/GroupBadge';
 
-export default class User extends Model {}
+export default class User extends Model {
+}
 
 Object.assign(User.prototype, {
   username: Model.attribute('username'),
@@ -27,9 +28,16 @@ Object.assign(User.prototype, {
 
   discussionCount: Model.attribute('discussionCount'),
   commentCount: Model.attribute('commentCount'),
-
-  canEdit: Model.attribute('canEdit'),
+  canEditUsername: Model.attribute('canEditUsername'),
+  canEditCredentials: Model.attribute('canEditCredentials'),
+  canEditGroups: Model.attribute('canEditGroups'),
   canDelete: Model.attribute('canDelete'),
+  canEdit: computed('canEditUsername', 'canEditCredentials', 'canEditGroups', function (canEditUsername, canEditCredentials, canEditGroups) {
+    console.log('Credentials: ' + canEditCredentials);
+    console.log('Groups: ' + canEditGroups);
+    console.log('Username: ' + canEditUsername);
+    return (canEditCredentials || canEditGroups || canEditUsername);
+  }),
 
   avatarColor: null,
   color: computed('username', 'avatarUrl', 'avatarColor', function (username, avatarUrl, avatarColor) {

--- a/js/src/common/models/User.js
+++ b/js/src/common/models/User.js
@@ -6,8 +6,7 @@ import ItemList from '../utils/ItemList';
 import computed from '../utils/computed';
 import GroupBadge from '../components/GroupBadge';
 
-export default class User extends Model {
-}
+export default class User extends Model {}
 
 Object.assign(User.prototype, {
   username: Model.attribute('username'),
@@ -33,7 +32,7 @@ Object.assign(User.prototype, {
   canEditGroups: Model.attribute('canEditGroups'),
   canDelete: Model.attribute('canDelete'),
   canEdit: computed('canEditUsername', 'canEditCredentials', 'canEditGroups', function (canEditUsername, canEditCredentials, canEditGroups) {
-    return (canEditCredentials || canEditGroups || canEditUsername);
+    return canEditCredentials || canEditGroups || canEditUsername;
   }),
 
   avatarColor: null,

--- a/js/src/forum/components/EditUserModal.js
+++ b/js/src/forum/components/EditUserModal.js
@@ -61,7 +61,7 @@ export default class EditUserModal extends Modal {
       );
     }
 
-    if (app.session.user !== this.props.user && app.session.user.canEditCredentials()) {
+    if (app.session.user.canEditCredentials()) {
       items.add(
         'email',
         <div className="Form-group">

--- a/js/src/forum/components/EditUserModal.js
+++ b/js/src/forum/components/EditUserModal.js
@@ -61,7 +61,6 @@ export default class EditUserModal extends Modal {
       );
     }
 
-    // The first part prevents silent account hijacking
     if (app.session.user !== this.props.user && app.session.user.canEditCredentials()) {
       items.add(
         'email',

--- a/js/src/forum/components/EditUserModal.js
+++ b/js/src/forum/components/EditUserModal.js
@@ -47,23 +47,26 @@ export default class EditUserModal extends Modal {
     const items = new ItemList();
 
     if (app.session.user.canEditUsername()) {
-      items.add('username', <div className="Form-group">
-        <label>{app.translator.trans('core.forum.edit_user.username_heading')}</label>
-        <input className="FormControl" placeholder={extractText(app.translator.trans('core.forum.edit_user.username_label'))}
-             bidi={this.username} />
-      </div>, 40);
+      items.add(
+        'username',
+        <div className="Form-group">
+          <label>{app.translator.trans('core.forum.edit_user.username_heading')}</label>
+          <input
+            className="FormControl"
+            placeholder={extractText(app.translator.trans('core.forum.edit_user.username_label'))}
+            bidi={this.username}
+          />
+        </div>,
+        40
+      );
     }
 
     // The first part prevents silent account hijacking
     if (app.session.user !== this.props.user && app.session.user.canEditCredentials()) {
-      items.add('email', <div className="Form-group">
-        <label>{app.translator.trans('core.forum.edit_user.email_heading')}</label>
-        <div>
-          <input className="FormControl"
-                 placeholder={extractText(app.translator.trans('core.forum.edit_user.email_label'))}
-                 bidi={this.email}/>
-        </div>
-        {!this.isEmailConfirmed() ? (
+      items.add(
+        'email',
+        <div className="Form-group">
+          <label>{app.translator.trans('core.forum.edit_user.email_heading')}</label>
           <div>
             <input className="FormControl" placeholder={extractText(app.translator.trans('core.forum.edit_user.email_label'))} bidi={this.email} />
           </div>
@@ -117,53 +120,42 @@ export default class EditUserModal extends Modal {
       );
     }
 
-    items.add(
-      'groups',
-      <div className="Form-group EditUserModal-groups">
-        <label>{app.translator.trans('core.forum.edit_user.groups_heading')}</label>
-        <div>
-          {Object.keys(this.groups)
-            .map((id) => app.store.getById('groups', id))
-            .map((group) => (
-              <label className="checkbox">
-                <input
-                  type="checkbox"
-                  bidi={this.groups[group.id()]}
-                  disabled={this.props.user.id() === '1' && group.id() === Group.ADMINISTRATOR_ID}
-                />
-                {GroupBadge.component({ group, label: '' })} {group.nameSingular()}
-              </label>
-            ))}
-        </div>
-      </div>, 20);
-    }
-
     if (app.session.user.canEditGroups()) {
-      items.add('groups', <div className="Form-group EditUserModal-groups">
-        <label>{app.translator.trans('core.forum.edit_user.groups_heading')}</label>
-        <div>
-          {Object.keys(this.groups)
-            .map(id => app.store.getById('groups', id))
-            .map(group => (
-              <label className="checkbox">
-                <input type="checkbox"
-                     bidi={this.groups[group.id()]}
-                     disabled={this.props.user.id() === '1' && group.id() === Group.ADMINISTRATOR_ID} />
-                {GroupBadge.component({group, label: ''})} {group.nameSingular()}
-              </label>
-            ))}
-        </div>
-      </div>, 10);
+      items.add(
+        'groups',
+        <div className="Form-group EditUserModal-groups">
+          <label>{app.translator.trans('core.forum.edit_user.groups_heading')}</label>
+          <div>
+            {Object.keys(this.groups)
+              .map((id) => app.store.getById('groups', id))
+              .map((group) => (
+                <label className="checkbox">
+                  <input
+                    type="checkbox"
+                    bidi={this.groups[group.id()]}
+                    disabled={this.props.user.id() === '1' && group.id() === Group.ADMINISTRATOR_ID}
+                  />
+                  {GroupBadge.component({ group, label: '' })} {group.nameSingular()}
+                </label>
+              ))}
+          </div>
+        </div>,
+        10
+      );
     }
 
-    items.add('submit', <div className="Form-group">
-      {Button.component({
-        className: 'Button Button--primary',
-        type: 'submit',
-        loading: this.loading,
-        children: app.translator.trans('core.forum.edit_user.submit_button')
-      })}
-    </div>, -10);
+    items.add(
+      'submit',
+      <div className="Form-group">
+        {Button.component({
+          className: 'Button Button--primary',
+          type: 'submit',
+          loading: this.loading,
+          children: app.translator.trans('core.forum.edit_user.submit_button'),
+        })}
+      </div>,
+      -10
+    );
 
     return items;
   }

--- a/src/Api/Serializer/UserSerializer.php
+++ b/src/Api/Serializer/UserSerializer.php
@@ -52,7 +52,7 @@ class UserSerializer extends BasicUserSerializer
             ];
         }
 
-        if ($canEdit || $this->actor->id === $user->id) {
+        if ($attributes['canEditCredentials'] || $this->actor->id === $user->id) {
             $attributes += [
                 'isEmailConfirmed' => (bool) $user->is_email_confirmed,
                 'email'            => $user->email

--- a/src/Api/Serializer/UserSerializer.php
+++ b/src/Api/Serializer/UserSerializer.php
@@ -36,14 +36,14 @@ class UserSerializer extends BasicUserSerializer
 
         $gate = $this->gate->forUser($this->actor);
 
-        $canEdit = $gate->allows('edit', $user);
-
         $attributes += [
-            'joinTime'         => $this->formatDate($user->joined_at),
-            'discussionCount'  => (int) $user->discussion_count,
-            'commentCount'     => (int) $user->comment_count,
-            'canEdit'          => $canEdit,
-            'canDelete'        => $gate->allows('delete', $user),
+            'joinTime'           => $this->formatDate($user->joined_at),
+            'discussionCount'    => (int) $user->discussion_count,
+            'commentCount'       => (int) $user->comment_count,
+            'canEditUsername'    => $gate->allows('user.edit.username', $user),
+            'canEditCredentials' => $gate->allows('user.edit.credentials', $user),
+            'canEditGroups'      => $gate->allows('user.edit.groups', $user),
+            'canDelete'          => $gate->allows('delete', $user),
         ];
 
         if ($user->getPreference('discloseOnline') || $this->actor->can('viewLastSeenAt', $user)) {

--- a/src/User/Command/EditUserHandler.php
+++ b/src/User/Command/EditUserHandler.php
@@ -80,6 +80,9 @@ class EditUserHandler
                     $validate['email'] = $attributes['email'];
                 }
             } else {
+                if ($attributes['email'] !== $user->email && $user->isAdmin()) {
+                    $this->assertAdmin($actor);
+                }
                 $this->assertPermission($canEdit);
                 $user->changeEmail($attributes['email']);
             }
@@ -90,6 +93,9 @@ class EditUserHandler
         }
 
         if (isset($attributes['password'])) {
+            if ($user->isAdmin()) {
+                $this->assertAdmin($actor);
+            }
             $this->assertPermission($canEdit);
             $user->changePassword($attributes['password']);
 

--- a/src/User/UserPolicy.php
+++ b/src/User/UserPolicy.php
@@ -21,10 +21,17 @@ class UserPolicy extends AbstractPolicy
     /**
      * @param User $actor
      * @param string $ability
+     * @param User $model
      * @return bool|null
      */
-    public function can(User $actor, $ability)
+    public function can(User $actor, $ability, User $model)
     {
+        if (strpos($ability, 'user.edit') === 0) {
+            if ($model->isAdmin() && !$actor->isAdmin()) {
+                return false;
+            }
+            return $actor->hasPermission($ability);
+        }
         if ($actor->hasPermission('user.'.$ability)) {
             return true;
         }

--- a/src/User/UserPolicy.php
+++ b/src/User/UserPolicy.php
@@ -27,9 +27,10 @@ class UserPolicy extends AbstractPolicy
     public function can(User $actor, $ability, User $model)
     {
         if (strpos($ability, 'user.edit') === 0) {
-            if ($model->isAdmin() && !$actor->isAdmin()) {
+            if ($model->isAdmin() && ! $actor->isAdmin()) {
                 return false;
             }
+
             return $actor->hasPermission($ability);
         }
         if ($actor->hasPermission('user.'.$ability)) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/framework#1965 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Currently only prevents non-admins from editing admin
- Splits the edit.user permission into three (edit.username, edit.credentials, edit.groups)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
- Is this the best way of doing this?
- Do we want to limit what shows up on the edit screen to only what users have permissions to do?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/3457368/78311495-049c2780-751f-11ea-984f-fdda1e7fab0c.png)

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**
- [x] Related core extension PRs: (Remove if irrelevant)
  - flarum/english#164