### PR TITLE
Move user badges to bottom of avatar

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -354,7 +354,7 @@
   }
   .PostUser-badges {
     position: absolute;
-    top: -12px;
+    top: 15px;
     left: 6px;
     width: 32px;
 
@@ -391,7 +391,7 @@
     float: left;
     position: relative;
     margin-left: -@avatar-column-width + 5px;
-    margin-top: -3px;
+    margin-top: 50px;
     width: 64px;
   }
   .EventPost-icon {


### PR DESCRIPTION
Move user badges to bottom of avatars.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Changes .PostUser-badges `top` to 15px for phone and `margin-top` to 50px for desktop which moves the badges from the top of avatars to the bottom. Also, compared to how much they overlapped the avatar before, this puts the badges right on the edge of the avatar.

The reason I am proposing this change is because currently the badges cover the user's face. Other proposed changes have been made in the past such as moving the badges to a completely different spot, off of the avatar completely. However, it is my opinion that one of the things that makes Flarum look like Flarum is the badges on the avatar. This keeps the badges tied to the avatar while uncovering faces.

**Reviewers should focus on:**
Does it look nice on both mobile and desktop?

**Screenshot**
![](https://i.ibb.co/2FkxN10/Screen-Shot-2021-05-02-at-2-37-05-AM.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
