### PR TITLE
User::fromRequest method

### DIFF
--- a/src/Admin/Middleware/RequireAdministrateAbility.php
+++ b/src/Admin/Middleware/RequireAdministrateAbility.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Admin\Middleware;
 
+use Flarum\User\User;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
@@ -18,7 +19,7 @@ class RequireAdministrateAbility implements Middleware
 {
     public function process(Request $request, Handler $handler): Response
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         return $handler->handle($request);
     }

--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -56,7 +56,7 @@ class Client
     {
         $request = ServerRequestFactory::fromGlobals(null, $queryParams, $body);
 
-        $request = $request->withAttribute('actor', $actor);
+        $request = User::setRequestActor($actor, $request);
 
         if (is_string($controller)) {
             $controller = $this->container->make($controller);

--- a/src/Api/Controller/ClearCacheController.php
+++ b/src/Api/Controller/ClearCacheController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Foundation\Console\CacheClearCommand;
+use Flarum\User\User;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -35,7 +36,7 @@ class ClearCacheController extends AbstractDeleteController
      */
     protected function delete(ServerRequestInterface $request)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $this->command->run(
             new ArrayInput([]),

--- a/src/Api/Controller/CreateDiscussionController.php
+++ b/src/Api/Controller/CreateDiscussionController.php
@@ -12,6 +12,7 @@ namespace Flarum\Api\Controller;
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Command\ReadDiscussion;
 use Flarum\Discussion\Command\StartDiscussion;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -53,7 +54,7 @@ class CreateDiscussionController extends AbstractCreateController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $ipAddress = $request->getAttribute('ipAddress');
 
         $discussion = $this->bus->dispatch(

--- a/src/Api/Controller/CreateGroupController.php
+++ b/src/Api/Controller/CreateGroupController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\GroupSerializer;
 use Flarum\Group\Command\CreateGroup;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,7 +43,7 @@ class CreateGroupController extends AbstractCreateController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         return $this->bus->dispatch(
-            new CreateGroup($request->getAttribute('actor'), Arr::get($request->getParsedBody(), 'data', []))
+            new CreateGroup(User::fromRequest($request), Arr::get($request->getParsedBody(), 'data', []))
         );
     }
 }

--- a/src/Api/Controller/CreatePostController.php
+++ b/src/Api/Controller/CreatePostController.php
@@ -12,6 +12,7 @@ namespace Flarum\Api\Controller;
 use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Discussion\Command\ReadDiscussion;
 use Flarum\Post\Command\PostReply;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -52,7 +53,7 @@ class CreatePostController extends AbstractCreateController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $data = Arr::get($request->getParsedBody(), 'data', []);
         $discussionId = Arr::get($data, 'relationships.discussion.data.id');
         $ipAddress = $request->getAttribute('ipAddress');

--- a/src/Api/Controller/CreateUserController.php
+++ b/src/Api/Controller/CreateUserController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\User\Command\RegisterUser;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,7 +43,7 @@ class CreateUserController extends AbstractCreateController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         return $this->bus->dispatch(
-            new RegisterUser($request->getAttribute('actor'), Arr::get($request->getParsedBody(), 'data', []))
+            new RegisterUser(User::fromRequest($request), Arr::get($request->getParsedBody(), 'data', []))
         );
     }
 }

--- a/src/Api/Controller/DeleteAvatarController.php
+++ b/src/Api/Controller/DeleteAvatarController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\UserSerializer;
 use Flarum\User\Command\DeleteAvatar;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,7 +43,7 @@ class DeleteAvatarController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         return $this->bus->dispatch(
-            new DeleteAvatar(Arr::get($request->getQueryParams(), 'id'), $request->getAttribute('actor'))
+            new DeleteAvatar(Arr::get($request->getQueryParams(), 'id'), User::fromRequest($request))
         );
     }
 }

--- a/src/Api/Controller/DeleteDiscussionController.php
+++ b/src/Api/Controller/DeleteDiscussionController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Discussion\Command\DeleteDiscussion;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,7 +36,7 @@ class DeleteDiscussionController extends AbstractDeleteController
     protected function delete(ServerRequestInterface $request)
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $input = $request->getParsedBody();
 
         $this->bus->dispatch(

--- a/src/Api/Controller/DeleteFaviconController.php
+++ b/src/Api/Controller/DeleteFaviconController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
 use Laminas\Diactoros\Response\EmptyResponse;
 use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -41,7 +42,7 @@ class DeleteFaviconController extends AbstractDeleteController
      */
     protected function delete(ServerRequestInterface $request)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $path = $this->settings->get('favicon_path');
 

--- a/src/Api/Controller/DeleteGroupController.php
+++ b/src/Api/Controller/DeleteGroupController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Group\Command\DeleteGroup;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,7 +36,7 @@ class DeleteGroupController extends AbstractDeleteController
     protected function delete(ServerRequestInterface $request)
     {
         $this->bus->dispatch(
-            new DeleteGroup(Arr::get($request->getQueryParams(), 'id'), $request->getAttribute('actor'))
+            new DeleteGroup(Arr::get($request->getQueryParams(), 'id'), User::fromRequest($request))
         );
     }
 }

--- a/src/Api/Controller/DeleteLogoController.php
+++ b/src/Api/Controller/DeleteLogoController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
 use Laminas\Diactoros\Response\EmptyResponse;
 use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -41,7 +42,7 @@ class DeleteLogoController extends AbstractDeleteController
      */
     protected function delete(ServerRequestInterface $request)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $path = $this->settings->get('logo_path');
 

--- a/src/Api/Controller/DeletePostController.php
+++ b/src/Api/Controller/DeletePostController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Post\Command\DeletePost;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,7 +36,7 @@ class DeletePostController extends AbstractDeleteController
     protected function delete(ServerRequestInterface $request)
     {
         $this->bus->dispatch(
-            new DeletePost(Arr::get($request->getQueryParams(), 'id'), $request->getAttribute('actor'))
+            new DeletePost(Arr::get($request->getQueryParams(), 'id'), User::fromRequest($request))
         );
     }
 }

--- a/src/Api/Controller/DeleteUserController.php
+++ b/src/Api/Controller/DeleteUserController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\User\Command\DeleteUser;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,7 +36,7 @@ class DeleteUserController extends AbstractDeleteController
     protected function delete(ServerRequestInterface $request)
     {
         $this->bus->dispatch(
-            new DeleteUser(Arr::get($request->getQueryParams(), 'id'), $request->getAttribute('actor'))
+            new DeleteUser(Arr::get($request->getQueryParams(), 'id'), User::fromRequest($request))
         );
     }
 }

--- a/src/Api/Controller/ListDiscussionsController.php
+++ b/src/Api/Controller/ListDiscussionsController.php
@@ -15,6 +15,7 @@ use Flarum\Discussion\Filter\DiscussionFilterer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Http\UrlGenerator;
 use Flarum\Query\QueryCriteria;
+use Flarum\User\User;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -85,7 +86,7 @@ class ListDiscussionsController extends AbstractListController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $filters = $this->extractFilter($request);
         $sort = $this->extractSort($request);
 

--- a/src/Api/Controller/ListGroupsController.php
+++ b/src/Api/Controller/ListGroupsController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\GroupSerializer;
 use Flarum\Group\Group;
+use Flarum\User\User;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -26,7 +27,7 @@ class ListGroupsController extends AbstractListController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         $results = Group::whereVisibleTo($actor)->get();
 

--- a/src/Api/Controller/ListNotificationsController.php
+++ b/src/Api/Controller/ListNotificationsController.php
@@ -13,6 +13,7 @@ use Flarum\Api\Serializer\NotificationSerializer;
 use Flarum\Discussion\Discussion;
 use Flarum\Http\UrlGenerator;
 use Flarum\Notification\NotificationRepository;
+use Flarum\User\User;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -62,7 +63,7 @@ class ListNotificationsController extends AbstractListController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         $actor->assertRegistered();
 

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -14,6 +14,7 @@ use Flarum\Http\UrlGenerator;
 use Flarum\Post\Filter\PostFilterer;
 use Flarum\Post\PostRepository;
 use Flarum\Query\QueryCriteria;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -74,7 +75,7 @@ class ListPostsController extends AbstractListController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         $filters = $this->extractFilter($request);
         $sort = $this->extractSort($request);
@@ -116,7 +117,7 @@ class ListPostsController extends AbstractListController
      */
     protected function extractOffset(ServerRequestInterface $request)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $queryParams = $request->getQueryParams();
         $sort = $this->extractSort($request);
         $limit = $this->extractLimit($request);

--- a/src/Api/Controller/ListUsersController.php
+++ b/src/Api/Controller/ListUsersController.php
@@ -14,6 +14,7 @@ use Flarum\Http\UrlGenerator;
 use Flarum\Query\QueryCriteria;
 use Flarum\User\Filter\UserFilterer;
 use Flarum\User\Search\UserSearcher;
+use Flarum\User\User;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -72,7 +73,7 @@ class ListUsersController extends AbstractListController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         $actor->assertCan('viewUserList');
 

--- a/src/Api/Controller/ReadAllNotificationsController.php
+++ b/src/Api/Controller/ReadAllNotificationsController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Notification\Command\ReadAllNotifications;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -34,7 +35,7 @@ class ReadAllNotificationsController extends AbstractDeleteController
     protected function delete(ServerRequestInterface $request)
     {
         $this->bus->dispatch(
-            new ReadAllNotifications($request->getAttribute('actor'))
+            new ReadAllNotifications(User::fromRequest($request))
         );
     }
 }

--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -13,6 +13,7 @@ use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\AccountActivationMailerTrait;
 use Flarum\User\Exception\PermissionDeniedException;
+use Flarum\User\User;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
@@ -65,7 +66,7 @@ class SendConfirmationEmailController implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         $actor->assertRegistered();
 

--- a/src/Api/Controller/SendTestMailController.php
+++ b/src/Api/Controller/SendTestMailController.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Api\Controller;
 
+use Flarum\User\User;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Mail\Message;
@@ -35,7 +36,7 @@ class SendTestMailController implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $actor->assertAdmin();
 
         $body = $this->translator->trans('core.email.send_test.body', ['{username}' => $actor->username]);

--- a/src/Api/Controller/SetPermissionController.php
+++ b/src/Api/Controller/SetPermissionController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Group\Permission;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -23,7 +24,7 @@ class SetPermissionController implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $body = $request->getParsedBody();
         $permission = Arr::get($body, 'permission');

--- a/src/Api/Controller/SetSettingsController.php
+++ b/src/Api/Controller/SetSettingsController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Settings\Event;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -43,7 +44,7 @@ class SetSettingsController implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $settings = $request->getParsedBody();
 

--- a/src/Api/Controller/ShowDiscussionController.php
+++ b/src/Api/Controller/ShowDiscussionController.php
@@ -82,7 +82,7 @@ class ShowDiscussionController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $discussionId = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $include = $this->extractInclude($request);
 
         if (Arr::get($request->getQueryParams(), 'bySlug', false)) {
@@ -111,7 +111,7 @@ class ShowDiscussionController extends AbstractShowController
      */
     private function includePosts(Discussion $discussion, ServerRequestInterface $request, array $include)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $limit = $this->extractLimit($request);
         $offset = $this->getPostsOffset($request, $discussion, $limit);
 
@@ -160,7 +160,7 @@ class ShowDiscussionController extends AbstractShowController
     private function getPostsOffset(ServerRequestInterface $request, Discussion $discussion, $limit)
     {
         $queryParams = $request->getQueryParams();
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         if (($near = Arr::get($queryParams, 'page.near')) > 1) {
             $offset = $this->posts->getIndexForNumber($discussion->id, $near, $actor);

--- a/src/Api/Controller/ShowForumController.php
+++ b/src/Api/Controller/ShowForumController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\ForumSerializer;
 use Flarum\Group\Group;
+use Flarum\User\User;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -32,7 +33,7 @@ class ShowForumController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         return [
-            'groups' => Group::whereVisibleTo($request->getAttribute('actor'))->get()
+            'groups' => Group::whereVisibleTo(User::fromRequest($request))->get()
         ];
     }
 }

--- a/src/Api/Controller/ShowMailSettingsController.php
+++ b/src/Api/Controller/ShowMailSettingsController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\MailSettingsSerializer;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
 use Illuminate\Contracts\Validation\Factory;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -27,7 +28,7 @@ class ShowMailSettingsController extends AbstractShowController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $drivers = array_map(function ($driver) {
             return self::$container->make($driver);

--- a/src/Api/Controller/ShowPostController.php
+++ b/src/Api/Controller/ShowPostController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Post\PostRepository;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -51,6 +52,6 @@ class ShowPostController extends AbstractShowController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        return $this->posts->findOrFail(Arr::get($request->getQueryParams(), 'id'), $request->getAttribute('actor'));
+        return $this->posts->findOrFail(Arr::get($request->getQueryParams(), 'id'), User::fromRequest($request));
     }
 }

--- a/src/Api/Controller/ShowUserController.php
+++ b/src/Api/Controller/ShowUserController.php
@@ -56,7 +56,7 @@ class ShowUserController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         if (Arr::get($request->getQueryParams(), 'bySlug', false)) {
             $user = $this->slugManager->forResource(User::class)->fromSlug($id, $actor);

--- a/src/Api/Controller/UninstallExtensionController.php
+++ b/src/Api/Controller/UninstallExtensionController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Extension\ExtensionManager;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -30,7 +31,7 @@ class UninstallExtensionController extends AbstractDeleteController
 
     protected function delete(ServerRequestInterface $request)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $name = Arr::get($request->getQueryParams(), 'name');
 

--- a/src/Api/Controller/UpdateDiscussionController.php
+++ b/src/Api/Controller/UpdateDiscussionController.php
@@ -12,6 +12,7 @@ namespace Flarum\Api\Controller;
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Command\EditDiscussion;
 use Flarum\Discussion\Command\ReadDiscussion;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Arr;
@@ -43,7 +44,7 @@ class UpdateDiscussionController extends AbstractShowController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $discussionId = Arr::get($request->getQueryParams(), 'id');
         $data = Arr::get($request->getParsedBody(), 'data', []);
 

--- a/src/Api/Controller/UpdateExtensionController.php
+++ b/src/Api/Controller/UpdateExtensionController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Extension\ExtensionManager;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -36,7 +37,7 @@ class UpdateExtensionController implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $enabled = Arr::get($request->getParsedBody(), 'enabled');
         $name = Arr::get($request->getQueryParams(), 'name');

--- a/src/Api/Controller/UpdateGroupController.php
+++ b/src/Api/Controller/UpdateGroupController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\GroupSerializer;
 use Flarum\Group\Command\EditGroup;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,7 +43,7 @@ class UpdateGroupController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $data = Arr::get($request->getParsedBody(), 'data', []);
 
         return $this->bus->dispatch(

--- a/src/Api/Controller/UpdateNotificationController.php
+++ b/src/Api/Controller/UpdateNotificationController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\NotificationSerializer;
 use Flarum\Notification\Command\ReadNotification;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,7 +43,7 @@ class UpdateNotificationController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         return $this->bus->dispatch(
             new ReadNotification($id, $actor)

--- a/src/Api/Controller/UpdatePostController.php
+++ b/src/Api/Controller/UpdatePostController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Post\Command\EditPost;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -50,7 +51,7 @@ class UpdatePostController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $data = Arr::get($request->getParsedBody(), 'data', []);
 
         return $this->bus->dispatch(

--- a/src/Api/Controller/UpdateUserController.php
+++ b/src/Api/Controller/UpdateUserController.php
@@ -13,6 +13,7 @@ use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\Api\Serializer\UserSerializer;
 use Flarum\User\Command\EditUser;
 use Flarum\User\Exception\NotAuthenticatedException;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -49,7 +50,7 @@ class UpdateUserController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $data = Arr::get($request->getParsedBody(), 'data', []);
 
         if ($actor->id == $id) {

--- a/src/Api/Controller/UploadAvatarController.php
+++ b/src/Api/Controller/UploadAvatarController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\UserSerializer;
 use Flarum\User\Command\UploadAvatar;
+use Flarum\User\User;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,7 +43,7 @@ class UploadAvatarController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $id = Arr::get($request->getQueryParams(), 'id');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $file = Arr::get($request->getUploadedFiles(), 'avatar');
 
         return $this->bus->dispatch(

--- a/src/Api/Controller/UploadImageController.php
+++ b/src/Api/Controller/UploadImageController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Intervention\Image\Image;
@@ -60,7 +61,7 @@ abstract class UploadImageController extends ShowForumController
      */
     public function data(ServerRequestInterface $request, Document $document)
     {
-        $request->getAttribute('actor')->assertAdmin();
+        User::fromRequest($request)->assertAdmin();
 
         $file = Arr::get($request->getUploadedFiles(), $this->filenamePrefix);
 

--- a/src/Api/Serializer/AbstractSerializer.php
+++ b/src/Api/Serializer/AbstractSerializer.php
@@ -64,7 +64,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     public function setRequest(Request $request)
     {
         $this->request = $request;
-        $this->actor = $request->getAttribute('actor');
+        $this->actor = User::fromRequest($request);
     }
 
     /**

--- a/src/Extend/ThrottleApi.php
+++ b/src/Extend/ThrottleApi.php
@@ -26,7 +26,7 @@ class ThrottleApi implements ExtenderInterface
      *
      * The callable can be a closure or invokable class, and should accept:
      *   - $request: The current `\Psr\Http\Message\ServerRequestInterface` request object.
-     *               `$request->getAttribute('actor')` can be used to get the current user.
+     *               `User::fromRequest($request)` can be used to get the current user.
      *               `$request->getAttribute('routeName')` can be used to get the current route.
      * Please note that every throttler runs by default on every route.
      * If you only want to throttle certain routes, you'll need to check for that inside your logic.

--- a/src/Forum/Content/AssertRegistered.php
+++ b/src/Forum/Content/AssertRegistered.php
@@ -10,12 +10,13 @@
 namespace Flarum\Forum\Content;
 
 use Flarum\Frontend\Document;
+use Flarum\User\User;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class AssertRegistered
 {
     public function __invoke(Document $document, Request $request)
     {
-        $request->getAttribute('actor')->assertRegistered();
+        User::fromRequest($request)->assertRegistered();
     }
 }

--- a/src/Forum/Content/Discussion.php
+++ b/src/Forum/Content/Discussion.php
@@ -61,7 +61,7 @@ class Discussion
             ]
         ];
 
-        $apiDocument = $this->getApiDocument($request->getAttribute('actor'), $params);
+        $apiDocument = $this->getApiDocument(User::fromRequest($request), $params);
 
         $getResource = function ($link) use ($apiDocument) {
             return Arr::first($apiDocument->included, function ($value) use ($link) {

--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -83,7 +83,7 @@ class Index
             $params['filter']['q'] = $q;
         }
 
-        $apiDocument = $this->getApiDocument($request->getAttribute('actor'), $params);
+        $apiDocument = $this->getApiDocument(User::fromRequest($request), $params);
         $defaultRoute = $this->settings->get('default_route');
 
         $document->title = $this->translator->trans('core.forum.index.meta_title_text');

--- a/src/Forum/Content/User.php
+++ b/src/Forum/Content/User.php
@@ -43,7 +43,7 @@ class User
     public function __invoke(Document $document, Request $request)
     {
         $queryParams = $request->getQueryParams();
-        $actor = $request->getAttribute('actor');
+        $actor = FlarumUser::fromRequest($request);
         $userId = Arr::get($queryParams, 'username');
 
         $params = [

--- a/src/Forum/Controller/LogInController.php
+++ b/src/Forum/Controller/LogInController.php
@@ -16,6 +16,7 @@ use Flarum\Http\RememberAccessToken;
 use Flarum\Http\Rememberer;
 use Flarum\Http\SessionAuthenticator;
 use Flarum\User\Event\LoggedIn;
+use Flarum\User\User;
 use Flarum\User\UserRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
@@ -70,7 +71,7 @@ class LogInController implements RequestHandlerInterface
      */
     public function handle(Request $request): ResponseInterface
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $body = $request->getParsedBody();
         $params = Arr::only($body, ['identification', 'password', 'remember']);
 

--- a/src/Forum/Controller/LogOutController.php
+++ b/src/Forum/Controller/LogOutController.php
@@ -14,6 +14,7 @@ use Flarum\Http\Rememberer;
 use Flarum\Http\SessionAuthenticator;
 use Flarum\Http\UrlGenerator;
 use Flarum\User\Event\LoggedOut;
+use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
@@ -79,7 +80,7 @@ class LogOutController implements RequestHandlerInterface
     public function handle(Request $request): ResponseInterface
     {
         $session = $request->getAttribute('session');
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         $url = Arr::get($request->getQueryParams(), 'return', $this->url->to('forum')->base());
 

--- a/src/Forum/Controller/RegisterController.php
+++ b/src/Forum/Controller/RegisterController.php
@@ -14,6 +14,7 @@ use Flarum\Api\Controller\CreateUserController;
 use Flarum\Http\RememberAccessToken;
 use Flarum\Http\Rememberer;
 use Flarum\Http\SessionAuthenticator;
+use Flarum\User\User;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -53,7 +54,7 @@ class RegisterController implements RequestHandlerInterface
     public function handle(Request $request): ResponseInterface
     {
         $controller = CreateUserController::class;
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
         $body = ['data' => ['attributes' => $request->getParsedBody()]];
 
         $response = $this->api->send($controller, $actor, [], $body);

--- a/src/Frontend/Content/CorePayload.php
+++ b/src/Frontend/Content/CorePayload.php
@@ -51,7 +51,7 @@ class CorePayload
     {
         $data = $this->getDataFromApiDocument($document->getForumApiDocument());
 
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         if ($actor->exists) {
             $user = $this->getUserApiDocument($actor);

--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -11,6 +11,7 @@ namespace Flarum\Frontend;
 
 use Flarum\Api\Client;
 use Flarum\Api\Controller\ShowForumController;
+use Flarum\User\User;
 use Illuminate\Contracts\View\Factory;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -66,7 +67,7 @@ class Frontend
 
     private function getForumDocument(Request $request): array
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         return $this->getResponseBody(
             $this->api->send(ShowForumController::class, $actor)

--- a/src/Http/Middleware/AuthenticateWithHeader.php
+++ b/src/Http/Middleware/AuthenticateWithHeader.php
@@ -46,7 +46,7 @@ class AuthenticateWithHeader implements Middleware
             }
 
             if (isset($actor)) {
-                $request = $request->withAttribute('actor', $actor);
+                $request = User::setRequestActor($actor, $request);
                 $request = $request->withAttribute('bypassCsrfToken', true);
                 $request = $request->withoutAttribute('session');
             }

--- a/src/Http/Middleware/AuthenticateWithSession.php
+++ b/src/Http/Middleware/AuthenticateWithSession.php
@@ -11,6 +11,7 @@ namespace Flarum\Http\Middleware;
 
 use Flarum\Http\AccessToken;
 use Flarum\User\Guest;
+use Flarum\User\User;
 use Illuminate\Contracts\Session\Session;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -27,7 +28,7 @@ class AuthenticateWithSession implements Middleware
 
         $actor->setSession($session);
 
-        $request = $request->withAttribute('actor', $actor);
+        $request = User::setRequestActor($actor, $request);
 
         return $handler->handle($request);
     }

--- a/src/Http/Middleware/SetLocale.php
+++ b/src/Http/Middleware/SetLocale.php
@@ -10,6 +10,7 @@
 namespace Flarum\Http\Middleware;
 
 use Flarum\Locale\LocaleManager;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -33,7 +34,7 @@ class SetLocale implements Middleware
 
     public function process(Request $request, Handler $handler): Response
     {
-        $actor = $request->getAttribute('actor');
+        $actor = User::fromRequest($request);
 
         if ($actor->exists) {
             $locale = $actor->getPreference('locale');

--- a/src/Post/PostServiceProvider.php
+++ b/src/Post/PostServiceProvider.php
@@ -12,6 +12,7 @@ namespace Flarum\Post;
 use DateTime;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Post\Access\ScopePostVisibility;
+use Flarum\User\User;
 
 class PostServiceProvider extends AbstractServiceProvider
 {
@@ -26,7 +27,7 @@ class PostServiceProvider extends AbstractServiceProvider
                     return;
                 }
 
-                $actor = $request->getAttribute('actor');
+                $actor = User::fromRequest($request);
 
                 if ($actor->can('postWithoutThrottle')) {
                     return false;

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -880,9 +880,9 @@ class User extends AbstractModel
 
     /**
      * Set a user as the actor on a request instance.
-     * 
+     *
      * @param Request $request
-     * @return 
+     * @return
      */
     public static function setRequestActor(self $actor, Request $request): Request
     {

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -879,6 +879,17 @@ class User extends AbstractModel
     }
 
     /**
+     * Set a user as the actor on a request instance.
+     * 
+     * @param Request $request
+     * @return 
+     */
+    public static function setRequestActor(self $actor, Request $request): Request
+    {
+        return $request->withAttribute('actor', $actor);
+    }
+
+    /**
      * Get the current user from a request instance.
      *
      * @param Request $request

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -882,9 +882,9 @@ class User extends AbstractModel
      * Get the current user from a request instance.
      *
      * @param Request $request
-     * @return static
+     * @return self
      */
-    public static function fromRequest(Request $request)
+    public static function fromRequest(Request $request): self
     {
         return $request->getAttribute('actor');
     }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -897,6 +897,6 @@ class User extends AbstractModel
      */
     public static function fromRequest(Request $request): self
     {
-        return $request->getAttribute('actor');
+        return $request->getAttribute('actor', new Guest());
     }
 }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -35,6 +35,7 @@ use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
 /**
  * @property int $id
@@ -875,5 +876,16 @@ class User extends AbstractModel
             ->count();
 
         return $this;
+    }
+
+    /**
+     * Get the current user from a request instance.
+     *
+     * @param Request $request
+     * @return static
+     */
+    public static function fromRequest(Request $request)
+    {
+        return $request->getAttribute('actor');
     }
 }


### PR DESCRIPTION
**Fixes #869**

**Changes proposed in this pull request:**
Add a `fromRequest()` static method to `User`, use this instead of `$request->getAttribute('actor')`

**Reviewers should focus on:**
Do we want to do this for other Flarum-specific stuff? I don't think it's worth it (at least for now), the only thing we really need this for is encapsulating the current user in the request.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
