### PR TITLE
Update tsconfig file to include .tsx files

### DIFF
--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "files": ["shims.d.ts"],
   "compilerOptions": {
     "allowUmdGlobalAccess": true,

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*"],
   "files": ["shims.d.ts"],
   "compilerOptions": {
     "allowUmdGlobalAccess": true,


### PR DESCRIPTION
**Refs flarum/framework#3533**

Doesn't really **fix** the umbrella issue but is related to it.

**Changes proposed in this pull request:**
Change `tsconfig.json` so that project-specific configuration is taken into account not just for `.ts` files but for `.tsx` files as well. Removing the file extension makes TS default to processing just `.ts`, `.tsx`, and `.d.ts`. files.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
