### PR TITLE
Revamp notifications stylesheet

### DIFF
--- a/js/src/forum/components/Notification.js
+++ b/js/src/forum/components/Notification.js
@@ -30,8 +30,11 @@ export default class Notification extends Component {
       >
         {avatar(notification.fromUser())}
         {icon(this.icon(), { className: 'Notification-icon' })}
-        <span className="Notification-content">{this.content()}</span>
-        {humanTime(notification.createdAt())}
+        <span className="Notification-title">
+          <span className="Notification-content">{this.content()}</span>
+          <span className="Notification-title-spring" />
+          {humanTime(notification.createdAt())}
+        </span>
         {!notification.isRead() && (
           <Button
             className="Notification-action Button Button--link"

--- a/js/src/forum/components/Notification.js
+++ b/js/src/forum/components/Notification.js
@@ -4,6 +4,7 @@ import icon from '../../common/helpers/icon';
 import humanTime from '../../common/helpers/humanTime';
 import Button from '../../common/components/Button';
 import Link from '../../common/components/Link';
+import classList from '../../common/utils/classList';
 
 /**
  * The `Notification` component abstract displays a single notification.
@@ -22,27 +23,28 @@ export default class Notification extends Component {
 
     return (
       <Link
-        className={'Notification Notification--' + notification.contentType() + ' ' + (!notification.isRead() ? 'unread' : '')}
+        className={classList('Notification', `Notification--${notification.contentType()}`, [!notification.isRead() && 'unread'])}
         href={href}
         external={href.includes('://')}
         onclick={this.markAsRead.bind(this)}
       >
-        {!notification.isRead() &&
-          Button.component({
-            className: 'Notification-action Button Button--icon Button--link',
-            icon: 'fas fa-check',
-            title: app.translator.trans('core.forum.notifications.mark_as_read_tooltip'),
-            onclick: (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-
-              this.markAsRead();
-            },
-          })}
         {avatar(notification.fromUser())}
         {icon(this.icon(), { className: 'Notification-icon' })}
         <span className="Notification-content">{this.content()}</span>
         {humanTime(notification.createdAt())}
+        {!notification.isRead() && (
+          <Button
+            className="Notification-action Button Button--link"
+            icon="fas fa-check"
+            title={app.translator.trans('core.forum.notifications.mark_as_read_tooltip')}
+            onclick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+
+              this.markAsRead();
+            }}
+          />
+        )}
         <div className="Notification-excerpt">{this.excerpt()}</div>
       </Link>
     );

--- a/js/src/forum/components/NotificationList.js
+++ b/js/src/forum/components/NotificationList.js
@@ -65,8 +65,8 @@ export default class NotificationList extends Component {
                     <div className="NotificationGroup">
                       {group.discussion ? (
                         <Link className="NotificationGroup-header" href={app.route.discussion(group.discussion)}>
-                          {badges && badges.length ? <ul className="NotificationGroup-badges badges">{listItems(badges)}</ul> : ''}
-                          {group.discussion.title()}
+                          {badges && badges.length && <ul className="NotificationGroup-badges badges">{listItems(badges)}</ul>}
+                          <span>{group.discussion.title()}</span>
                         </Link>
                       ) : (
                         <div className="NotificationGroup-header">{app.forum.attribute('title')}</div>

--- a/js/src/forum/components/NotificationList.js
+++ b/js/src/forum/components/NotificationList.js
@@ -43,7 +43,7 @@ export default class NotificationList extends Component {
                   // Get the discussion that this notification is related to. If it's not
                   // directly related to a discussion, it may be related to a post or
                   // other entity which is related to a discussion.
-                  let discussion = false;
+                  let discussion = null;
                   if (subject instanceof Discussion) discussion = subject;
                   else if (subject && subject.discussion) discussion = subject.discussion();
 

--- a/js/src/forum/components/NotificationList.js
+++ b/js/src/forum/components/NotificationList.js
@@ -17,16 +17,16 @@ export default class NotificationList extends Component {
     return (
       <div className="NotificationList">
         <div className="NotificationList-header">
-          <div className="App-primaryControl">
-            {Button.component({
-              className: 'Button Button--icon Button--link',
-              icon: 'fas fa-check',
-              title: app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip'),
-              onclick: state.markAllAsRead.bind(state),
-            })}
-          </div>
-
           <h4 className="App-titleControl App-titleControl--text">{app.translator.trans('core.forum.notifications.title')}</h4>
+
+          <div className="App-primaryControl">
+            <Button
+              className="Button Button--link"
+              icon="fas fa-check"
+              title={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')}
+              onclick={state.markAllAsRead.bind(state)}
+            />
+          </div>
         </div>
 
         <div className="NotificationList-content">

--- a/js/src/forum/components/NotificationsDropdown.js
+++ b/js/src/forum/components/NotificationsDropdown.js
@@ -34,7 +34,7 @@ export default class NotificationsDropdown extends Dropdown {
 
     return [
       icon(this.attrs.icon, { className: 'Button-icon' }),
-      unread && <span className="NotificationsDropdown-unread">{unread}</span>,
+      unread !== 0 && <span className="NotificationsDropdown-unread">{unread}</span>,
       <span className="Button-label">{this.attrs.label}</span>,
     ];
   }

--- a/js/src/forum/components/NotificationsDropdown.js
+++ b/js/src/forum/components/NotificationsDropdown.js
@@ -1,5 +1,6 @@
 import Dropdown from '../../common/components/Dropdown';
 import icon from '../../common/helpers/icon';
+import classList from '../../common/utils/classList';
 import NotificationList from './NotificationList';
 
 export default class NotificationsDropdown extends Dropdown {
@@ -9,6 +10,7 @@ export default class NotificationsDropdown extends Dropdown {
     attrs.menuClassName = attrs.menuClassName || 'Dropdown-menu--right';
     attrs.label = attrs.label || app.translator.trans('core.forum.notifications.tooltip');
     attrs.icon = attrs.icon || 'fas fa-bell';
+
     // For best a11y support, both `title` and `aria-label` should be used
     attrs.accessibleToggleLabel = attrs.accessibleToggleLabel || app.translator.trans('core.forum.notifications.toggle_dropdown_accessible_label');
 
@@ -21,7 +23,7 @@ export default class NotificationsDropdown extends Dropdown {
 
     vdom.attrs.title = this.attrs.label;
 
-    vdom.attrs.className += newNotifications ? ' new' : '';
+    vdom.attrs.className = classList(vdom.attrs.className, [newNotifications && 'new']);
     vdom.attrs.onclick = this.onclick.bind(this);
 
     return vdom;
@@ -32,15 +34,15 @@ export default class NotificationsDropdown extends Dropdown {
 
     return [
       icon(this.attrs.icon, { className: 'Button-icon' }),
-      unread ? <span className="NotificationsDropdown-unread">{unread}</span> : '',
+      unread && <span className="NotificationsDropdown-unread">{unread}</span>,
       <span className="Button-label">{this.attrs.label}</span>,
     ];
   }
 
   getMenu() {
     return (
-      <div className={'Dropdown-menu ' + this.attrs.menuClassName} onclick={this.menuClick.bind(this)}>
-        {this.showing ? NotificationList.component({ state: this.attrs.state }) : ''}
+      <div className={classList('Dropdown-menu', this.attrs.menuClassName)} onclick={this.menuClick.bind(this)}>
+        {this.showing && NotificationList.component({ state: this.attrs.state })}
       </div>
     );
   }

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -168,7 +168,8 @@
 
     grid-area: button;
 
-    & when (@config-colored-header = true) {
+    // Needs more specificity to fix hover/focus styles not applying in dropdown
+    .Notification & when (@config-colored-header = true) {
       color: @control-color;
 
       &:hover,

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -66,20 +66,23 @@
   &-header {
     font-weight: bold;
     color: @heading-color !important;
-    padding: 6px 15px;
-    display: block;
+    padding: 8px 16px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    display: flex;
+    align-items: center;
   }
 
   &-badges {
-    margin-left: -2px;
-    margin-right: 18px;
-    vertical-align: 1px;
+    @overlap: 13px;
+
+    margin-right: 8px;
+    padding-right: @overlap;
 
     .Badge {
-      margin-right: -13px;
+      margin-right: -@overlap;
       position: relative;
       .Badge--size(21px);
     }

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -73,6 +73,9 @@
 
     display: flex;
     align-items: center;
+
+    // Prevent outline overflowing parent
+    .add-keyboard-focus-ring-offset(-1px);
   }
 
   &-badges {
@@ -110,6 +113,9 @@
   align-items: baseline;
   row-gap: 1px;
   column-gap: 6px;
+
+  // Prevent outline overflowing parent
+  .add-keyboard-focus-ring-offset(-1px);
 
   &.unread {
     background: @control-bg;

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -1,48 +1,60 @@
-
 .NotificationList {
   overflow: hidden;
-  & .loading-indicator {
-    height: 100px;
-  }
-}
 
-.NotificationList-header {
-  @media @tablet-up {
-    padding: 12px 15px;
-    border-bottom: 1px solid @control-bg;
+  &-header {
+    @media @tablet-up {
+      padding: 12px 15px;
+      border-bottom: 1px solid @control-bg;
 
-    h4 {
-      font-size: 12px;
-      text-transform: uppercase;
-      font-weight: bold;
-      margin: 0;
-      color: @muted-color;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      h4 {
+        font-size: 12px;
+        text-transform: uppercase;
+        font-weight: bold;
+        margin: 0;
+        color: @muted-color;
+      }
     }
-  }
-  .Button {
-    float: right;
-    margin-top: -11px;
-    margin-right: -11px;
 
-    // The NotificationList may be displayed inside of the drawer as a
-    // dropdown menu – but the drawer may have .light-contents() applied to
-    // it. In this case we will need to reset the button's styles back to
-    // normal.
-    & when (@config-colored-header = true) {
-      .Button--color(@control-color, @control-bg);
+    // Mark all as read button
+    .Button {
+      padding: 0;
+      text-decoration: none;
 
-      &:hover {
-        color: @link-color;
+      // The NotificationList may be displayed inside of the drawer as a
+      // dropdown menu – but the drawer may have .light-contents() applied to
+      // it. In this case we will need to reset the button's styles back to
+      // normal.
+      & when (@config-colored-header = true) {
+        color: @control-color;
+
+        &:hover,
+        &:focus {
+          color: @link-color;
+        }
+      }
+
+      .add-keyboard-focus-ring();
+      .add-keyboard-focus-ring-offset(4px);
+
+      .icon {
+        margin-right: 0;
       }
     }
   }
+
+  // Message displayed when notifications are empty
+  &-empty {
+    color: @muted-color;
+    text-align: center;
+    padding: 50px 0;
+    font-size: 16px;
+  }
 }
-.NotificationList-empty {
-  color: @muted-color;
-  text-align: center;
-  padding: 50px 0;
-  font-size: 16px;
-}
+
 .NotificationGroup {
   border-top: 1px solid @control-bg;
   margin-top: -1px;
@@ -50,99 +62,133 @@
   &:not(:last-child) {
     margin-bottom: 20px;
   }
-}
-.NotificationGroup-header {
-  font-weight: bold;
-  color: @heading-color !important;
-  padding: 6px 15px;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.NotificationGroup-badges {
-  margin-left: -2px;
-  margin-right: 18px;
-  vertical-align: 1px;
 
-  .Badge {
-    margin-right: -13px;
-    position: relative;
-    .Badge--size(21px);
+  &-header {
+    font-weight: bold;
+    color: @heading-color !important;
+    padding: 6px 15px;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &-badges {
+    margin-left: -2px;
+    margin-right: 18px;
+    vertical-align: 1px;
+
+    .Badge {
+      margin-right: -13px;
+      position: relative;
+      .Badge--size(21px);
+    }
+  }
+
+  &-content {
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 }
-.NotificationGroup-content {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+
 .Notification {
-  display: block;
-  padding: 8px 15px 8px 70px;
+  padding: 8px 16px;
   color: @muted-color !important; // required to override .light-contents applied to header
   overflow: hidden;
 
-  .unread& {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+
+  grid-template-areas:
+    "avatar icon title   button"
+    "x      x    excerpt excerpt";
+
+  align-items: baseline;
+  row-gap: 1px;
+  column-gap: 6px;
+
+  &.unread {
     background: @control-bg;
   }
-  &:hover {
+
+  &:hover,
+  &:focus,
+  &:focus-within {
     text-decoration: none;
     background: @control-bg;
-    
+
     .Notification-action {
-      display: block;
+      opacity: 1;
     }
   }
+
   .Avatar {
     .Avatar--size(24px);
-    float: left;
-    margin: -2px 0 -2px -55px;
+    grid-area: avatar;
   }
+
+  &-icon {
+    font-size: 14px;
+    grid-area: icon;
+  }
+
+  &-title {
+    grid-area: title;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: baseline;
+  }
+
+  &-content {
+    line-height: 19px;
+    margin-right: 8px;
+
+    .username {
+      font-weight: bold;
+    }
+  }
+
   time {
+    line-height: inherit;
     font-size: 11px;
+    line-height: 19px;
     font-weight: bold;
     text-transform: uppercase;
   }
 
-  .Notification-action {
-    float: right;
-    display: none;
-    margin-top: -7px;
-    margin-right: -10px;
+  &-action {
     line-height: inherit;
-    padding: 5px 0;
+    padding: 0;
+    opacity: 0;
+
+    .add-keyboard-focus-ring();
+    .add-keyboard-focus-ring-offset(4px);
+
+    grid-area: button;
 
     & when (@config-colored-header = true) {
-      .Button--color(@control-color, @control-bg);
+      color: @control-color;
 
-      &:hover {
+      &:hover,
+      &:focus {
         color: @link-color;
       }
     }
 
     .icon {
-      font-size: 12px;
+      font-size: 13px;
+      margin-right: 0;
     }
   }
-}
-.Notification-icon {
-  float: left;
-  margin-left: -23px;
-  font-size: 14px;
-  margin-top: 2px;
-}
-.Notification-content {
-  margin-right: 5px;
 
-  .username {
-    font-weight: bold;
+  &-excerpt {
+    grid-area: excerpt;
+    color: @muted-more-color;
+    font-size: 11px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
-}
-.Notification-excerpt {
-  color: @muted-more-color;
-  font-size: 11px;
-  margin-top: 3px;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/framework#2813. Progresses flarum/issue-archive#355.**

**Changes proposed in this pull request:**
- Fixes layout shift caused by tick button being added to layout DOM on hover.
- Fixes styles not being applied on focus.
- Add missing focus outlines.
- Rewrite styles to use Less nesting, Grid and Flexbox
- Use `classList` util (clsx) instead of string interpolation

This should really have been multiple PRs... I got a little carried away.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Anything I've missed or should be changed? It's a pretty big rewrite so I wouldn't be surprised! I tried to add some comments to the styles too to help the review process (and me if I ever wonder what on earth I was doing).

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/116623686-8a66ee00-a93e-11eb-9996-8be17e835604.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
