### PR TITLE
Convert icon helper to Typescript

### DIFF
--- a/js/src/common/helpers/icon.tsx
+++ b/js/src/common/helpers/icon.tsx
@@ -1,13 +1,13 @@
-import { Attributes, Vnode } from 'mithril';
+import * as Mithril from 'mithril';
 
 /**
  * The `icon` helper displays an icon.
  *
  * @param {String} fontClass The full icon class, prefix and the icon’s name.
- * @param {Attributes} attrs Any other attributes to apply.
- * @return {Vnode}
+ * @param {Mithril.Attributes} attrs Any other attributes to apply.
+ * @return {Mithril.Vnode}
  */
-export default function icon(fontClass: string, attrs: Attributes = {}): Vnode {
+export default function icon(fontClass: string, attrs: Mithril.Attributes = {}): Mithril.Vnode {
   attrs.className = 'icon ' + fontClass + ' ' + (attrs.className || '');
 
   return <i {...attrs} />;

--- a/js/src/common/helpers/icon.tsx
+++ b/js/src/common/helpers/icon.tsx
@@ -1,11 +1,13 @@
+import { Attributes, Vnode } from 'mithril';
+
 /**
  * The `icon` helper displays an icon.
  *
  * @param {String} fontClass The full icon class, prefix and the icon’s name.
- * @param {Object} attrs Any other attributes to apply.
- * @return {Object}
+ * @param {Attributes} attrs Any other attributes to apply.
+ * @return {Vnode}
  */
-export default function icon(fontClass, attrs = {}) {
+export default function icon(fontClass: string, attrs: Attributes = {}): Vnode {
   attrs.className = 'icon ' + fontClass + ' ' + (attrs.className || '');
 
   return <i {...attrs} />;

--- a/js/src/common/helpers/icon.tsx
+++ b/js/src/common/helpers/icon.tsx
@@ -3,9 +3,8 @@ import * as Mithril from 'mithril';
 /**
  * The `icon` helper displays an icon.
  *
- * @param {String} fontClass The full icon class, prefix and the icon’s name.
- * @param {Mithril.Attributes} attrs Any other attributes to apply.
- * @return {Mithril.Vnode}
+ * @param fontClass The full icon class, prefix and the icon’s name.
+ * @param attrs Any other attributes to apply.
  */
 export default function icon(fontClass: string, attrs: Mithril.Attributes = {}): Mithril.Vnode {
   attrs.className = 'icon ' + fontClass + ' ' + (attrs.className || '');


### PR DESCRIPTION
Convert common icon helper to Typescript. See flarum/framework#3533 

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
