### PR TITLE
Permissions Cleanup: Core

### DIFF
--- a/js/src/admin/AdminApplication.js
+++ b/js/src/admin/AdminApplication.js
@@ -49,7 +49,7 @@ export default class AdminApplication extends Application {
     const required = [];
 
     if (permission === 'startDiscussion' || permission.indexOf('discussion.') === 0) {
-      required.push('viewDiscussions');
+      required.push('viewForum');
     }
     if (permission === 'discussion.delete') {
       required.push('discussion.hide');

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -102,11 +102,11 @@ export default class PermissionGrid extends Component {
     const items = new ItemList();
 
     items.add(
-      'viewDiscussions',
+      'viewForum',
       {
         icon: 'fas fa-eye',
-        label: app.translator.trans('core.admin.permissions.view_discussions_label'),
-        permission: 'viewDiscussions',
+        label: app.translator.trans('core.admin.permissions.view_forum_label'),
+        permission: 'viewForum',
         allowGuest: true,
       },
       100

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -123,11 +123,11 @@ export default class PermissionGrid extends Component {
     );
 
     items.add(
-      'viewUserList',
+      'searchUsers',
       {
         icon: 'fas fa-users',
-        label: app.translator.trans('core.admin.permissions.view_user_list_label'),
-        permission: 'viewUserList',
+        label: app.translator.trans('core.admin.permissions.search_users_label'),
+        permission: 'searchUsers',
         allowGuest: true,
       },
       100

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -202,7 +202,7 @@ export default class Search extends Component {
   sourceItems() {
     const items = new ItemList();
 
-    if (app.forum.attribute('canViewDiscussions')) items.add('discussions', new DiscussionsSearchSource());
+    if (app.forum.attribute('canViewForum')) items.add('discussions', new DiscussionsSearchSource());
     if (app.forum.attribute('canViewUserList')) items.add('users', new UsersSearchSource());
 
     return items;

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -203,7 +203,7 @@ export default class Search extends Component {
     const items = new ItemList();
 
     if (app.forum.attribute('canViewForum')) items.add('discussions', new DiscussionsSearchSource());
-    if (app.forum.attribute('canViewUserList')) items.add('users', new UsersSearchSource());
+    if (app.forum.attribute('canSearchUsers')) items.add('users', new UsersSearchSource());
 
     return items;
   }

--- a/migrations/2020_06_27_000000_rename_permissions.php
+++ b/migrations/2020_06_27_000000_rename_permissions.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $db = $schema->getConnection();
+
+        $db->table('group_permission')->where('permission', 'viewDiscussions')->update(['permission' => 'viewForum']);
+    },
+
+    'down' => function (Builder $schema) {
+        $db = $schema->getConnection();
+
+        $db->table('group_permission')->where('permission', 'viewForum')->update(['permission' => 'viewDiscussions']);
+    }
+];

--- a/migrations/2020_06_27_000000_rename_permissions.php
+++ b/migrations/2020_06_27_000000_rename_permissions.php
@@ -14,11 +14,13 @@ return [
         $db = $schema->getConnection();
 
         $db->table('group_permission')->where('permission', 'viewDiscussions')->update(['permission' => 'viewForum']);
+        $db->table('group_permission')->where('permission', 'viewUserList')->update(['permission' => 'searchUsers']);
     },
 
     'down' => function (Builder $schema) {
         $db = $schema->getConnection();
 
         $db->table('group_permission')->where('permission', 'viewForum')->update(['permission' => 'viewDiscussions']);
+        $db->table('group_permission')->where('permission', 'searchUsers')->update(['permission' => 'viewUserList']);
     }
 ];

--- a/src/Api/Controller/ListUsersController.php
+++ b/src/Api/Controller/ListUsersController.php
@@ -70,7 +70,7 @@ class ListUsersController extends AbstractListController
     {
         $actor = $request->getAttribute('actor');
 
-        $this->assertCan($actor, 'viewUserList');
+        $this->assertCan($actor, 'searchUsers');
 
         $query = Arr::get($this->extractFilter($request), 'q');
         $sort = $this->extractSort($request);

--- a/src/Api/Serializer/ForumSerializer.php
+++ b/src/Api/Serializer/ForumSerializer.php
@@ -80,7 +80,7 @@ class ForumSerializer extends AbstractSerializer
             'defaultRoute'  => $this->settings->get('default_route'),
             'canViewForum' => $this->actor->can('viewForum'),
             'canStartDiscussion' => $this->actor->can('startDiscussion'),
-            'canViewUserList' => $this->actor->can('viewUserList')
+            'canSearchUsers' => $this->actor->can('searchUsers')
         ];
 
         if ($this->actor->can('administrate')) {

--- a/src/Api/Serializer/ForumSerializer.php
+++ b/src/Api/Serializer/ForumSerializer.php
@@ -78,7 +78,7 @@ class ForumSerializer extends AbstractSerializer
             'footerHtml' => $this->settings->get('custom_footer'),
             'allowSignUp' => (bool) $this->settings->get('allow_sign_up'),
             'defaultRoute'  => $this->settings->get('default_route'),
-            'canViewDiscussions' => $this->actor->can('viewDiscussions'),
+            'canViewForum' => $this->actor->can('viewForum'),
             'canStartDiscussion' => $this->actor->can('startDiscussion'),
             'canViewUserList' => $this->actor->can('viewUserList')
         ];

--- a/src/Discussion/DiscussionPolicy.php
+++ b/src/Discussion/DiscussionPolicy.php
@@ -61,7 +61,7 @@ class DiscussionPolicy extends AbstractPolicy
      */
     public function find(User $actor, Builder $query)
     {
-        if ($actor->cannot('viewDiscussions')) {
+        if ($actor->cannot('viewForum')) {
             $query->whereRaw('FALSE');
 
             return;

--- a/src/User/UserPolicy.php
+++ b/src/User/UserPolicy.php
@@ -36,7 +36,7 @@ class UserPolicy extends AbstractPolicy
      */
     public function find(User $actor, Builder $query)
     {
-        if ($actor->cannot('viewUserList')) {
+        if ($actor->cannot('viewForum')) {
             if ($actor->isGuest()) {
                 $query->whereRaw('FALSE');
             } else {

--- a/tests/integration/api/authentication/WithApiKeyTest.php
+++ b/tests/integration/api/authentication/WithApiKeyTest.php
@@ -53,7 +53,7 @@ class WithApiKeyTest extends TestCase
         );
 
         $data = json_decode($response->getBody(), true);
-        $this->assertFalse($data['data']['attributes']['canViewUserList']);
+        $this->assertFalse($data['data']['attributes']['canSearchUsers']);
     }
 
     /**
@@ -69,7 +69,7 @@ class WithApiKeyTest extends TestCase
         );
 
         $data = json_decode($response->getBody(), true);
-        $this->assertTrue($data['data']['attributes']['canViewUserList']);
+        $this->assertTrue($data['data']['attributes']['canSearchUsers']);
         $this->assertArrayHasKey('adminUrl', $data['data']['attributes']);
 
         $key->refresh();
@@ -90,7 +90,7 @@ class WithApiKeyTest extends TestCase
         );
 
         $data = json_decode($response->getBody(), true);
-        $this->assertTrue($data['data']['attributes']['canViewUserList']);
+        $this->assertTrue($data['data']['attributes']['canSearchUsers']);
         $this->assertArrayNotHasKey('adminUrl', $data['data']['attributes']);
 
         $key->refresh();
@@ -111,7 +111,7 @@ class WithApiKeyTest extends TestCase
         );
 
         $data = json_decode($response->getBody(), true);
-        $this->assertTrue($data['data']['attributes']['canViewUserList']);
+        $this->assertTrue($data['data']['attributes']['canSearchUsers']);
         $this->assertArrayNotHasKey('adminUrl', $data['data']['attributes']);
 
         $key->refresh();

--- a/tests/integration/api/csrf_protection/RequireCsrfTokenTest.php
+++ b/tests/integration/api/csrf_protection/RequireCsrfTokenTest.php
@@ -31,7 +31,7 @@ class RequireCsrfTokenTest extends TestCase
                 ['user_id' => 1, 'group_id' => 1],
             ],
             'group_permission' => [
-                ['permission' => 'viewUserList', 'group_id' => 3],
+                ['permission' => 'searchUsers', 'group_id' => 3],
             ],
             'api_keys' => [
                 ['user_id' => 1, 'key' => 'superadmin'],

--- a/tests/integration/api/discussions/ListTest.php
+++ b/tests/integration/api/discussions/ListTest.php
@@ -36,7 +36,7 @@ class ListTest extends TestCase
                 $this->guestGroup(),
             ],
             'group_permission' => [
-                ['permission' => 'viewDiscussions', 'group_id' => 2],
+                ['permission' => 'viewForum', 'group_id' => 2],
             ]
         ]);
     }

--- a/tests/integration/api/discussions/ShowTest.php
+++ b/tests/integration/api/discussions/ShowTest.php
@@ -46,8 +46,8 @@ class ShowTest extends TestCase
                 ['user_id' => 2, 'group_id' => 3],
             ],
             'group_permission' => [
-                ['permission' => 'viewDiscussions', 'group_id' => 2],
-                ['permission' => 'viewDiscussions', 'group_id' => 3],
+                ['permission' => 'viewForum', 'group_id' => 2],
+                ['permission' => 'viewForum', 'group_id' => 3],
             ]
         ]);
     }

--- a/tests/integration/api/posts/CreateTest.php
+++ b/tests/integration/api/posts/CreateTest.php
@@ -36,7 +36,7 @@ class CreateTest extends TestCase
                 ['user_id' => 2, 'group_id' => 3],
             ],
             'group_permission' => [
-                ['permission' => 'viewDiscussions', 'group_id' => 3],
+                ['permission' => 'viewForum', 'group_id' => 3],
             ]
         ]);
     }

--- a/tests/integration/api/users/ListTest.php
+++ b/tests/integration/api/users/ListTest.php
@@ -55,7 +55,7 @@ class ListTest extends TestCase
     {
         Permission::unguarded(function () {
             Permission::create([
-                'permission' => 'viewUserList',
+                'permission' => 'searchUsers',
                 'group_id' => 2,
             ]);
         });

--- a/tests/integration/api/users/UpdateTest.php
+++ b/tests/integration/api/users/UpdateTest.php
@@ -69,7 +69,7 @@ class UpdateTest extends TestCase
         );
 
         // Make sure sensitive information is not made public
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(404, $response->getStatusCode());
         $this->assertNotContains('admin@machine.local', (string) $response->getBody());
     }
 }

--- a/tests/integration/api/users/UpdateTest.php
+++ b/tests/integration/api/users/UpdateTest.php
@@ -34,7 +34,7 @@ class UpdateTest extends TestCase
                 ['user_id' => 2, 'group_id' => 3],
             ],
             'group_permission' => [
-                ['permission' => 'viewUserList', 'group_id' => 3],
+                ['permission' => 'searchUsers', 'group_id' => 3],
             ]
         ]);
     }


### PR DESCRIPTION
**Fixes #1680**

**Changes proposed in this pull request:**
- Rename viewDiscussions to viewForum
- Rename viewUserList to searchUsers
- Revert https://github.com/flarum/core/commit/40e4c0acddd5c29dec322e6588ecd84a89544fa4
- Add migrations to update permission keys
- Fix an improperly configured test

**Reviewers should focus on:**
This is marked as draft until we agree upon https://github.com/flarum/core/issues/2202

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
