### PR TITLE
Require viewUserList to get user by ID

### DIFF
--- a/src/Api/Controller/ShowUserController.php
+++ b/src/Api/Controller/ShowUserController.php
@@ -61,6 +61,7 @@ class ShowUserController extends AbstractShowController
         if (Arr::get($request->getQueryParams(), 'bySlug', false)) {
             $user = $this->slugManager->forResource(User::class)->fromSlug($id, $actor);
         } else {
+            $actor->assertCan('viewUserList');
             $user = $this->users->findOrFail($id, $actor);
         }
 

--- a/tests/integration/api/users/ShowTest.php
+++ b/tests/integration/api/users/ShowTest.php
@@ -101,11 +101,17 @@ class ShowTest extends TestCase
      */
     public function guest_can_see_user_by_id_if_allowed()
     {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'viewUserList', 'group_id' => 2],
+            ]
+        ]);
+
         $response = $this->send(
             $this->request('GET', '/api/users/2')
         );
 
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     /**

--- a/tests/integration/api/users/ShowTest.php
+++ b/tests/integration/api/users/ShowTest.php
@@ -40,14 +40,6 @@ class ShowTest extends TestCase
         $this->database()->table('group_permission')->where('permission', 'viewUserList')->where('group_id', 3)->delete();
     }
 
-    private function allowGuestsToSearchUsers()
-    {
-        $this->database()->table('group_permission')->insert([
-            'permission' => 'viewUserList',
-            'group_id' => 3
-        ]);
-    }
-
     /**
      * @test
      */
@@ -109,8 +101,6 @@ class ShowTest extends TestCase
      */
     public function guest_can_see_user_by_id_if_allowed()
     {
-        $this->allowGuestsToSearchUsers();
-
         $response = $this->send(
             $this->request('GET', '/api/users/2')
         );

--- a/tests/integration/api/users/ShowTest.php
+++ b/tests/integration/api/users/ShowTest.php
@@ -40,6 +40,14 @@ class ShowTest extends TestCase
         $this->database()->table('group_permission')->where('permission', 'viewUserList')->where('group_id', 3)->delete();
     }
 
+    private function allowGuestsToSearchUsers()
+    {
+        $this->database()->table('group_permission')->insert([
+            'permission' => 'viewUserList',
+            'group_id' => 3
+        ]);
+    }
+
     /**
      * @test
      */
@@ -73,13 +81,13 @@ class ShowTest extends TestCase
     /**
      * @test
      */
-    public function guest_can_see_user_by_default()
+    public function guest_cant_see_user_by_id_default()
     {
         $response = $this->send(
             $this->request('GET', '/api/users/2')
         );
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(403, $response->getStatusCode());
     }
 
     /**
@@ -99,9 +107,9 @@ class ShowTest extends TestCase
     /**
      * @test
      */
-    public function guest_cant_see_user_if_blocked()
+    public function guest_can_see_user_by_id_if_allowed()
     {
-        $this->forbidGuestsFromSeeingForum();
+        $this->allowGuestsToSearchUsers();
 
         $response = $this->send(
             $this->request('GET', '/api/users/2')

--- a/tests/integration/api/users/ShowTest.php
+++ b/tests/integration/api/users/ShowTest.php
@@ -105,7 +105,7 @@ class ShowTest extends TestCase
             $this->request('GET', '/api/users/2')
         );
 
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(403, $response->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/2560

This makes it more difficult to scape the API for users.

Is there another place where this check would be more appropriate? I'm unsure about putting it in the repository since that method is used by other classes.


