### PR TITLE
Harden formatter

### DIFF
--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -253,16 +253,20 @@ class Formatter extends RevisionCompiler
 
     protected function ensureRendererExists()
     {
-        if (! static::$formatter) return;
+        if (! static::$formatter) {
+            return;
+        }
 
         $revision = $this->getRevision();
 
-        if (file_exists($this->cacheDir . "/Renderer_$revision.php")) return;
+        if (file_exists($this->cacheDir."/Renderer_$revision.php")) {
+            return;
+        }
 
         $renderer = Arr::get(static::$formatter, 'renderer');
 
         if (! empty($renderer)) {
-            file_put_contents($this->cacheDir . "/Renderer_$revision.php", $renderer);
+            file_put_contents($this->cacheDir."/Renderer_$revision.php", $renderer);
         } else {
             $this->finalize();
         }
@@ -272,7 +276,7 @@ class Formatter extends RevisionCompiler
 
         if ($renderer && static::$formatter['renderer'] instanceof __PHP_Incomplete_Class) {
             // Autoload the file from disk using a simple include, while suppressing errors.
-            @include $this->cacheDir . "/Renderer_$revision.php";
+            @include $this->cacheDir."/Renderer_$revision.php";
 
             // Reload the formatter again from cache to resolve the __PHP_Incomplete_Class
             static::$formatter = $this->cache->get('flarum.formatter');
@@ -293,9 +297,13 @@ class Formatter extends RevisionCompiler
 
     protected function requiresRefresh(): bool
     {
-        if (! $this->getRevision()) return true;
+        if (! $this->getRevision()) {
+            return true;
+        }
 
-        if (! Arr::get(static::$formatter, 'renderer')) return true;
+        if (! Arr::get(static::$formatter, 'renderer')) {
+            return true;
+        }
 
         $renderer = static::$formatter['renderer'] instanceof __PHP_Incomplete_Class
             ? (new ArrayObject(static::$formatter['renderer']))['__PHP_Incomplete_Class_Name']

--- a/src/Formatter/FormatterServiceProvider.php
+++ b/src/Formatter/FormatterServiceProvider.php
@@ -24,7 +24,8 @@ class FormatterServiceProvider extends AbstractServiceProvider
         $this->container->singleton('flarum.formatter', function (Container $container) {
             return new Formatter(
                 new Repository($container->make('cache.filestore')),
-                $this->container[Paths::class]->storage.'/formatter'
+                $container[Paths::class]->storage.'/formatter',
+                $container->make('filesystem')->disk('flarum-assets')
             );
         });
 


### PR DESCRIPTION
**See flarum/issue-archive#121**

**Changes proposed in this pull request:**

This is not excellent code, but it takes into consideration performance and handles the incomplete class issue that some people experienced. You can reproduce this error by deleting `storage/formatter/*` and not cache clearing. My changes test whether the file exists and stores it on disk for autoload inclusion.

- prevents __PHP_Incomplete_Class
- stores a revision


**Reviewers should focus on:**

I dislike extending the RevisionCompiler as many methods go unused and it could open errors if used incorrectly. Any suggestions on how to improve this welcome.


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
