### PR TITLE
[A11Y] Fix nav drawer being focusable when off-screen on small viewports

### DIFF
--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -31,7 +31,18 @@ export default class Drawer {
    * @public
    */
   hide() {
-    $('#app').removeClass('drawerOpen');
+    const $app = $('#app');
+
+    // If the drawer isn't open, stop execution
+    if (!$app.hasClass('drawerOpen')) return;
+
+    const $drawer = $('#drawer');
+
+    // Used to prevent `visibility: hidden` from breaking the exit animation
+    $drawer.one('transitionend', () => $drawer.css('visibility', ''));
+    $drawer.css('visibility', 'visible');
+
+    $app.removeClass('drawerOpen');
 
     if (this.$backdrop) this.$backdrop.remove();
   }

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -31,16 +31,22 @@ export default class Drawer {
    * @public
    */
   hide() {
+    /**
+     * As part of hiding the drawer, this function also ensures that the drawer
+     * correctly animates out, while ensuring it is not part of the navigation
+     * tree while off-screen.
+     * 
+     * More info: https://github.com/flarum/core/pull/2666#discussion_r595381014
+     */
+
     const $app = $('#app');
 
-    // If the drawer isn't open, stop execution
     if (!$app.hasClass('drawerOpen')) return;
 
     const $drawer = $('#drawer');
 
     // Used to prevent `visibility: hidden` from breaking the exit animation
-    $drawer.one('transitionend', () => $drawer.css('visibility', ''));
-    $drawer.css('visibility', 'visible');
+    $drawer.css('visibility', 'visible').one('transitionend', () => $drawer.css('visibility', ''));
 
     $app.removeClass('drawerOpen');
 

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -35,7 +35,7 @@ export default class Drawer {
      * As part of hiding the drawer, this function also ensures that the drawer
      * correctly animates out, while ensuring it is not part of the navigation
      * tree while off-screen.
-     * 
+     *
      * More info: https://github.com/flarum/core/pull/2666#discussion_r595381014
      */
 

--- a/less/common/App.less
+++ b/less/common/App.less
@@ -123,6 +123,9 @@
 // the left side of the screen. On other devices, the drawer has no specific
 // appearance.
 @media @phone {
+  .App:not(.drawerOpen) .App-drawer {
+    visibility: hidden;
+  }
   .drawerOpen {
     overflow: hidden;
   }


### PR DESCRIPTION
Fixes flarum/framework#2565
Progresses towards completion of flarum/framework#3360 

**Changes proposed in this pull request:**
- Implements `visibility: hidden` on mobile when the drawer is not open.
- Adds inline `visibility: visible` as drawer exits.
- Removes inline style to re-apply `visibility: hidden` once transition is complete.

In the GIFs below, keep an eye on the watched variables in the dev console to see the effect of the change.

### Before
![LKOf0u](https://user-images.githubusercontent.com/7406822/110225946-1e3db000-7ee2-11eb-995b-6bcfe07a29bb.gif)

### After
![TpPNeQ](https://user-images.githubusercontent.com/7406822/110225947-239afa80-7ee2-11eb-814d-9932868bf507.gif)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
