### PR TITLE
Add check to register state of '0' as false for checkboxes

### DIFF
--- a/js/src/admin/components/AppearancePage.js
+++ b/js/src/admin/components/AppearancePage.js
@@ -13,8 +13,8 @@ export default class AppearancePage extends Page {
 
     this.primaryColor = m.prop(app.data.settings.theme_primary_color);
     this.secondaryColor = m.prop(app.data.settings.theme_secondary_color);
-    this.darkMode = m.prop(app.data.settings.theme_dark_mode === '1');
-    this.coloredHeader = m.prop(app.data.settings.theme_colored_header === '1');
+    this.darkMode = m.prop(app.data.settings.theme_dark_mode);
+    this.coloredHeader = m.prop(app.data.settings.theme_colored_header);
   }
 
   view() {

--- a/js/src/common/components/Checkbox.js
+++ b/js/src/common/components/Checkbox.js
@@ -16,6 +16,7 @@ import icon from '../helpers/icon';
  */
 export default class Checkbox extends Component {
   view() {
+    if (this.props.state === '0') this.props.state = false;
     let className = 'Checkbox ' + (this.props.state ? 'on' : 'off') + ' ' + (this.props.className || '');
     if (this.props.loading) className += ' loading';
     if (this.props.disabled) className += ' disabled';

--- a/js/src/common/components/Checkbox.js
+++ b/js/src/common/components/Checkbox.js
@@ -16,6 +16,8 @@ import icon from '../helpers/icon';
  */
 export default class Checkbox extends Component {
   view() {
+    // Sometimes, false is stored in the DB as '0'. This is a temporary
+    // conversion layer until a more robust settings encoding is introduced
     if (this.props.state === '0') this.props.state = false;
     let className = 'Checkbox ' + (this.props.state ? 'on' : 'off') + ' ' + (this.props.className || '');
     if (this.props.loading) className += ' loading';


### PR DESCRIPTION
**Fixes flarum/framework#1395**
**Fixes flarum/framework#1478**

**Changes proposed in this pull request:**
- If the state supplied to a checkbox is '0', change it to false
- Remove unnecessary conversion in AppearancePage

**Reviewers should focus on:**
- Do we still want this workaround? I'm in favor because we might not get to flarum/issue-archive#299 for a while

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
