### PR TITLE
Fix DiscussionListPane jumping around (when going from discussion to discussion)

### DIFF
--- a/js/src/forum/components/DiscussionListPane.js
+++ b/js/src/forum/components/DiscussionListPane.js
@@ -40,7 +40,7 @@ export default class DiscussionListPane extends Component {
     // When coming from another discussion, scroll to the previous postition
     // to prevent the discussion list jumping around.
     if (app.previous.matches(DiscussionPage)) {
-      const top = app.cache.paneScrollTop || 0;
+      const top = app.cache.discussionListPaneScrollTop || 0;
       $list.scrollTop(top);
     } else {
       // If the discussion we are viewing is listed in the discussion list, then
@@ -61,7 +61,7 @@ export default class DiscussionListPane extends Component {
   }
 
   onremove(vnode) {
-    app.cache.paneScrollTop = $(vnode.dom).scrollTop();
+    app.cache.discussionListPaneScrollTop = $(vnode.dom).scrollTop();
     $(document).off('mousemove', hotEdge);
   }
 

--- a/js/src/forum/components/DiscussionListPane.js
+++ b/js/src/forum/components/DiscussionListPane.js
@@ -40,6 +40,8 @@ export default class DiscussionListPane extends Component {
     // If the discussion we are viewing is listed in the discussion list, then
     // we will make sure it is visible in the viewport – if it is not we will
     // scroll the list down to it.
+    // When coming from another discussion, scroll to the previous postition
+    // to prevent the discussion list jumping around.
     if (!app.previous.matches(DiscussionPage)) {
       const $discussion = $list.find('.DiscussionListItem.active');
       if ($discussion.length) {

--- a/js/src/forum/components/DiscussionListPane.js
+++ b/js/src/forum/components/DiscussionListPane.js
@@ -37,12 +37,15 @@ export default class DiscussionListPane extends Component {
 
     $(document).on('mousemove', hotEdge);
 
-    // If the discussion we are viewing is listed in the discussion list, then
-    // we will make sure it is visible in the viewport – if it is not we will
-    // scroll the list down to it.
     // When coming from another discussion, scroll to the previous postition
     // to prevent the discussion list jumping around.
-    if (!app.previous.matches(DiscussionPage)) {
+    if (app.previous.matches(DiscussionPage)) {
+      const top = app.cache.paneScrollTop || 0;
+      $list.scrollTop(top);
+    } else {
+      // If the discussion we are viewing is listed in the discussion list, then
+      // we will make sure it is visible in the viewport – if it is not we will
+      // scroll the list down to it.
       const $discussion = $list.find('.DiscussionListItem.active');
       if ($discussion.length) {
         const listTop = $list.offset().top;
@@ -54,9 +57,6 @@ export default class DiscussionListPane extends Component {
           $list.scrollTop($list.scrollTop() - listTop + discussionTop);
         }
       }
-    } else {
-      const top = app.cache.paneScrollTop || 0;
-      $list.scrollTop(top);
     }
   }
 

--- a/js/src/forum/components/DiscussionListPane.js
+++ b/js/src/forum/components/DiscussionListPane.js
@@ -1,5 +1,6 @@
 import DiscussionList from './DiscussionList';
 import Component from '../../common/Component';
+import DiscussionPage from './DiscussionPage';
 
 const hotEdge = (e) => {
   if (e.pageX < 10) app.pane.show();
@@ -39,20 +40,26 @@ export default class DiscussionListPane extends Component {
     // If the discussion we are viewing is listed in the discussion list, then
     // we will make sure it is visible in the viewport – if it is not we will
     // scroll the list down to it.
-    const $discussion = $list.find('.DiscussionListItem.active');
-    if ($discussion.length) {
-      const listTop = $list.offset().top;
-      const listBottom = listTop + $list.outerHeight();
-      const discussionTop = $discussion.offset().top;
-      const discussionBottom = discussionTop + $discussion.outerHeight();
+    if (!app.previous.matches(DiscussionPage)) {
+      const $discussion = $list.find('.DiscussionListItem.active');
+      if ($discussion.length) {
+        const listTop = $list.offset().top;
+        const listBottom = listTop + $list.outerHeight();
+        const discussionTop = $discussion.offset().top;
+        const discussionBottom = discussionTop + $discussion.outerHeight();
 
-      if (discussionTop < listTop || discussionBottom > listBottom) {
-        $list.scrollTop($list.scrollTop() - listTop + discussionTop);
+        if (discussionTop < listTop || discussionBottom > listBottom) {
+          $list.scrollTop($list.scrollTop() - listTop + discussionTop);
+        }
       }
+    } else {
+      const top = app.cache.paneScrollTop || 0;
+      $list.scrollTop(top);
     }
   }
 
-  onremove() {
+  onremove(vnode) {
+    app.cache.paneScrollTop = $(vnode.dom).scrollTop();
     $(document).off('mousemove', hotEdge);
   }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes the following issue:**

1. Go to https://nightly.flarum.site and open a discussions.
2. On the discussion page scroll the pane a little. 
3. Click on a different discussion and the pane jumps back to the top, not keeping the scrolled position. 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
