### PR TITLE
Add new modal options to require confirmation before closing

### DIFF
--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -10,7 +10,9 @@ import Button from './Button';
  */
 export default class Modal extends Component {
   /**
-   * Determine whether or not the modal should be dismissible via an 'x' button.
+   * Determine whether or not the modal should be dismissible.
+   *
+   * This overrides `doesBackdropClickDismiss` and `doesEscKeyDismiss`.
    */
   static isDismissible = true;
 
@@ -21,9 +23,9 @@ export default class Modal extends Component {
    * inadvertantly trigger this.
    *
    * It's recommended to disable this for modals which contain forms that may
-   * take a user a longer amount of time to complete.
+   * take a user a longer amount of time to complete to prevent frustration.
    */
-  static doesBackdropDismiss = false;
+  static doesBackdropClickDismiss = false;
 
   /**
    * Determine whether pressing the Escape key should dismiss the modal.

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -12,7 +12,8 @@ export default class Modal extends Component {
   /**
    * Determine whether or not the modal should be dismissible.
    *
-   * This overrides `doesBackdropClickDismiss` and `doesEscKeyDismiss`.
+   * Setting to `false` will override `doesBackdropClickDismiss` and
+   * `doesEscKeyDismiss`.
    */
   static isDismissible = true;
 
@@ -25,12 +26,12 @@ export default class Modal extends Component {
    * It's recommended to disable this for modals which contain forms that may
    * take a user a longer amount of time to complete to prevent frustration.
    */
-  static doesBackdropClickDismiss = false;
+  static dismissOnBackdropClick = false;
 
   /**
    * Determine whether pressing the Escape key should dismiss the modal.
    */
-  static doesEscKeyDismiss = true;
+  static dismissOnEscapeKeyPress = true;
 
   /**
    * Attributes for an alert component to show below the header.

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -15,6 +15,22 @@ export default class Modal extends Component {
   static isDismissible = true;
 
   /**
+   * Determine whether a click on the modal backdrop should dismiss the modal.
+   *
+   * Clicking and dragging from certain elements onto the backdrop can sometimes
+   * inadvertantly trigger this.
+   *
+   * It's recommended to disable this for modals which contain forms that may
+   * take a user a longer amount of time to complete.
+   */
+  static doesBackdropDismiss = false;
+
+  /**
+   * Determine whether pressing the Escape key should dismiss the modal.
+   */
+  static doesEscKeyDismiss = true;
+
+  /**
    * Attributes for an alert component to show below the header.
    *
    * @type {object}

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -36,8 +36,8 @@ export default class ModalManager extends Component {
     const isDismissible = !!this.attrs.state.modal.componentClass.isDismissible;
 
     // If the modal isn't dismissible, set these options to false.
-    const backdropDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.dismissOnBackdropClick : false;
-    const keyboardDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.dismissOnEscapeKeyPress : false;
+    const backdropDismissible = isDismissible && !!this.attrs.state.modal.componentClass.dismissOnBackdropClick;
+    const keyboardDismissible = isDismissible && !!this.attrs.state.modal.componentClass.dismissOnEscapeKeyPress;
 
     // If we are opening this modal while another modal is already open,
     // the shown event will not run, because the modal is already open.

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -110,7 +110,7 @@ export default class ModalManager extends Component {
    * actually closing the modal.
    *
    * @param {*} e jQuery event
-   * @param {*} forceRun force-run the confirmation code, even if the event doesn't match
+   * @param {boolean} forceRun Force-run the confirmation code, even if the event doesn't match
    */
   closeWithConfirmation(e, forceRun) {
     /**

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -33,7 +33,9 @@ export default class ModalManager extends Component {
   }
 
   animateShow(readyCallback) {
-    const dismissible = !!this.attrs.state.modal.componentClass.isDismissible;
+    const buttonDismissible = !!this.attrs.state.modal.componentClass.isDismissible;
+    const backdropDismissible = !!this.attrs.state.modal.componentClass.doesBackdropDismiss;
+    const keyboardDismissible = !!this.attrs.state.modal.componentClass.doesEscKeyDismiss;
 
     // If we are opening this modal while another modal is already open,
     // the shown event will not run, because the modal is already open.
@@ -46,8 +48,8 @@ export default class ModalManager extends Component {
     this.$()
       .one('shown.bs.modal', readyCallback)
       .modal({
-        backdrop: dismissible || 'static',
-        keyboard: dismissible,
+        backdrop: backdropDismissible ? true : 'static',
+        keyboard: keyboardDismissible,
       })
       .modal('show');
   }

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -38,8 +38,6 @@ export default class ModalManager extends Component {
     const requireCloseConfirmation = !!this.attrs.state.modal.componentClass.requireImplicitCloseConfirmation;
     const isDismissible = !requireCloseConfirmation && !!this.attrs.state.modal.componentClass.isDismissible;
 
-    console.log(requireCloseConfirmation, isDismissible);
-
     // If we are opening this modal while another modal is already open,
     // the shown event will not run, because the modal is already open.
     // So, we need to manually trigger the readyCallback.

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -33,8 +33,11 @@ export default class ModalManager extends Component {
   }
 
   animateShow(readyCallback) {
-    const backdropDismissible = !!this.attrs.state.modal.componentClass.doesBackdropClickDismiss;
-    const keyboardDismissible = !!this.attrs.state.modal.componentClass.doesEscKeyDismiss;
+    const isDismissible = !!this.attrs.state.modal.componentClass.isDismissible;
+
+    // If the modal isn't dismissible, set these options to false.
+    const backdropDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.doesBackdropClickDismiss : false;
+    const keyboardDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.doesEscKeyDismiss : false;
 
     // If we are opening this modal while another modal is already open,
     // the shown event will not run, because the modal is already open.
@@ -47,6 +50,7 @@ export default class ModalManager extends Component {
     this.$()
       .one('shown.bs.modal', readyCallback)
       .modal({
+        // 'static' means that a backdrop click doesn't dismiss the modal
         backdrop: backdropDismissible ? true : 'static',
         keyboard: keyboardDismissible,
       })

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -36,8 +36,8 @@ export default class ModalManager extends Component {
     const isDismissible = !!this.attrs.state.modal.componentClass.isDismissible;
 
     // If the modal isn't dismissible, set these options to false.
-    const backdropDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.doesBackdropClickDismiss : false;
-    const keyboardDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.doesEscKeyDismiss : false;
+    const backdropDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.dismissOnBackdropClick : false;
+    const keyboardDismissible = isDismissible ? !!this.attrs.state.modal.componentClass.dismissOnEscapeKeyPress : false;
 
     // If we are opening this modal while another modal is already open,
     // the shown event will not run, because the modal is already open.
@@ -51,7 +51,7 @@ export default class ModalManager extends Component {
       .one('shown.bs.modal', readyCallback)
       .modal({
         // 'static' means that a backdrop click doesn't dismiss the modal
-        backdrop: backdropDismissible ? true : 'static',
+        backdrop: backdropDismissible || 'static',
         keyboard: keyboardDismissible,
       })
       .modal('show');

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -33,8 +33,7 @@ export default class ModalManager extends Component {
   }
 
   animateShow(readyCallback) {
-    const buttonDismissible = !!this.attrs.state.modal.componentClass.isDismissible;
-    const backdropDismissible = !!this.attrs.state.modal.componentClass.doesBackdropDismiss;
+    const backdropDismissible = !!this.attrs.state.modal.componentClass.doesBackdropClickDismiss;
     const keyboardDismissible = !!this.attrs.state.modal.componentClass.doesEscKeyDismiss;
 
     // If we are opening this modal while another modal is already open,

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -55,6 +55,18 @@ export default class ModalManager extends Component {
         keyboard: keyboardDismissible,
       })
       .modal('show');
+
+    // Disabling backdrop dismissal also disables keyboard dismissibility
+    // but we want to be able to provide key-based dismissal while having
+    // backdrop-based disabled. To do this, we set up our own event
+    // handler to hide the modal if we press Escape.
+    if (!backdropDismissible && keyboardDismissible) {
+      this.$().on('keypress', function (e) {
+        if (e.key === 'Escape') {
+          this.animateHide();
+        }
+      });
+    }
   }
 
   animateHide() {

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -486,6 +486,10 @@ core:
     username:
       deleted_text: "[deleted]"
 
+    # These translations are used for modals
+    modal:
+      close_confirmation: Are you sure you want to close this modal? You may lose any changes you've made.
+
   # Translations in this namespace are used in views other than Flarum's normal JS client.
   views:
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

> For clarity, this PR was originally for adding attrs which disabled modal dismissing via backdrop clicks and Esc keypresses, but was changed after discussion.

I'm aware that Bootstrap Modals is set to get replaced by Micromodal (or another library) in the near future, but implementing this functionality now should (hopefully) mean it gets carried across to the new library. 🤞 

**Changes proposed in this pull request:**
This provides more customisability for modals, allowing extensions (and core) to determine if confirmation should be required before closing the modal.

The current field `isDismissible` was previously incorrectly labelled as only determining if an X button is visible, not stating that it also controlled if a backdrop click or Esc key press would dismiss the modal. (To be fair, I can't think of any situation where you want to remove a close button and keep Esc and backdrop dismissal.)

This PR adds two new static fields: `requireImplicitCloseConfirmation` and `requireExplicitCloseConfirmation`. This allows extensions to set whether confirmation should be needed for implicit actions, such as backdrop clicks and Esc keypresses.

I've been in the middle of completing several modals with forms in some extensions where I begin to click the button, then decide to edit one of the form entries, so drag my cursor off the submit button onto the backdrop, which then closes the modal. I then either have to re-complete the entire modal again, or just don't bother.

Another situation where backdrop dismissals frustrate me is if I'm copying text from the modal. I tend to click and drag off the end of the component (bottom or sides) to quickly copy all the text I need quickly. Releasing the click causes the modal to dismiss.

While extensions should probably find a way around this, or Bootstrap itself should be patched, in the long run, more customisability is better (in my mind), so exposing these options to extensions is a good thing!

---

This also addresses an issue with Esc-based closure. BS Modals currently only detect Esc presses when performed within their content, which requires that they have focused content. Modals without any autofocused content (no inputs, selects, or textareas) cannot be closed via Esc by default.

This PR disables the default detection techniques used by BS Modal and instead implements custom handlers to match behaviour between the confirmation-based and standard closures, and to fix this issue.

https://user-images.githubusercontent.com/7406822/111080808-0d9bc400-84f8-11eb-8c0e-d0e7fac5e2cf.mp4

**Reviewers should focus on:**
Where should `requireImplicitCloseConfirmation` be overridden to `true`? I've thought of the tag selection modal off the top of my head, but please suggest any other locations.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
