### PR TITLE
Add user badges to post preview #1765

### DIFF
--- a/js/src/forum/components/ReplyPlaceholder.js
+++ b/js/src/forum/components/ReplyPlaceholder.js
@@ -5,6 +5,7 @@ import avatar from '../../common/helpers/avatar';
 import username from '../../common/helpers/username';
 import DiscussionControls from '../utils/DiscussionControls';
 import ComposerPostPreview from './ComposerPostPreview';
+import listItems from '../../common/helpers/listItems';
 
 /**
  * The `ReplyPlaceholder` component displays a placeholder for a reply, which,
@@ -25,6 +26,7 @@ export default class ReplyPlaceholder extends Component {
                 {avatar(app.session.user, { className: 'PostUser-avatar' })}
                 {username(app.session.user)}
               </h3>
+              <ul className="PostUser-badges badges">{listItems(app.session.user.badges().toArray())}</ul>
             </div>
           </header>
           <ComposerPostPreview className="Post-body" composer={app.composer} surround={this.anchorPreview.bind(this)} />


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/issue-archive#248 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
For consistency, the user badges are added to the post preview, so that it cosmetically fits with the rest of the post stream

**Screenshot**
![image](https://user-images.githubusercontent.com/16573496/105094534-5311b700-5a9c-11eb-8ed0-8ad7821af6e1.png)


**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

