### PR TITLE
Return promises in onsubmit

### DIFF
--- a/js/src/admin/components/AppearancePage.js
+++ b/js/src/admin/components/AppearancePage.js
@@ -131,7 +131,7 @@ export default class AppearancePage extends Page {
 
     this.loading = true;
 
-    saveSettings({
+    return saveSettings({
       theme_primary_color: this.primaryColor(),
       theme_secondary_color: this.secondaryColor(),
       theme_dark_mode: this.darkMode(),

--- a/js/src/admin/components/BasicsPage.js
+++ b/js/src/admin/components/BasicsPage.js
@@ -223,7 +223,7 @@ export default class BasicsPage extends Page {
 
     this.fields.forEach((key) => (settings[key] = this.values[key]()));
 
-    saveSettings(settings)
+    return saveSettings(settings)
       .then(() => {
         this.successAlert = app.alerts.show({ type: 'success' }, app.translator.trans('core.admin.basics.saved_message'));
       })

--- a/js/src/admin/components/EditGroupModal.js
+++ b/js/src/admin/components/EditGroupModal.js
@@ -138,7 +138,7 @@ export default class EditGroupModal extends Modal {
 
     this.loading = true;
 
-    this.group
+    return this.group
       .save(this.submitData(), { errorHandler: this.onerror.bind(this) })
       .then(this.hide.bind(this))
       .catch(() => {

--- a/js/src/admin/components/MailPage.js
+++ b/js/src/admin/components/MailPage.js
@@ -217,7 +217,7 @@ export default class MailPage extends Page {
 
     this.fields.forEach((key) => (settings[key] = this.values[key]()));
 
-    saveSettings(settings)
+    return saveSettings(settings)
       .then(() => {
         this.successAlert = app.alerts.show({ type: 'success' }, app.translator.trans('core.admin.basics.saved_message'));
       })

--- a/js/src/admin/components/SettingsModal.js
+++ b/js/src/admin/components/SettingsModal.js
@@ -64,7 +64,7 @@ export default class SettingsModal extends Modal {
 
     this.loading = true;
 
-    saveSettings(this.dirty()).then(this.onsaved.bind(this), this.loaded.bind(this));
+    return saveSettings(this.dirty()).then(this.onsaved.bind(this), this.loaded.bind(this));
   }
 
   onsaved() {

--- a/js/src/forum/components/ChangeEmailModal.js
+++ b/js/src/forum/components/ChangeEmailModal.js
@@ -109,7 +109,7 @@ export default class ChangeEmailModal extends Modal {
     this.loading = true;
     this.alertAttrs = null;
 
-    app.session.user
+    return app.session.user
       .save(
         { email: this.email() },
         {

--- a/js/src/forum/components/ChangePasswordModal.js
+++ b/js/src/forum/components/ChangePasswordModal.js
@@ -39,7 +39,7 @@ export default class ChangePasswordModal extends Modal {
 
     this.loading = true;
 
-    app
+    return app
       .request({
         method: 'POST',
         url: app.forum.attribute('apiUrl') + '/forgot',

--- a/js/src/forum/components/DiscussionComposer.js
+++ b/js/src/forum/components/DiscussionComposer.js
@@ -95,7 +95,7 @@ export default class DiscussionComposer extends ComposerBody {
 
     const data = this.data();
 
-    app.store
+    return app.store
       .createRecord('discussions')
       .save(data)
       .then((discussion) => {

--- a/js/src/forum/components/EditPostComposer.js
+++ b/js/src/forum/components/EditPostComposer.js
@@ -76,7 +76,7 @@ export default class EditPostComposer extends ComposerBody {
 
     const data = this.data();
 
-    this.attrs.post.save(data).then((post) => {
+    return this.attrs.post.save(data).then((post) => {
       // If we're currently viewing the discussion which this edit was made
       // in, then we can scroll to the post.
       if (app.viewingDiscussion(discussion)) {

--- a/js/src/forum/components/EditUserModal.js
+++ b/js/src/forum/components/EditUserModal.js
@@ -201,7 +201,7 @@ export default class EditUserModal extends Modal {
 
     this.loading = true;
 
-    this.attrs.user
+    return this.attrs.user
       .save(this.data(), { errorHandler: this.onerror.bind(this) })
       .then(this.hide.bind(this))
       .catch(() => {

--- a/js/src/forum/components/ForgotPasswordModal.js
+++ b/js/src/forum/components/ForgotPasswordModal.js
@@ -88,7 +88,7 @@ export default class ForgotPasswordModal extends Modal {
 
     this.loading = true;
 
-    app
+    return app
       .request({
         method: 'POST',
         url: app.forum.attribute('apiUrl') + '/forgot',

--- a/js/src/forum/components/LogInModal.js
+++ b/js/src/forum/components/LogInModal.js
@@ -175,7 +175,7 @@ export default class LogInModal extends Modal {
     const password = this.password();
     const remember = this.remember();
 
-    app.session
+    return app.session
       .login({ identification, password, remember }, { errorHandler: this.onerror.bind(this) })
       .then(() => window.location.reload(), this.loaded.bind(this));
   }

--- a/js/src/forum/components/ReplyComposer.js
+++ b/js/src/forum/components/ReplyComposer.js
@@ -75,7 +75,7 @@ export default class ReplyComposer extends ComposerBody {
 
     const data = this.data();
 
-    app.store
+    return app.store
       .createRecord('posts')
       .save(data)
       .then((post) => {

--- a/js/src/forum/components/SignUpModal.js
+++ b/js/src/forum/components/SignUpModal.js
@@ -161,7 +161,7 @@ export default class SignUpModal extends Modal {
 
     const body = this.submitData();
 
-    return app
+    app
       .request({
         url: app.forum.attribute('baseUrl') + '/register',
         method: 'POST',

--- a/js/src/forum/components/SignUpModal.js
+++ b/js/src/forum/components/SignUpModal.js
@@ -161,7 +161,7 @@ export default class SignUpModal extends Modal {
 
     const body = this.submitData();
 
-    app
+    return app
       .request({
         url: app.forum.attribute('baseUrl') + '/register',
         method: 'POST',


### PR DESCRIPTION
This allows extensions using the `extend` util to react to the server's response with `then`s. There might be other places we want to do this.

One example of a use case is https://github.com/FriendsOfFlarum/drafts/issues/18