### PR TITLE
Add unparse to Formatter extender

### DIFF
--- a/src/Extend/Formatter.php
+++ b/src/Extend/Formatter.php
@@ -18,6 +18,7 @@ class Formatter implements ExtenderInterface, LifecycleInterface
 {
     private $configurationCallbacks = [];
     private $parsingCallbacks = [];
+    private $unparsingCallbacks = [];
     private $renderingCallbacks = [];
 
     /**
@@ -59,6 +60,28 @@ class Formatter implements ExtenderInterface, LifecycleInterface
     }
 
     /**
+     * Prepare the system for unparsing. This can be used to modify the text that was parsed.
+     * Please note that the parsed text must be returned, regardless of whether it's changed.
+     *
+     * @param callable|string $callback
+     *
+     * The callback can be a closure or invokable class, and should accept:
+     * - mixed $context
+     * - string $xml: The parsed text.
+     *
+     * The callback should return:
+     * - string $xml: The text to be unparsed.
+     *
+     * @return self
+     */
+    public function unparse($callback)
+    {
+        $this->unparsingCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
      * Prepare the system for rendering. This can be used to modify the xml that will be rendered, or to modify the renderer.
      * Please note that the xml to be rendered must be returned, regardless of whether it's changed.
      *
@@ -89,6 +112,10 @@ class Formatter implements ExtenderInterface, LifecycleInterface
 
             foreach ($this->parsingCallbacks as $callback) {
                 $formatter->addParsingCallback(ContainerUtil::wrapCallback($callback, $container));
+            }
+
+            foreach ($this->unparsingCallbacks as $callback) {
+                $formatter->addUnparsingCallback(ContainerUtil::wrapCallback($callback, $container));
             }
 
             foreach ($this->renderingCallbacks as $callback) {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -20,6 +20,8 @@ class Formatter
 
     protected $parsingCallbacks = [];
 
+    protected $unparsingCallbacks = [];
+
     protected $renderingCallbacks = [];
 
     /**
@@ -50,6 +52,11 @@ class Formatter
     public function addParsingCallback($callback)
     {
         $this->parsingCallbacks[] = $callback;
+    }
+
+    public function addUnparsingCallback($callback)
+    {
+        $this->unparsingCallbacks[] = $callback;
     }
 
     public function addRenderingCallback($callback)
@@ -98,10 +105,15 @@ class Formatter
      * Unparse XML.
      *
      * @param string $xml
+     * @param mixed $context
      * @return string
      */
-    public function unparse($xml)
+    public function unparse($xml, $context = null)
     {
+        foreach ($this->unparsingCallbacks as $callback) {
+            $xml = $callback($context, $xml);
+        }
+
         return Unparser::unparse($xml);
     }
 

--- a/src/Post/CommentPost.php
+++ b/src/Post/CommentPost.php
@@ -128,7 +128,7 @@ class CommentPost extends Post
      */
     public function getContentAttribute($value)
     {
-        return static::$formatter->unparse($value);
+        return static::$formatter->unparse($value, $this);
     }
 
     /**

--- a/tests/integration/extenders/FormatterTest.php
+++ b/tests/integration/extenders/FormatterTest.php
@@ -92,6 +92,36 @@ class FormatterTest extends TestCase
     /**
      * @test
      */
+    public function custom_formatter_unparsing_doesnt_work_by_default()
+    {
+        $this->assertEquals('Text<a>', $this->getFormatter()->unparse('<t>Text&lt;a&gt;</t>'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_unparsing_works_if_added_with_closure()
+    {
+        $this->extend((new Extend\Formatter)->unparse(function ($context, $xml) {
+            return '<t>ReplacedText&lt;a&gt;</t>';
+        }));
+
+        $this->assertEquals('ReplacedText<a>', $this->getFormatter()->unparse('<t>Text&lt;a&gt;</t>'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_unparsing_works_if_added_with_invokable_class()
+    {
+        $this->extend((new Extend\Formatter)->unparse(InvokableUnparsing::class));
+
+        $this->assertEquals('ReplacedText<a>', $this->getFormatter()->unparse('<t>Text&lt;a&gt;</t>'));
+    }
+
+    /**
+     * @test
+     */
     public function custom_formatter_rendering_doesnt_work_by_default()
     {
         $this->assertEquals('Text', $this->getFormatter()->render('<p>Text</p>'));
@@ -133,6 +163,14 @@ class InvokableParsing
     public function __invoke($parser, $context, $text)
     {
         return 'ReplacedText<a>';
+    }
+}
+
+class InvokableUnparsing
+{
+    public function __invoke($context, $xml)
+    {
+        return '<t>ReplacedText&lt;a&gt;</t>';
     }
 }
 


### PR DESCRIPTION
**Part of flarum/mentions#65**
**Part of flarum/issue-archive#254**

**Changes proposed in this pull request:**
Adds an unparse method to the Formatter extender that allows hooking into the unparsing process.

**Reviewers should focus on:**
Code quality.

**Confirmed**

- [X] Backend changes: tests are green (run `composer test`).
