### PR TITLE
Allow overriding routes

### DIFF
--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -31,6 +31,7 @@ class Frontend implements ExtenderInterface
     private $css = [];
     private $js;
     private $routes = [];
+    private $removedRoutes = [];
     private $content = [];
 
     public function __construct(string $frontend)
@@ -55,6 +56,13 @@ class Frontend implements ExtenderInterface
     public function route(string $path, string $name, $content = null)
     {
         $this->routes[] = compact('path', 'name', 'content');
+
+        return $this;
+    }
+
+    public function removeRoute(string $name)
+    {
+        $this->removedRoutes[] = compact('name');
 
         return $this;
     }
@@ -141,7 +149,7 @@ class Frontend implements ExtenderInterface
 
     private function registerRoutes(Container $container)
     {
-        if (empty($this->routes)) {
+        if (empty($this->routes) && empty($this->removedRoutes)) {
             return;
         }
 
@@ -150,6 +158,10 @@ class Frontend implements ExtenderInterface
             function (RouteCollection $collection, Container $container) {
                 /** @var RouteHandlerFactory $factory */
                 $factory = $container->make(RouteHandlerFactory::class);
+
+                foreach ($this->removedRoutes as $route) {
+                    $collection->removeRoute('GET', $route['name']);
+                }
 
                 foreach ($this->routes as $route) {
                     $collection->get(

--- a/src/Extend/Routes.php
+++ b/src/Extend/Routes.php
@@ -19,6 +19,7 @@ class Routes implements ExtenderInterface
     private $appName;
 
     private $routes = [];
+    private $removedRoutes = [];
 
     public function __construct($appName)
     {
@@ -62,9 +63,16 @@ class Routes implements ExtenderInterface
         return $this;
     }
 
+    public function remove(string $method, string $name)
+    {
+        $this->removedRoutes[] = compact('method', 'name');
+
+        return $this;
+    }
+
     public function extend(Container $container, Extension $extension = null)
     {
-        if (empty($this->routes)) {
+        if (empty($this->routes) && empty($this->removedRoutes)) {
             return;
         }
 
@@ -73,6 +81,10 @@ class Routes implements ExtenderInterface
             function (RouteCollection $collection, Container $container) {
                 /** @var RouteHandlerFactory $factory */
                 $factory = $container->make(RouteHandlerFactory::class);
+
+                foreach ($this->removedRoutes as $route) {
+                    $collection->removeRoute($route['method'], $route['name']);
+                }
 
                 foreach ($this->routes as $route) {
                     $collection->addRoute(

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -203,8 +203,8 @@ class ForumServiceProvider extends AbstractServiceProvider
         $factory = $this->app->make(RouteHandlerFactory::class);
         $defaultRoute = $this->app->make('flarum.settings')->get('default_route');
 
-        if (isset($routes->getRouteData()[0]['GET'][$defaultRoute]['handler'])) {
-            $toDefaultController = $routes->getRouteData()[0]['GET'][$defaultRoute]['handler'];
+        if (isset($routes->getRoutes()['GET'][$defaultRoute]['handler'])) {
+            $toDefaultController = $routes->getRoutes()['GET'][$defaultRoute]['handler'];
         } else {
             $toDefaultController = $factory->toForum(Content\Index::class);
         }

--- a/src/Http/RouteCollection.php
+++ b/src/Http/RouteCollection.php
@@ -68,7 +68,18 @@ class RouteCollection
 
     public function addRoute($method, $path, $name, $handler)
     {
+        if (isset($this->routes[$method][$name])) {
+            throw new \RuntimeException("Route $name already exists");
+        }
+
         $this->routes[$method][$name] = compact('path', 'handler');
+
+        return $this;
+    }
+
+    public function removeRoute(string $method, string $name): self
+    {
+        unset($this->routes[$method][$name]);
 
         return $this;
     }

--- a/src/Http/RouteCollection.php
+++ b/src/Http/RouteCollection.php
@@ -30,6 +30,11 @@ class RouteCollection
      */
     protected $routeParser;
 
+    /**
+     * @var array
+     */
+    protected $routes = [];
+
     public function __construct()
     {
         $this->dataGenerator = new DataGenerator\GroupCountBased;
@@ -63,19 +68,37 @@ class RouteCollection
 
     public function addRoute($method, $path, $name, $handler)
     {
-        $routeDatas = $this->routeParser->parse($path);
-
-        foreach ($routeDatas as $routeData) {
-            $this->dataGenerator->addRoute($method, $routeData, ['name' => $name, 'handler' => $handler]);
-        }
-
-        $this->reverse[$name] = $routeDatas;
+        $this->routes[$method][$name] = compact('path', 'handler');
 
         return $this;
     }
 
+    protected function applyRoutes(): void
+    {
+        foreach ($this->routes as $method => $routes) {
+            foreach ($routes as $name => $route) {
+                $routeDatas = $this->routeParser->parse($route['path']);
+
+                foreach ($routeDatas as $routeData) {
+                    $this->dataGenerator->addRoute($method, $routeData, ['name' => $name, 'handler' => $route['handler']]);
+                }
+
+                $this->reverse[$name] = $routeDatas;
+            }
+        }
+    }
+
+    public function getRoutes(): array
+    {
+        return $this->routes;
+    }
+
     public function getRouteData()
     {
+        if (empty($this->reverse)) {
+            $this->applyRoutes();
+        }
+
         return $this->dataGenerator->getData();
     }
 
@@ -88,6 +111,10 @@ class RouteCollection
 
     public function getPath($name, array $parameters = [])
     {
+        if (empty($this->reverse)) {
+            $this->applyRoutes();
+        }
+
         if (isset($this->reverse[$name])) {
             $maxMatches = 0;
             $matchingParts = $this->reverse[$name][0];

--- a/tests/integration/extenders/RoutesTest.php
+++ b/tests/integration/extenders/RoutesTest.php
@@ -51,24 +51,36 @@ class RoutesTest extends TestCase
     /**
      * @test
      */
+    public function existing_route_can_be_removed()
+    {
+        $this->extend(
+            (new Extend\Routes('api'))
+                ->remove('GET', 'forum.show')
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api')
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
     public function custom_route_can_override_existing_route_if_removed()
     {
         $this->extend(
             (new Extend\Routes('api'))
                 ->remove('GET', 'forum.show')
-                ->get('/overridenRoute', 'forum.show', CustomRoute::class)
+                ->get('/', 'forum.show', CustomRoute::class)
         );
 
         $response = $this->send(
-            $this->request('GET', '/api/')
+            $this->request('GET', '/api')
         );
 
-        $response2 = $this->send(
-            $this->request('GET', '/api/overridenRoute')
-        );
-
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEquals('Hello Flarumites!', $response2->getBody());
+        $this->assertEquals('Hello Flarumites!', $response->getBody());
     }
 }
 

--- a/tests/integration/extenders/RoutesTest.php
+++ b/tests/integration/extenders/RoutesTest.php
@@ -47,6 +47,28 @@ class RoutesTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Hello Flarumites!', $response->getBody());
     }
+
+    /**
+     * @test
+     */
+    public function custom_route_can_override_existing_route()
+    {
+        $this->extend(
+            (new Extend\Routes('api'))
+                ->get('/overridenRoute', 'forum.show', CustomRoute::class)
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/')
+        );
+
+        $response2 = $this->send(
+            $this->request('GET', '/api/overridenRoute')
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals('Hello Flarumites!', $response2->getBody());
+    }
 }
 
 class CustomRoute implements RequestHandlerInterface

--- a/tests/integration/extenders/RoutesTest.php
+++ b/tests/integration/extenders/RoutesTest.php
@@ -51,10 +51,11 @@ class RoutesTest extends TestCase
     /**
      * @test
      */
-    public function custom_route_can_override_existing_route()
+    public function custom_route_can_override_existing_route_if_removed()
     {
         $this->extend(
             (new Extend\Routes('api'))
+                ->remove('GET', 'forum.show')
                 ->get('/overridenRoute', 'forum.show', CustomRoute::class)
         );
 

--- a/tests/unit/Http/RouteCollectionTest.php
+++ b/tests/unit/Http/RouteCollectionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Http;
+
+use Flarum\Http\RouteCollection;
+use Flarum\Tests\unit\TestCase;
+
+class RouteCollectionTest extends TestCase
+{
+    /** @test */
+    public function can_add_routes()
+    {
+        $routeCollection = (new RouteCollection)
+            ->addRoute('GET', '/index', 'index', function () {
+                echo 'index';
+            })
+            ->addRoute('DELETE', '/posts', 'forum.posts.delete', function () {
+                echo 'delete posts';
+            });
+
+        $this->assertEquals('/index', $routeCollection->getPath('index'));
+        $this->assertEquals('/posts', $routeCollection->getPath('forum.posts.delete'));
+    }
+
+    /** @test */
+    public function can_add_routes_late()
+    {
+        $routeCollection = (new RouteCollection)->addRoute('GET', '/index', 'index', function () {
+                echo 'index';
+            });
+
+        $this->assertEquals('/index', $routeCollection->getPath('index'));
+
+        $routeCollection->addRoute('DELETE', '/posts', 'forum.posts.delete', function () {
+                echo 'delete posts';
+            });
+
+        $this->assertEquals('/posts', $routeCollection->getPath('forum.posts.delete'));
+    }
+}

--- a/tests/unit/Http/RouteCollectionTest.php
+++ b/tests/unit/Http/RouteCollectionTest.php
@@ -33,14 +33,14 @@ class RouteCollectionTest extends TestCase
     public function can_add_routes_late()
     {
         $routeCollection = (new RouteCollection)->addRoute('GET', '/index', 'index', function () {
-                echo 'index';
-            });
+            echo 'index';
+        });
 
         $this->assertEquals('/index', $routeCollection->getPath('index'));
 
         $routeCollection->addRoute('DELETE', '/posts', 'forum.posts.delete', function () {
-                echo 'delete posts';
-            });
+            echo 'delete posts';
+        });
 
         $this->assertEquals('/posts', $routeCollection->getPath('forum.posts.delete'));
     }


### PR DESCRIPTION
**Fixes flarum/framework#2553**

**Changes proposed in this pull request:**
Store registered routes in an array before applying them to FastRoute, thus allowing extensions to replace them (as described in the issue).

**Reviewers should focus on:**
The default route `/` is a special route, it is dynamically set in `ForumServiceProvider` after `flarum.forum.routes` has been resolved, at which point, extensions have already registered their routes, which means it's the one route they cannot override.
That said, I don't think there's a problem with that, they should not be directly overriding this route, instead they should be adding an option for a homepage route like tags.

**TODO**
* [x] Check that this fixes flarum/issue-archive#199

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
