### PR TITLE
WIP Floating Discussion hero

### DIFF
--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -58,10 +58,13 @@ export default class DiscussionPage extends Page {
     const scrollListener = new ScrollListener((top) => {
       const $hero = $('.DiscussionHero');
       if ($hero.offset()) {
-        $hero.toggleClass('DiscussionHero--floating', top > 92);
+        const container = $('.DiscussionHero').children('.container');
+        const containerPadding = parseInt(container.css('padding-top')) + parseInt(container.css('padding-bottom'));
+
+        $hero.toggleClass('DiscussionHero--floating', top > 22 + containerPadding);
         $('.DiscussionPage-discussion')
           .children('.container')
-          .toggleClass('scrolled', top > 92);
+          .toggleClass('scrolled', top > 22 + containerPadding);
       }
     });
 

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -9,6 +9,7 @@ import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';
 import PostStreamState from '../states/PostStreamState';
+import ScrollListener from "../../common/utils/ScrollListener";
 
 /**
  * The `DiscussionPage` component displays a whole discussion page, including
@@ -49,6 +50,21 @@ export default class DiscussionPage extends Page {
     app.history.push('discussion');
 
     this.bodyClass = 'App--discussion';
+  }
+
+  oncreate(vnode) {
+    super.oncreate(vnode);
+
+    const scrollListener = new ScrollListener((top) => {
+      const $hero = $('.DiscussionHero');
+      if ($hero.offset()) {
+        $hero.toggleClass('DiscussionHero--floating', top > 92);
+        $('.DiscussionPage-discussion').children('.container').toggleClass('scrolled', top > 92);
+      }
+    });
+
+    scrollListener.start();
+    scrollListener.update();
   }
 
   onremove() {

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -9,7 +9,7 @@ import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';
 import PostStreamState from '../states/PostStreamState';
-import ScrollListener from "../../common/utils/ScrollListener";
+import ScrollListener from '../../common/utils/ScrollListener';
 
 /**
  * The `DiscussionPage` component displays a whole discussion page, including
@@ -59,7 +59,9 @@ export default class DiscussionPage extends Page {
       const $hero = $('.DiscussionHero');
       if ($hero.offset()) {
         $hero.toggleClass('DiscussionHero--floating', top > 92);
-        $('.DiscussionPage-discussion').children('.container').toggleClass('scrolled', top > 92);
+        $('.DiscussionPage-discussion')
+          .children('.container')
+          .toggleClass('scrolled', top > 92);
       }
     });
 

--- a/less/forum/DiscussionHero.less
+++ b/less/forum/DiscussionHero.less
@@ -1,4 +1,7 @@
 .DiscussionHero {
+  z-index: 1;
+  .transition(all 0.4s ease);
+
   .badges {
     margin-right: 10px;
     margin-bottom: -2px;
@@ -17,4 +20,35 @@
 .DiscussionHero-title {
   display: inline;
   vertical-align: middle;
+}
+
+.DiscussionHero--floating {
+  position: fixed;
+  height: 50px;
+  width: 100%;
+
+  > .container {
+    padding-top: 10px !important;
+  }
+
+  .DiscussionHero-items {
+    li {
+      vertical-align: middle;
+    }
+
+    .item-title {
+      display: inline-block;
+      margin-top: -2px;
+    }
+
+    .tooltip {
+      top: unset !important;
+      bottom: -30px;
+    }
+
+    .tooltip-arrow {
+      top: 0;
+      .scale(1, -1);
+    }
+  }
 }

--- a/less/forum/DiscussionHero.less
+++ b/less/forum/DiscussionHero.less
@@ -24,8 +24,8 @@
 
 .DiscussionHero--floating {
   position: fixed;
-  height: 50px;
   width: 100%;
+  .box-shadow(0 1px 6px @shadow-color);
 
   @media @desktop-up {
     height: 50px;

--- a/less/forum/DiscussionHero.less
+++ b/less/forum/DiscussionHero.less
@@ -27,6 +27,14 @@
   height: 50px;
   width: 100%;
 
+  @media @desktop-up {
+    height: 50px;
+  }
+
+  @media (max-width: @screen-tablet-max) {
+    height: 40px;
+  }
+
   > .container {
     padding-top: 10px !important;
   }

--- a/less/forum/DiscussionHero.less
+++ b/less/forum/DiscussionHero.less
@@ -1,6 +1,5 @@
 .DiscussionHero {
   z-index: 1;
-  .transition(all 0.4s ease);
 
   .badges {
     margin-right: 10px;

--- a/less/forum/DiscussionPage.less
+++ b/less/forum/DiscussionPage.less
@@ -151,3 +151,13 @@
     }
   }
 }
+
+.DiscussionPage-discussion {
+  > .container.scrolled {
+    padding-top: ~"calc(90px + @{header-height})";
+
+    .DiscussionPage-nav {
+      margin-top: -1px;
+    }
+  }
+}

--- a/less/forum/DiscussionPage.less
+++ b/less/forum/DiscussionPage.less
@@ -153,11 +153,19 @@
 }
 
 .DiscussionPage-discussion {
-  > .container.scrolled {
-    padding-top: ~"calc(90px + @{header-height})";
+  @media @desktop-up {
+    .container.scrolled {
+      padding-top: ~"calc(90px + @{header-height})";
+    }
+  }
+
+  @media (max-width: @screen-tablet-max) {
+    .container.scrolled {
+      padding-top: ~"calc(50px + @{header-height})";
+    }
+  }
 
     .DiscussionPage-nav {
       margin-top: -1px;
     }
-  }
 }


### PR DESCRIPTION
**Closes flarum/issue-archive#433**

**Changes proposed in this pull request:**
Float the discussion header on scroll so it's visible farther down. I am also going to submit a PR to tags to hide secondary tags from the floated discussion as too many tags makes it very cluttered and cramped.

**Reviewers should focus on:**
Please check the CSS. There may be better ways of doing what I am doing.

**Screenshot**
<img width="948" alt="Screen Shot 2021-02-16 at 5 30 14 PM" src="https://user-images.githubusercontent.com/13856015/108143452-a87dbb80-707c-11eb-8f40-6c1a1efb74ae.png">


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

**Required changes:**

- [x] Related core extension PRs: Tags: https://github.com/flarum/tags/pull/119
