### PR TITLE
Remove `lodash` from core

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -18,7 +18,8 @@
         "mithril": "^2.0.4",
         "punycode": "^2.1.1",
         "spin.js": "^3.1.0",
-        "textarea-caret": "^3.1.0"
+        "textarea-caret": "^3.1.0",
+        "throttle-debounce": "^3.0.1"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.13.0",
@@ -6638,6 +6639,14 @@
       "resolved": "https://registry.npmjs.org/textarea-caret/-/textarea-caret-3.1.0.tgz",
       "integrity": "sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q=="
     },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -12973,6 +12982,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/textarea-caret/-/textarea-caret-3.1.0.tgz",
       "integrity": "sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q=="
+    },
+    "throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
     },
     "through2": {
       "version": "2.0.5",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -15,7 +15,6 @@
         "expose-loader": "^1.0.3",
         "jquery": "^3.6.0",
         "jquery.hotkeys": "^0.1.0",
-        "lodash-es": "^4.17.21",
         "mithril": "^2.0.4",
         "punycode": "^2.1.1",
         "spin.js": "^3.1.0",
@@ -24,7 +23,6 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.13.0",
         "@types/jquery": "^3.5.5",
-        "@types/lodash-es": "^4.17.4",
         "@types/mithril": "^2.0.7",
         "@types/punycode": "^2.1.0",
         "@types/textarea-caret": "^3.0.0",
@@ -1497,21 +1495,6 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
-      "dev": true
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mithril": {
       "version": "2.0.7",
@@ -4668,11 +4651,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -8885,21 +8863,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
-    "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
-      "dev": true
-    },
-    "@types/lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/mithril": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/mithril/-/mithril-2.0.7.tgz",
@@ -11398,11 +11361,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/js/package.json
+++ b/js/package.json
@@ -11,7 +11,6 @@
     "expose-loader": "^1.0.3",
     "jquery": "^3.6.0",
     "jquery.hotkeys": "^0.1.0",
-    "lodash-es": "^4.17.21",
     "mithril": "^2.0.4",
     "punycode": "^2.1.1",
     "spin.js": "^3.1.0",
@@ -20,7 +19,6 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.13.0",
     "@types/jquery": "^3.5.5",
-    "@types/lodash-es": "^4.17.4",
     "@types/mithril": "^2.0.7",
     "@types/punycode": "^2.1.0",
     "@types/textarea-caret": "^3.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,8 @@
     "mithril": "^2.0.4",
     "punycode": "^2.1.1",
     "spin.js": "^3.1.0",
-    "textarea-caret": "^3.1.0"
+    "textarea-caret": "^3.1.0",
+    "throttle-debounce": "^3.0.1"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.13.0",

--- a/js/src/common/Application.js
+++ b/js/src/common/Application.js
@@ -20,7 +20,6 @@ import Discussion from './models/Discussion';
 import Post from './models/Post';
 import Group from './models/Group';
 import Notification from './models/Notification';
-import { flattenDeep } from 'lodash-es';
 import PageState from './states/PageState';
 import ModalManagerState from './states/ModalManagerState';
 import AlertManagerState from './states/AlertManagerState';
@@ -184,7 +183,7 @@ export default class Application {
     Object.keys(extensions).forEach((name) => {
       const extension = extensions[name];
 
-      const extenders = flattenDeep(extension.extend);
+      const extenders = extension.extend.flat(Infinity);
 
       for (const extender of extenders) {
         extender.extend(this, { name, exports: extension });

--- a/js/src/common/compat.js
+++ b/js/src/common/compat.js
@@ -12,7 +12,9 @@ import Drawer from './utils/Drawer';
 import anchorScroll from './utils/anchorScroll';
 import RequestError from './utils/RequestError';
 import abbreviateNumber from './utils/abbreviateNumber';
+import escapeRegExp from './utils/escapeRegExp';
 import * as string from './utils/string';
+import * as ThrottleDebounce from './utils/throttleDebounce';
 import Stream from './utils/Stream';
 import SubtreeRetainer from './utils/SubtreeRetainer';
 import setRouteWithForcedRefresh from './utils/setRouteWithForcedRefresh';
@@ -91,6 +93,7 @@ export default {
   'utils/abbreviateNumber': abbreviateNumber,
   'utils/string': string,
   'utils/SubtreeRetainer': SubtreeRetainer,
+  'utils/escapeRegExp': escapeRegExp,
   'utils/extract': extract,
   'utils/ScrollListener': ScrollListener,
   'utils/stringToColor': stringToColor,
@@ -104,6 +107,7 @@ export default {
   'utils/formatNumber': formatNumber,
   'utils/mapRoutes': mapRoutes,
   'utils/withAttr': withAttr,
+  'utils/throttleDebounce': ThrottleDebounce,
   'models/Notification': Notification,
   'models/User': User,
   'models/Post': Post,

--- a/js/src/common/index.js
+++ b/js/src/common/index.js
@@ -23,3 +23,5 @@ patchMithril(window);
 import * as Extend from './extend/index';
 
 export { Extend };
+
+import './utils/arrayFlatPolyfill';

--- a/js/src/common/utils/arrayFlatPolyfill.ts
+++ b/js/src/common/utils/arrayFlatPolyfill.ts
@@ -3,7 +3,7 @@
 // Needed to provide support for Safari on iOS < 12
 
 if (!Array.prototype['flat']) {
-  Array.prototype['flat'] = function flat(depth?: number) {
+  Array.prototype['flat'] = function flat(this: any, depth?: number) {
     const realDepth = isNaN(depth as any) ? 1 : depth;
 
     return realDepth
@@ -11,15 +11,17 @@ if (!Array.prototype['flat']) {
           this,
           function (acc, cur) {
             if (Array.isArray(cur)) {
-              acc.push.apply(acc, flat.call(cur, realDepth - 1));
+              (acc as Array<any>).push.apply(acc, flat.call(cur, realDepth - 1));
             } else {
-              acc.push(cur);
+              (acc as Array<any>).push(cur);
             }
 
             return acc;
           },
-          []
+          [] as Array<any>
         )
-      : Array.prototype.slice.call(this);
+      : // If no depth is provided, or depth is 0, just return a copy of
+        // the array. Spread is supported in all major browsers (iOS 8+)
+        [...this];
   };
 }

--- a/js/src/common/utils/arrayFlatPolyfill.ts
+++ b/js/src/common/utils/arrayFlatPolyfill.ts
@@ -1,25 +1,12 @@
-// Based off of the CC-0 polyfill at https://github.com/jonathantneal/array-flat-polyfill
+// Based off of the polyfill on MDN
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#reduce_concat_isarray_recursivity
 //
 // Needed to provide support for Safari on iOS < 12
 
 if (!Array.prototype['flat']) {
-  Array.prototype['flat'] = function flat(this: any, depth?: number) {
-    const realDepth = isNaN(depth as any) ? 1 : depth;
-
-    return realDepth
-      ? Array.prototype.reduce.call(
-          this,
-          function (acc, cur) {
-            if (Array.isArray(cur)) {
-              (acc as Array<any>).push.apply(acc, flat.call(cur, realDepth - 1));
-            } else {
-              (acc as Array<any>).push(cur);
-            }
-
-            return acc;
-          },
-          [] as Array<any>
-        )
+  Array.prototype['flat'] = function flat(this: any[], depth: number = 1): any[] {
+    return depth > 0
+      ? Array.prototype.reduce.call(this, (acc, val): any[] => acc.concat(Array.isArray(val) ? flat.call(val, depth - 1) : val), [])
       : // If no depth is provided, or depth is 0, just return a copy of
         // the array. Spread is supported in all major browsers (iOS 8+)
         [...this];

--- a/js/src/common/utils/arrayFlatPolyfill.ts
+++ b/js/src/common/utils/arrayFlatPolyfill.ts
@@ -1,4 +1,4 @@
-// Based of the CC-0 polyfill at https://github.com/jonathantneal/array-flat-polyfill
+// Based off of the CC-0 polyfill at https://github.com/jonathantneal/array-flat-polyfill
 //
 // Needed to provide support for Safari on iOS < 12
 

--- a/js/src/common/utils/arrayFlatPolyfill.ts
+++ b/js/src/common/utils/arrayFlatPolyfill.ts
@@ -1,0 +1,25 @@
+// Based of the CC-0 polyfill at https://github.com/jonathantneal/array-flat-polyfill
+//
+// Needed to provide support for Safari on iOS < 12
+
+if (!Array.prototype['flat']) {
+  Array.prototype['flat'] = function flat(depth?: number) {
+    const realDepth = isNaN(depth as any) ? 1 : depth;
+
+    return realDepth
+      ? Array.prototype.reduce.call(
+          this,
+          function (acc, cur) {
+            if (Array.isArray(cur)) {
+              acc.push.apply(acc, flat.call(cur, realDepth - 1));
+            } else {
+              acc.push(cur);
+            }
+
+            return acc;
+          },
+          []
+        )
+      : Array.prototype.slice.call(this);
+  };
+}

--- a/js/src/common/utils/escapeRegExp.ts
+++ b/js/src/common/utils/escapeRegExp.ts
@@ -1,13 +1,10 @@
-const specialChars = /[\\^$.*+?()[\]{}|]/g;
+const specialChars = /[.*+?^${}()|[\]\\]/g;
 
 /**
- * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+", "?", "(", ")", "[", "]", "{", "}", and "|" in `input`.
+ * Escapes the `RegExp` special characters in `input`.
  *
- * The difference between this function and Lodash is that we blindly trust that the `input` is a string, not a number, Symbol,
- * `null` or anything else.
- *
- * Based on Lodash's `escapeRegExp`: https://github.com/lodash/lodash/blob/4.1.2-npm-packages/lodash.escaperegexp/index.js
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
  */
-export default function escapeRegExp(input: string) {
-  return specialChars.test(input) ? input.replace(specialChars, '\\$&') : input;
+export default function escapeRegExp(input: string): string {
+  return input.replace(specialChars, '\\$&');
 }

--- a/js/src/common/utils/escapeRegExp.ts
+++ b/js/src/common/utils/escapeRegExp.ts
@@ -1,0 +1,13 @@
+const specialChars = /[\\^$.*+?()[\]{}|]/g;
+
+/**
+ * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+", "?", "(", ")", "[", "]", "{", "}", and "|" in `input`.
+ *
+ * The difference between this function and Lodash is that we blindly trust that the `input` is a string, not a number, Symbol,
+ * `null` or anything else.
+ *
+ * Based on Lodash's `escapeRegExp`: https://github.com/lodash/lodash/blob/4.1.2-npm-packages/lodash.escaperegexp/index.js
+ */
+export default function escapeRegExp(input: string) {
+  return specialChars.test(input) ? input.replace(specialChars, '\\$&') : input;
+}

--- a/js/src/common/utils/throttleDebounce.ts
+++ b/js/src/common/utils/throttleDebounce.ts
@@ -1,0 +1,3 @@
+// Re-exports `throttle-debounce` to be used in `compat.js`.
+
+export { throttle, debounce } from 'throttle-debounce';

--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -1,21 +1,21 @@
-import DiscussionPage from './DiscussionPage';
-import TerminalPost from './TerminalPost';
-import DiscussionControls from '../utils/DiscussionControls';
-import slidable from '../utils/slidable';
 import Component from '../../common/Component';
 import Link from '../../common/components/Link';
-import Dropdown from '../../common/components/Dropdown';
-import abbreviateNumber from '../../common/utils/abbreviateNumber';
-import classList from '../../common/utils/classList';
-import extractText from '../../common/utils/extractText';
-import escapeRegExp from '../../common/utils/escapeRegExp';
-import humanTime from '../../common/utils/humanTime';
-import ItemList from '../../common/utils/ItemList';
-import SubtreeRetainer from '../../common/utils/SubtreeRetainer';
 import avatar from '../../common/helpers/avatar';
 import listItems from '../../common/helpers/listItems';
 import highlight from '../../common/helpers/highlight';
 import icon from '../../common/helpers/icon';
+import humanTime from '../../common/utils/humanTime';
+import ItemList from '../../common/utils/ItemList';
+import abbreviateNumber from '../../common/utils/abbreviateNumber';
+import Dropdown from '../../common/components/Dropdown';
+import TerminalPost from './TerminalPost';
+import SubtreeRetainer from '../../common/utils/SubtreeRetainer';
+import DiscussionControls from '../utils/DiscussionControls';
+import slidable from '../utils/slidable';
+import extractText from '../../common/utils/extractText';
+import classList from '../../common/utils/classList';
+import DiscussionPage from './DiscussionPage';
+import escapeRegExp from '../../common/utils/escapeRegExp';
 
 /**
  * The `DiscussionListItem` component shows a single discussion in the

--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -1,22 +1,22 @@
+import DiscussionPage from './DiscussionPage';
+import TerminalPost from './TerminalPost';
+import DiscussionControls from '../utils/DiscussionControls';
+import slidable from '../utils/slidable';
 import Component from '../../common/Component';
 import Link from '../../common/components/Link';
+import Dropdown from '../../common/components/Dropdown';
+import abbreviateNumber from '../../common/utils/abbreviateNumber';
+import classList from '../../common/utils/classList';
+import extractText from '../../common/utils/extractText';
+import escapeRegExp from '../../common/utils/escapeRegExp';
+import humanTime from '../../common/utils/humanTime';
+import ItemList from '../../common/utils/ItemList';
+import SubtreeRetainer from '../../common/utils/SubtreeRetainer';
 import avatar from '../../common/helpers/avatar';
 import listItems from '../../common/helpers/listItems';
 import highlight from '../../common/helpers/highlight';
 import icon from '../../common/helpers/icon';
-import humanTime from '../../common/utils/humanTime';
-import ItemList from '../../common/utils/ItemList';
-import abbreviateNumber from '../../common/utils/abbreviateNumber';
-import Dropdown from '../../common/components/Dropdown';
-import TerminalPost from './TerminalPost';
-import SubtreeRetainer from '../../common/utils/SubtreeRetainer';
-import DiscussionControls from '../utils/DiscussionControls';
-import slidable from '../utils/slidable';
-import extractText from '../../common/utils/extractText';
-import classList from '../../common/utils/classList';
-import DiscussionPage from './DiscussionPage';
 
-import { escapeRegExp } from 'lodash-es';
 /**
  * The `DiscussionListItem` component shows a single discussion in the
  * discussion list.

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash-es';
+import { throttle } from 'throttle-debounce';
 import anchorScroll from '../../common/utils/anchorScroll';
 
 class PostStreamState {
@@ -50,8 +50,8 @@ class PostStreamState {
      */
     this.forceUpdateScrubber = false;
 
-    this.loadNext = throttle(this._loadNext, 300);
-    this.loadPrevious = throttle(this._loadPrevious, 300);
+    this.loadNext = throttle(300, this._loadNext);
+    this.loadPrevious = throttle(300, this._loadPrevious);
 
     this.show(includedPosts);
   }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Progresses flarum/issue-archive#179**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Removed `lodash-es` from our dependencies, and have replaced them with a custom util, a polyfill for a native browser method, and the `throttle-debounce` library.

**Reviewers should focus on:**
These replacements don't function identically to the original library's, but should suit our use cases.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
