### PR TITLE
Fix unavailable translator catalogue for cli use

### DIFF
--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -68,7 +68,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
         }
 
         $this->container->make('flarum.locales')->getTranslator()->getCatalogue(
-            $this->container->make(SettingsRepositoryInterface::class)->get('default_locale', 'en')
+            $container->make(SettingsRepositoryInterface::class)->get('default_locale', 'en')
         );
     }
 }

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -67,7 +67,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
             $scheduled['callback']($event);
         }
 
-        $this->container->make('flarum.locales')->getTranslator()->getCatalogue(
+        $container->make('flarum.locales')->getTranslator()->getCatalogue(
             $container->make(SettingsRepositoryInterface::class)->get('default_locale', 'en')
         );
     }

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -15,6 +15,7 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Console\AssetsPublishCommand;
 use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\Foundation\Console\InfoCommand;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Scheduling\Schedule as LaravelSchedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
@@ -65,5 +66,9 @@ class ConsoleServiceProvider extends AbstractServiceProvider
             $event = $schedule->command($scheduled['command'], $scheduled['args']);
             $scheduled['callback']($event);
         }
+
+        $this->container->make('flarum.locales')->getTranslator()->getCatalogue(
+            $this->container->make(SettingsRepositoryInterface::class)->get('default_locale', 'en')
+        );
     }
 }

--- a/tests/integration/console/AbstractCommandTest.php
+++ b/tests/integration/console/AbstractCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\console;
+
+use Flarum\Console\AbstractCommand;
+use Flarum\Extend;
+use Flarum\Locale\Translator;
+use Flarum\Testing\integration\ConsoleTestCase;
+
+class AbstractCommandTest extends ConsoleTestCase
+{
+    /**
+     * @test
+     */
+    public function scheduled_command_exists_when_added()
+    {
+        $this->extend(
+            (new Extend\Console())
+                ->command(CustomEchoTranslationsCommand::class)
+        );
+
+        $input = [
+            'command' => 'customEchoTranslationsCommand'
+        ];
+
+        // Arbitrary translation
+        $this->assertEquals('Flarum Email Test', $this->runCommand($input));
+    }
+}
+
+class CustomEchoTranslationsCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('customEchoTranslationsCommand');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fire()
+    {
+        $translator = resolve(Translator::class);
+
+        $this->info($translator->trans('core.emails.send_test.subject'));
+    }
+}


### PR DESCRIPTION
Fixes flarum/issue-archive#100

When there's no locale cache, cli cannot translate. This re-instantiates
that cache when needed.

**Confirmed**


- [x] Backend changes: tests are green (run `composer test`).

