### PR TITLE
Add tooltip component

### DIFF
--- a/js/@types/tooltips/index.d.ts
+++ b/js/@types/tooltips/index.d.ts
@@ -1,0 +1,68 @@
+/**
+ * Selection of options accepted by [Bootstrap's tooltips](https://getbootstrap.com/docs/3.3/javascript/#tooltips-options).
+ *
+ * ---
+ *
+ * Not all options are present from Bootstrap to discourage the use of options
+ * that will be deprecated in the future.
+ *
+ * More commonly used options that will be deprecated remain, but are marked as
+ * such.
+ *
+ * @see https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
+ */
+export interface TooltipOptions {
+  /**
+   * Whether HTML content is allowed in the tooltip.
+   *
+   * ---
+   *
+   * **Warning:** this is a possible XSS attack vector. This option shouldn't
+   * be used wherever possible, and will not work when we migrate to CSS-only
+   * tooltips.
+   *
+   * @deprecated
+   */
+  html?: boolean;
+  /**
+   * Tooltip position around the target element.
+   */
+  placement?: 'top' | 'bottom' | 'left' | 'right';
+  /**
+   * Sets the delay between a trigger state occurring and the tooltip appearing
+   * on-screen.
+   *
+   * ---
+   *
+   * **Warning:** this option will be removed when we switch to CSS-only
+   * tooltips.
+   *
+   * @deprecated
+   */
+  delay?: number;
+  /**
+   * Value used if no `title` attribute is present on the HTML element.
+   *
+   * If a function is given, it will be called with its `this` reference set to
+   * the element that the tooltip is attached to.
+   */
+  title?: string;
+  /**
+   * How the tooltip is triggered.
+   *
+   * Either on `hover`, on `hover focus` (either of the two).
+   *
+   * ---
+   *
+   * **Warning:** `manual`, `click` and `focus` on its own are deprecated options
+   * which will not be supported in the future.
+   */
+  trigger?: 'hover' | 'hover focus';
+}
+
+/**
+ * Creates a tooltip on a jQuery element reference.
+ *
+ * Returns the same jQuery reference to allow for method chaining.
+ */
+export type TooltipJQueryFunction = (tooltipOptions?: TooltipOptions) => JQuery;

--- a/js/@types/tooltips/index.d.ts
+++ b/js/@types/tooltips/index.d.ts
@@ -11,7 +11,7 @@
  *
  * @see https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
  */
-export interface TooltipOptions {
+export interface TooltipCreationOptions {
   /**
    * Whether HTML content is allowed in the tooltip.
    *
@@ -65,4 +65,4 @@ export interface TooltipOptions {
  *
  * Returns the same jQuery reference to allow for method chaining.
  */
-export type TooltipJQueryFunction = (tooltipOptions?: TooltipOptions) => JQuery;
+export type TooltipJQueryFunction = (tooltipOptions?: TooltipCreationOptions | 'destroy') => JQuery;

--- a/js/@types/tooltips/index.d.ts
+++ b/js/@types/tooltips/index.d.ts
@@ -65,4 +65,4 @@ export interface TooltipCreationOptions {
  *
  * Returns the same jQuery reference to allow for method chaining.
  */
-export type TooltipJQueryFunction = (tooltipOptions?: TooltipCreationOptions | 'destroy') => JQuery;
+export type TooltipJQueryFunction = (tooltipOptions?: TooltipCreationOptions | 'destroy' | 'show' | 'hide') => JQuery;

--- a/js/shims.d.ts
+++ b/js/shims.d.ts
@@ -8,7 +8,7 @@ import * as _$ from 'jquery';
 // Globals from flarum/core
 import Application from './src/common/Application';
 
-import type { TooltipJQueryFunction } from './@types/tooltips/index';
+import type { TooltipJQueryFunction } from './@types/tooltips';
 
 /**
  * flarum/core exposes several extensions globally:

--- a/js/shims.d.ts
+++ b/js/shims.d.ts
@@ -8,6 +8,8 @@ import * as _$ from 'jquery';
 // Globals from flarum/core
 import Application from './src/common/Application';
 
+import type { TooltipJQueryFunction } from './@types/tooltips/index';
+
 /**
  * flarum/core exposes several extensions globally:
  *
@@ -25,14 +27,7 @@ declare global {
 
   // Extend JQuery with our custom functions, defined with $.fn
   interface JQuery {
-    /**
-     * Creates a tooltip on a jQuery element reference.
-     *
-     * Optionally accepts placement and delay options.
-     *
-     * Returns the same reference to allow for method chaining.
-     */
-    tooltip: (tooltipOptions?: { placement?: 'top' | 'bottom' | 'left' | 'right'; delay?: number }) => JQuery;
+    tooltip: TooltipJQueryFunction;
   }
 }
 

--- a/js/src/common/compat.js
+++ b/js/src/common/compat.js
@@ -62,6 +62,7 @@ import GroupBadge from './components/GroupBadge';
 import TextEditor from './components/TextEditor';
 import TextEditorButton from './components/TextEditorButton';
 import EditUserModal from './components/EditUserModal';
+import Tooltip from './components/Tooltip';
 import Model from './Model';
 import Application from './Application';
 import fullTime from './helpers/fullTime';
@@ -141,6 +142,7 @@ export default {
   'components/GroupBadge': GroupBadge,
   'components/TextEditor': TextEditor,
   'components/TextEditorButton': TextEditorButton,
+  'components/Tooltip': Tooltip,
   'components/EditUserModal': EditUserModal,
   Model: Model,
   Application: Application,

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -1,5 +1,5 @@
+import Tooltip from './Tooltip';
 import Component from '../Component';
-import Tooltip from '../Tooltip';
 import icon from '../helpers/icon';
 
 /**

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -1,6 +1,6 @@
 import Component from '../Component';
+import Tooltip from '../Tooltip';
 import icon from '../helpers/icon';
-import extract from '../utils/extract';
 
 /**
  * The `Badge` component represents a user/discussion badge, indicating some
@@ -18,13 +18,16 @@ import extract from '../utils/extract';
 export default class Badge extends Component {
   view() {
     const attrs = Object.assign({}, this.attrs);
-    const type = extract(attrs, 'type');
-    const iconName = extract(attrs, 'icon');
 
-    attrs.className = 'Badge ' + (type ? 'Badge--' + type : '') + ' ' + (attrs.className || '');
-    attrs.title = extract(attrs, 'label') || '';
+    const { type, icon: iconName, title = '' } = attrs;
 
-    return <span {...attrs}>{iconName ? icon(iconName, { className: 'Badge-icon' }) : m.trust('&nbsp;')}</span>;
+    const className = classList('Badge', [type && `Badge--${type}`], attrs.className);
+
+    return (
+      <Tooltip text={title} {...attrs} className={className}>
+        {iconName ? icon(iconName, { className: 'Badge-icon' }) : m.trust('&nbsp;')}
+      </Tooltip>
+    );
   }
 
   oncreate(vnode) {

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -30,7 +30,7 @@ export default class Badge extends Component {
     };
 
     // If we don't have a tooltip label, don't render the tooltip component.
-    if (typeof tooltipText !== 'string') {
+    if (typeof label !== 'string' && !Array.isArray(label)) {
       return <div {...badgeAttrs}>{iconChild}</div>;
     }
 

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -1,6 +1,7 @@
 import Tooltip from './Tooltip';
 import Component from '../Component';
 import icon from '../helpers/icon';
+import classList from '../utils/classList';
 
 /**
  * The `Badge` component represents a user/discussion badge, indicating some

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -2,7 +2,6 @@ import Tooltip from './Tooltip';
 import Component from '../Component';
 import icon from '../helpers/icon';
 import classList from '../utils/classList';
-import extractText from '../utils/extractText';
 
 /**
  * The `Badge` component represents a user/discussion badge, indicating some
@@ -22,7 +21,6 @@ export default class Badge extends Component {
     const { type, icon: iconName, label, ...attrs } = this.attrs;
 
     const className = classList('Badge', [type && `Badge--${type}`], attrs.className);
-    const tooltipText = extractText(label);
 
     const iconChild = iconName ? icon(iconName, { className: 'Badge-icon' }) : m.trust('&nbsp;');
 
@@ -37,7 +35,7 @@ export default class Badge extends Component {
     }
 
     return (
-      <Tooltip text={tooltipText} {...badgeAttrs}>
+      <Tooltip text={label} {...badgeAttrs}>
         {iconChild}
       </Tooltip>
     );

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -29,15 +29,11 @@ export default class Badge extends Component {
       ...attrs,
     };
 
-    // If we don't have a tooltip label, don't render the tooltip component.
-    if (typeof label !== 'string' && !Array.isArray(label)) {
-      return <div {...badgeAttrs}>{iconChild}</div>;
-    }
+    const badgeNode = <div {...badgeAttrs}>{iconChild}</div>;
 
-    return (
-      <Tooltip text={label} {...badgeAttrs}>
-        {iconChild}
-      </Tooltip>
-    );
+    // If we don't have a tooltip label, don't render the tooltip component.
+    if (!label) return badgeNode;
+
+    return <Tooltip text={label}>{badgeNode}</Tooltip>;
   }
 }

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -2,6 +2,7 @@ import Tooltip from './Tooltip';
 import Component from '../Component';
 import icon from '../helpers/icon';
 import classList from '../utils/classList';
+import extractText from '../utils/extractText';
 
 /**
  * The `Badge` component represents a user/discussion badge, indicating some
@@ -18,22 +19,27 @@ import classList from '../utils/classList';
  */
 export default class Badge extends Component {
   view() {
-    const attrs = Object.assign({}, this.attrs);
-
-    const { type, icon: iconName, title = '' } = attrs;
+    const { type, icon: iconName, label, ...attrs } = this.attrs;
 
     const className = classList('Badge', [type && `Badge--${type}`], attrs.className);
+    const tooltipText = extractText(label);
+
+    const iconChild = iconName ? icon(iconName, { className: 'Badge-icon' }) : m.trust('&nbsp;');
+
+    const badgeAttrs = {
+      className,
+      ...attrs,
+    };
+
+    // If we don't have a tooltip label, don't render the tooltip component.
+    if (typeof tooltipText !== 'string') {
+      return <div {...badgeAttrs}>{iconChild}</div>;
+    }
 
     return (
-      <Tooltip text={title} {...attrs} className={className}>
-        {iconName ? icon(iconName, { className: 'Badge-icon' }) : m.trust('&nbsp;')}
+      <Tooltip text={tooltipText} {...badgeAttrs}>
+        {iconChild}
       </Tooltip>
     );
-  }
-
-  oncreate(vnode) {
-    super.oncreate(vnode);
-
-    if (this.attrs.label) this.$().tooltip();
   }
 }

--- a/js/src/common/components/TextEditor.js
+++ b/js/src/common/components/TextEditor.js
@@ -4,6 +4,7 @@ import listItems from '../helpers/listItems';
 import Button from './Button';
 
 import BasicEditorDriver from '../utils/BasicEditorDriver';
+import Tooltip from './Tooltip';
 
 /**
  * The `TextEditor` component displays a textarea with controls, including a
@@ -108,13 +109,9 @@ export default class TextEditor extends Component {
     if (this.attrs.preview) {
       items.add(
         'preview',
-        Button.component({
-          icon: 'far fa-eye',
-          className: 'Button Button--icon',
-          onclick: this.attrs.preview,
-          title: app.translator.trans('core.forum.composer.preview_tooltip'),
-          oncreate: (vnode) => $(vnode.dom).tooltip(),
-        })
+        <Tooltip text={app.translator.trans('core.forum.composer.preview_tooltip')}>
+          <Button icon="far fa-eye" className="Button Button--icon" onclick={this.attrs.preview} />
+        </Tooltip>
       );
     }
 

--- a/js/src/common/components/TextEditorButton.js
+++ b/js/src/common/components/TextEditorButton.js
@@ -16,7 +16,7 @@ export default class TextEditorButton extends Button {
     delete originalView.attrs.title;
 
     return (
-      <Tooltip inline text={tooltipText}>
+      <Tooltip containerType="inline-block" text={tooltipText}>
         {originalView}
       </Tooltip>
     );

--- a/js/src/common/components/TextEditorButton.js
+++ b/js/src/common/components/TextEditorButton.js
@@ -1,19 +1,30 @@
 import Button from './Button';
+import Tooltip from './Tooltip';
 
 /**
  * The `TextEditorButton` component displays a button suitable for the text
  * editor toolbar.
  */
 export default class TextEditorButton extends Button {
+  view(vnode) {
+    const originalView = super.view(vnode);
+
+    console.log(originalView);
+
+    // Steal tooltip label from the Button superclass
+    const tooltipText = originalView.attrs.title;
+    delete originalView.attrs.title;
+
+    return (
+      <Tooltip inline text={tooltipText}>
+        {originalView}
+      </Tooltip>
+    );
+  }
+
   static initAttrs(attrs) {
     super.initAttrs(attrs);
 
     attrs.className = attrs.className || 'Button Button--icon Button--link';
-  }
-
-  oncreate(vnode) {
-    super.oncreate(vnode);
-
-    this.$().tooltip();
   }
 }

--- a/js/src/common/components/TextEditorButton.js
+++ b/js/src/common/components/TextEditorButton.js
@@ -9,17 +9,11 @@ export default class TextEditorButton extends Button {
   view(vnode) {
     const originalView = super.view(vnode);
 
-    console.log(originalView);
-
     // Steal tooltip label from the Button superclass
     const tooltipText = originalView.attrs.title;
     delete originalView.attrs.title;
 
-    return (
-      <Tooltip containerType="inline-block" text={tooltipText}>
-        {originalView}
-      </Tooltip>
-    );
+    return <Tooltip text={tooltipText}>{originalView}</Tooltip>;
   }
 
   static initAttrs(attrs) {

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -141,6 +141,12 @@ export default class Tooltip extends Component<TooltipAttrs> {
       this.$().tooltip('destroy');
       this.createTooltip();
     }
+
+    if (this.attrs.tooltipVisible === true) {
+      this.$().tooltip('show');
+    } else if (this.attrs.tooltipVisible === false) {
+      this.$().tooltip('hide');
+    }
   }
 
   private createTooltip() {
@@ -150,7 +156,12 @@ export default class Tooltip extends Component<TooltipAttrs> {
       delay,
       // This will have no effect when switching to CSS tooltips
       html = false,
+      tooltipVisible,
     } = this.attrs;
+
+    const trigger = (typeof tooltipVisible === 'boolean'
+      ? 'manual'
+      : classList('hover', [showOnFocus && 'focus'])) as TooltipCreationOptions['trigger'];
 
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
     this.$().tooltip(
@@ -159,7 +170,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
         delay,
         placement: position,
         // Fancy "hack" to assemble the trigger string
-        trigger: classList('hover', [showOnFocus && 'focus']) as TooltipCreationOptions['trigger'],
+        trigger,
       },
       // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
       'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -86,7 +86,10 @@ export interface TooltipAttrs extends ComponentAttrs {
  */
 export default class Tooltip extends Component<TooltipAttrs> {
   private oldText: string = '';
+  private oldVisibility: boolean | undefined;
+
   private shouldRecreateTooltip: boolean = false;
+  private shouldChangeTooltipVisibility: boolean = false;
 
   view(vnode) {
     const { children } = vnode;
@@ -119,6 +122,11 @@ export default class Tooltip extends Component<TooltipAttrs> {
       this.shouldRecreateTooltip = true;
     }
 
+    if (tooltipVisible !== this.oldVisibility) {
+      this.oldVisibility = this.attrs.tooltipVisible;
+      this.shouldChangeTooltipVisibility = true;
+    }
+
     return (
       <div title={realText} className={classList('tooltip-container', `tooltip-container--${containerType}`, className, classes)} {...attrs}>
         {children}
@@ -138,14 +146,35 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
   private recreateTooltip() {
     if (this.shouldRecreateTooltip) {
-      this.$().tooltip('destroy');
+      this.$().tooltip(
+        'destroy',
+        // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
+        'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
+      );
       this.createTooltip();
+      this.shouldRecreateTooltip = false;
     }
 
+    if (this.shouldChangeTooltipVisibility) {
+      this.shouldChangeTooltipVisibility = false;
+      this.updateVisibility();
+
+    }
+  }
+
+  private updateVisibility() {
     if (this.attrs.tooltipVisible === true) {
-      this.$().tooltip('show');
+      this.$().tooltip(
+        'show',
+        // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
+        'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
+      );
     } else if (this.attrs.tooltipVisible === false) {
-      this.$().tooltip('hide');
+      this.$().tooltip(
+        'hide',
+        // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
+        'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
+      );
     }
   }
 

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -1,10 +1,10 @@
-import Component, { ComponentAttrs } from '../Component';
+import Component from '../Component';
 import type Mithril from 'mithril';
 import classList from '../utils/classList';
 import { TooltipCreationOptions } from '../../../@types/tooltips';
 import extractText from '../utils/extractText';
 
-export interface TooltipAttrs extends ComponentAttrs {
+export interface TooltipAttrs extends Mithril.CommonAttributes<TooltipAttrs, Tooltip> {
   /**
    * Tooltip textual content.
    *
@@ -12,13 +12,6 @@ export interface TooltipAttrs extends ComponentAttrs {
    * into strings.
    */
   text: string | string[];
-  /**
-   * Defines the type of container to use. Chosen option defines the `display`
-   * property of the container element in CSS.
-   *
-   * Default: `'block'`.
-   */
-  containerType?: 'block' | 'inline' | 'inline-block';
   /**
    * Manually show tooltip. `false` will show based on cursor events.
    *
@@ -41,8 +34,8 @@ export interface TooltipAttrs extends ComponentAttrs {
    * Whether HTML content is allowed in the tooltip.
    *
    * **Warning:** this is a possible XSS attack vector. This option shouldn't
-   * be used wherever possible, and will not work when we migrate to CSS-only
-   * tooltips.
+   * be used wherever possible, and may not work when we migrate to another
+   * tooltip library. Be prepared for this to break in Flarum stable.
    *
    * Default: `false`.
    *
@@ -53,8 +46,8 @@ export interface TooltipAttrs extends ComponentAttrs {
    * Sets the delay between a trigger state occurring and the tooltip appearing
    * on-screen.
    *
-   * **Warning:** this option will be removed when we switch to CSS-only
-   * tooltips.
+   * **Warning:** this option may be removed when switching to another tooltip
+   * library. Be prepared for this to break in Flarum stable.
    *
    * Default: `0`.
    *
@@ -71,12 +64,15 @@ export interface TooltipAttrs extends ComponentAttrs {
 
 /**
  * The `Tooltip` component is used to create a tooltip for an element. It
- * surrounds it with a div (or span) which has the required tooltip setup
- * applied.
+ * requires a single child element to be passed to it. Passing multiple
+ * children or fragments will throw an error.
  *
  * You should use this for any tooltips you create to allow for backwards
- * compatibility when we switch to pure CSS tooltips instead of Bootstrap
- * tooltips.
+ * compatibility when we switch to another tooltip library instead of
+ * Bootstrap tooltips.
+ *
+ * If you need to pass multiple children, surround them with another element,
+ * such as a `<span>` or `<div>`.
  *
  * @example <caption>Basic usage</caption>
  *          <Tooltip text="You wish!">
@@ -87,29 +83,43 @@ export interface TooltipAttrs extends ComponentAttrs {
  *
  * @example <caption>Use of `position` and `showOnFocus` attrs</caption>
  *          <Tooltip text="Woah! That's cool!" position="bottom" showOnFocus>
- *            <div>3 replies</div>
+ *            <span>3 replies</span>
+ *          </Tooltip>
+ *
+ * @example <caption>Incorrect usage</caption>
+ *          // This is wrong! Surround the children with a <span> or similar.
+ *          <Tooltip text="This won't work">
+ *            Click
+ *            <a href="/">here</a>
  *          </Tooltip>
  */
 export default class Tooltip extends Component<TooltipAttrs> {
+  private firstChild: Mithril.Vnode<any, any> | null = null;
+  private childDomNode: HTMLElement | null = null;
+
   private oldText: string = '';
   private oldVisibility: boolean | undefined;
 
   private shouldRecreateTooltip: boolean = false;
   private shouldChangeTooltipVisibility: boolean = false;
 
-  view(vnode) {
-    const { children } = vnode;
+  view(vnode: Mithril.Vnode<TooltipAttrs, this>) {
+    /**
+     * We know this will be a ChildArray and not a primitive as this
+     * vnode is a component, not a text or trusted HTML vnode.
+     */
+    const children = vnode.children as Mithril.ChildArray | undefined;
 
     // We remove these to get the remaining attrs to pass to the DOM element
     const { text, tooltipVisible, showOnFocus = true, position = 'top', ignoreTitleWarning = false, html = false, delay = 0, ...attrs } = this.attrs;
 
-    if (this.attrs.title && !ignoreTitleWarning) {
+    if ((this.attrs as any).title && !ignoreTitleWarning) {
       console.warn(
         '`title` attribute was passed to Tooltip component. Was this intentional? Tooltip content should be passed to the `text` attr instead.'
       );
     }
 
-    const realText = Array.isArray(text) ? extractText(text) : text;
+    const realText = this.getRealText();
 
     // We need to recreate the tooltip if the text has changed
     if (realText !== this.oldText) {
@@ -122,15 +132,50 @@ export default class Tooltip extends Component<TooltipAttrs> {
       this.shouldChangeTooltipVisibility = true;
     }
 
-    return (
-      <div title={realText} className={classList('tooltip-container', `tooltip-container--${containerType}`, className, classes)} {...attrs}>
-        {children}
-      </div>
-    );
+    // We'll try our best to detect any issues created by devs before they cause any weird effects.
+    // Throwing an error will prevent the forum rendering, but will be better at alerting devs to
+    // an issue.
+
+    if (typeof children === 'undefined') {
+      throw new Error(
+        `Tooltip component was provided with no direct child DOM element. Tooltips must contain a single direct DOM node to attach to.`
+      );
+    }
+
+    if (children.length !== 1) {
+      throw new Error(
+        `Tooltip component was either passed more than one or no child node.\n\nPlease wrap multiple children in another element, such as a <div> or <span>.`
+      );
+    }
+
+    const firstChild = children[0];
+
+    if (typeof firstChild !== 'object' || Array.isArray(firstChild) || firstChild === null) {
+      throw new Error(
+        `Tooltip component was provided with no direct child DOM element. Tooltips must contain a single direct DOM node to attach to.`
+      );
+    }
+
+    if (typeof firstChild.tag === 'string' && ['#', '[', '<'].includes(firstChild.tag)) {
+      throw new Error(
+        `Tooltip component with provided with a vnode with tag "${firstChild.tag}". This is not a DOM element, so is not a valid child element. Please wrap this vnode in another element, such as a <div> or <span>.`
+      );
+    }
+
+    this.firstChild = firstChild;
+
+    return children;
   }
 
   oncreate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
     super.oncreate(vnode);
+
+    const domNode = (this.firstChild as Mithril.VnodeDOM<any, any>).dom as HTMLElement;
+
+    if (!domNode.isSameNode(this.childDomNode)) {
+      this.childDomNode = domNode;
+      this.shouldRecreateTooltip = true;
+    }
 
     this.recreateTooltip();
   }
@@ -138,12 +183,19 @@ export default class Tooltip extends Component<TooltipAttrs> {
   onupdate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
     super.onupdate(vnode);
 
+    const domNode = (this.firstChild as Mithril.VnodeDOM<any, any>).dom as HTMLElement;
+
+    if (!domNode.isSameNode(this.childDomNode)) {
+      this.childDomNode = domNode;
+      this.shouldRecreateTooltip = true;
+    }
+
     this.recreateTooltip();
   }
 
   private recreateTooltip() {
-    if (this.shouldRecreateTooltip) {
-      this.$().tooltip(
+    if (this.shouldRecreateTooltip && this.childDomNode !== null) {
+      $(this.childDomNode).tooltip(
         'destroy',
         // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
         'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
@@ -159,14 +211,16 @@ export default class Tooltip extends Component<TooltipAttrs> {
   }
 
   private updateVisibility() {
+    if (this.childDomNode === null) return;
+
     if (this.attrs.tooltipVisible === true) {
-      this.$().tooltip(
+      $(this.childDomNode).tooltip(
         'show',
         // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
         'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
       );
     } else if (this.attrs.tooltipVisible === false) {
-      this.$().tooltip(
+      $(this.childDomNode).tooltip(
         'hide',
         // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
         'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
@@ -175,6 +229,8 @@ export default class Tooltip extends Component<TooltipAttrs> {
   }
 
   private createTooltip() {
+    if (this.childDomNode === null) return;
+
     const {
       showOnFocus = true,
       position = 'top',
@@ -182,14 +238,19 @@ export default class Tooltip extends Component<TooltipAttrs> {
       // This will have no effect when switching to CSS tooltips
       html = false,
       tooltipVisible,
+      text,
     } = this.attrs;
 
-    const trigger = (typeof tooltipVisible === 'boolean'
-      ? 'manual'
-      : classList('hover', [showOnFocus && 'focus'])) as TooltipCreationOptions['trigger'];
+    const trigger = (
+      typeof tooltipVisible === 'boolean' ? 'manual' : classList('hover', [showOnFocus && 'focus'])
+    ) as TooltipCreationOptions['trigger'];
+
+    const realText = this.getRealText();
+    this.childDomNode.setAttribute('title', realText);
+    this.childDomNode.setAttribute('aria-label', realText);
 
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
-    this.$().tooltip(
+    $(this.childDomNode).tooltip(
       {
         html,
         delay,
@@ -200,5 +261,11 @@ export default class Tooltip extends Component<TooltipAttrs> {
       // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
       'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
     );
+  }
+
+  private getRealText(): string {
+    const { text } = this.attrs;
+
+    return Array.isArray(text) ? extractText(text) : text;
   }
 }

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -33,6 +33,8 @@ export interface TooltipAttrs extends ComponentAttrs {
   showOnFocus?: boolean;
   /**
    * Tooltip position around element.
+   *
+   * Default: `'top'`.
    */
   position?: 'top' | 'bottom' | 'left' | 'right';
   /**
@@ -41,6 +43,8 @@ export interface TooltipAttrs extends ComponentAttrs {
    * **Warning:** this is a possible XSS attack vector. This option shouldn't
    * be used wherever possible, and will not work when we migrate to CSS-only
    * tooltips.
+   *
+   * Default: `false`.
    *
    * @deprecated
    */
@@ -51,6 +55,8 @@ export interface TooltipAttrs extends ComponentAttrs {
    *
    * **Warning:** this option will be removed when we switch to CSS-only
    * tooltips.
+   *
+   * Default: `0`.
    *
    * @deprecated
    */
@@ -92,7 +98,18 @@ export default class Tooltip extends Component<TooltipAttrs> {
     }
 
     // We remove these to get the remaining attrs to pass to the DOM element
-    const { text, containerType = 'block', tooltipVisible, showOnFocus, position, html, delay, className, class: classes, ...attrs } = this.attrs;
+    const {
+      text,
+      containerType = 'block',
+      tooltipVisible,
+      showOnFocus = true,
+      position = 'top',
+      html = false,
+      delay = 0,
+      className,
+      class: classes,
+      ...attrs
+    } = this.attrs;
 
     const realText = Array.isArray(text) ? extractText(text) : text;
 

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -74,6 +74,10 @@ export interface TooltipAttrs extends Mithril.CommonAttributes<TooltipAttrs, Too
  * If you need to pass multiple children, surround them with another element,
  * such as a `<span>` or `<div>`.
  *
+ * **Note:** this component will overwrite the `title` attribute of the first
+ * child you pass to it, as this is how the current tooltip system works in
+ * Flarum. This shouldn't be an issue if you're using this component correctly.
+ *
  * @example <caption>Basic usage</caption>
  *          <Tooltip text="You wish!">
  *            <Button>

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -83,7 +83,6 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
   view(vnode) {
     const { children } = vnode;
-    console.log(this.attrs);
 
     // We remove these to get the remaining attrs to pass to the DOM element
     const { text, inline, tooltipVisible, showOnFocus, position, html, delay, ...attrs } = this.attrs;

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -2,12 +2,16 @@ import Component, { ComponentAttrs } from '../Component';
 import type Mithril from 'mithril';
 import classList from '../utils/classList';
 import { TooltipCreationOptions } from '../../../@types/tooltips';
+import extractText from '../utils/extractText';
 
 export interface TooltipAttrs extends ComponentAttrs {
   /**
    * Tooltip textual content.
+   *
+   * String arrays, like those provided by the translator, will be flattened
+   * into strings.
    */
-  text: string;
+  text: string | string[];
   /**
    * If inline, uses a `<span>` container, else uses a `<div>`.
    *
@@ -80,16 +84,18 @@ export default class Tooltip extends Component<TooltipAttrs> {
     // We remove these to get the remaining attrs to pass to the DOM element
     const { text, inline, tooltipVisible, showOnFocus, position, html, delay, ...attrs } = this.attrs;
 
+    const realText = Array.isArray(text) ? extractText(text) : text;
+
     if (inline) {
       return (
-        <span title={text} {...attrs}>
+        <span title={realText} {...attrs}>
           {children}
         </span>
       );
     }
 
     return (
-      <div title={text} {...attrs}>
+      <div title={realText} {...attrs}>
         {children}
       </div>
     );

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -1,7 +1,7 @@
 import Component, { ComponentAttrs } from '../Component';
 import type Mithril from 'mithril';
 import classList from '../utils/classList';
-import { TooltipOptions } from '../../../@types/tooltips';
+import { TooltipCreationOptions } from '../../../@types/tooltips';
 
 export interface TooltipAttrs extends ComponentAttrs {
   /**
@@ -119,7 +119,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
       placement: position,
       title: text,
       // Fancy "hack" to assemble the trigger string
-      trigger: classList('hover', [showOnFocus && 'focus']) as TooltipOptions['trigger'],
+      trigger: classList('hover', [showOnFocus && 'focus']) as TooltipCreationOptions['trigger'],
     });
   }
 }

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -141,6 +141,8 @@ export default class Tooltip extends Component<TooltipAttrs> {
   }
 
   onupdate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
+    super.onupdate(vnode);
+
     this.recreateTooltip();
   }
 

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -13,11 +13,12 @@ export interface TooltipAttrs extends ComponentAttrs {
    */
   text: string | string[];
   /**
-   * If inline, uses a `<span>` container, else uses a `<div>`.
+   * Defines the type of container to use. Chosen option defines the `display`
+   * property of the container element in CSS.
    *
-   * Default: `false`.
+   * Default: `'block'`.
    */
-  inline?: boolean;
+  containerType?: 'block' | 'inline' | 'inline-block';
   /**
    * Manually show tooltip. `false` will show based on cursor events.
    *
@@ -82,12 +83,12 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const { children } = vnode;
 
     // We remove these to get the remaining attrs to pass to the DOM element
-    const { text, inline, tooltipVisible, showOnFocus, position, html, delay, className, class: classes, ...attrs } = this.attrs;
+    const { text, containerType = 'block', tooltipVisible, showOnFocus, position, html, delay, className, class: classes, ...attrs } = this.attrs;
 
     const realText = Array.isArray(text) ? extractText(text) : text;
 
     return (
-      <div title={realText} className={classList('tooltip-container', [inline && 'tooltip-container--inline'], className, classes)} {...attrs}>
+      <div title={realText} className={classList('tooltip-container', `tooltip-container--${containerType}`, className, classes)} {...attrs}>
         {children}
       </div>
     );

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -136,12 +136,16 @@ export default class Tooltip extends Component<TooltipAttrs> {
     } = this.attrs;
 
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
-    this.$().tooltip({
-      html,
-      delay,
-      placement: position,
-      // Fancy "hack" to assemble the trigger string
-      trigger: classList('hover', [showOnFocus && 'focus']) as TooltipCreationOptions['trigger'],
-    });
+    this.$().tooltip(
+      {
+        html,
+        delay,
+        placement: position,
+        // Fancy "hack" to assemble the trigger string
+        trigger: classList('hover', [showOnFocus && 'focus']) as TooltipCreationOptions['trigger'],
+      },
+      // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
+      'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
+    );
   }
 }

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -74,8 +74,16 @@ export interface TooltipAttrs extends ComponentAttrs {
  *          </Tooltip>
  */
 export default class Tooltip extends Component<TooltipAttrs> {
+  /**
+   * Contains the old tooltip text.
+   *
+   * Used to determine whether the tooltip should be recreated.
+   */
+  private oldText: string = '';
+
   view(vnode) {
     const { children } = vnode;
+    console.log(this.attrs);
 
     // We remove these to get the remaining attrs to pass to the DOM element
     const { text, inline, tooltipVisible, showOnFocus, position, html, delay, ...attrs } = this.attrs;
@@ -90,24 +98,29 @@ export default class Tooltip extends Component<TooltipAttrs> {
   oncreate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
     super.oncreate(vnode);
 
+    this.oldText = this.attrs.text;
+
     this.createTooltip();
   }
 
   onupdate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
-    this.createTooltip();
+    // In case the `text` attr was updated, we need to recreate the tooltip
+    if (this.attrs.text !== this.oldText) {
+      this.oldText = this.attrs.text;
+
+      this.$().tooltip('destroy');
+      this.createTooltip();
+    }
   }
 
   private createTooltip() {
     const {
       text,
-      inline,
-      tooltipVisible,
       showOnFocus = true,
       position = 'top',
       delay,
       // This will have no effect when switching to CSS tooltips
       html = false,
-      ...attrs
     } = this.attrs;
 
     this.attrs['aria-label'] = text;

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -82,6 +82,12 @@ export default class Tooltip extends Component<TooltipAttrs> {
   view(vnode) {
     const { children } = vnode;
 
+    if (this.attrs.title) {
+      console.warn(
+        '`title` attribute was passed to Tooltip component. Was this intentional? Tooltip content should be passed to the `text` attr instead.'
+      );
+    }
+
     // We remove these to get the remaining attrs to pass to the DOM element
     const { text, containerType = 'block', tooltipVisible, showOnFocus, position, html, delay, className, class: classes, ...attrs } = this.attrs;
 

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -1,6 +1,7 @@
 import Component, { ComponentAttrs } from '../Component';
 import type Mithril from 'mithril';
 import classList from '../utils/classList';
+import { TooltipOptions } from '../../../@types/tooltips';
 
 export interface TooltipAttrs extends ComponentAttrs {
   /**
@@ -39,6 +40,16 @@ export interface TooltipAttrs extends ComponentAttrs {
    * @deprecated
    */
   html?: boolean;
+  /**
+   * Sets the delay between a trigger state occurring and the tooltip appearing
+   * on-screen.
+   *
+   * **Warning:** this option will be removed when we switch to CSS-only
+   * tooltips.
+   *
+   * @deprecated
+   */
+  delay?: number;
 }
 
 /**
@@ -50,15 +61,15 @@ export interface TooltipAttrs extends ComponentAttrs {
  * compatibility when we switch to pure CSS tooltips instead of Bootstrap
  * tooltips.
  *
- * @example <caption>Correct use of Tooltip component</caption>
+ * @example <caption>Basic usage</caption>
  *          <Tooltip text="You wish!">
  *            <Button>
  *              Click for free money!
  *            </Button>
  *          </Tooltip>
  *
- * @example <caption>Correct use of Tooltip component</caption>
- *          <Tooltip text="Replies from xxx, yyy, zzz and more.">
+ * @example <caption>Use of `position` and `showOnFocus` attrs</caption>
+ *          <Tooltip text="Woah! That's cool!" position="bottom" showOnFocus>
  *            <div>3 replies</div>
  *          </Tooltip>
  */
@@ -67,7 +78,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const { children } = vnode;
 
     // We remove these to get the remaining attrs to pass to the DOM element
-    const { text, inline, tooltipVisible, showOnFocus, position, html, ...attrs } = this.attrs;
+    const { text, inline, tooltipVisible, showOnFocus, position, html, delay, ...attrs } = this.attrs;
 
     if (inline) {
       return <span {...attrs}>{children}</span>;
@@ -93,6 +104,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
       tooltipVisible,
       showOnFocus = true,
       position = 'top',
+      delay,
       // This will have no effect when switching to CSS tooltips
       html = false,
       ...attrs
@@ -101,12 +113,13 @@ export default class Tooltip extends Component<TooltipAttrs> {
     this.attrs['aria-label'] = text;
 
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
-    this.$.tooltip({
+    this.$().tooltip({
       html,
+      delay,
       placement: position,
       title: text,
       // Fancy "hack" to assemble the trigger string
-      trigger: classList('hover', [showOnFocus && 'focus']),
+      trigger: classList('hover', [showOnFocus && 'focus']) as TooltipOptions['trigger'],
     });
   }
 }

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -63,9 +63,30 @@ export interface TooltipAttrs extends ComponentAttrs {
  *          </Tooltip>
  */
 export default class Tooltip extends Component<TooltipAttrs> {
-  view(vnode: Mithril.Vnode<TooltipAttrs, this>) {
+  view(vnode) {
     const { children } = vnode;
 
+    // We remove these to get the remaining attrs to pass to the DOM element
+    const { text, inline, tooltipVisible, showOnFocus, position, html, ...attrs } = this.attrs;
+
+    if (inline) {
+      return <span {...attrs}>{children}</span>;
+    }
+
+    return <div {...attrs}>{children}</div>;
+  }
+
+  oncreate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
+    super.oncreate(vnode);
+
+    this.createTooltip();
+  }
+
+  onupdate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
+    this.createTooltip();
+  }
+
+  private createTooltip() {
     const {
       text,
       inline,
@@ -77,7 +98,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
       ...attrs
     } = this.attrs;
 
-    attrs['aria-label'] = text;
+    this.attrs['aria-label'] = text;
 
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
     this.$.tooltip({
@@ -87,11 +108,5 @@ export default class Tooltip extends Component<TooltipAttrs> {
       // Fancy "hack" to assemble the trigger string
       trigger: classList('hover', [showOnFocus && 'focus']),
     });
-
-    if (inline) {
-      return <span {...attrs}>{children}</span>;
-    }
-
-    return <div {...attrs}>{children}</div>;
   }
 }

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -174,26 +174,14 @@ export default class Tooltip extends Component<TooltipAttrs> {
   oncreate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
     super.oncreate(vnode);
 
-    const domNode = (this.firstChild as Mithril.VnodeDOM<any, any>).dom as HTMLElement;
-
-    if (!domNode.isSameNode(this.childDomNode)) {
-      this.childDomNode = domNode;
-      this.shouldRecreateTooltip = true;
-    }
-
+    this.checkDomNodeChanged();
     this.recreateTooltip();
   }
 
   onupdate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
     super.onupdate(vnode);
 
-    const domNode = (this.firstChild as Mithril.VnodeDOM<any, any>).dom as HTMLElement;
-
-    if (!domNode.isSameNode(this.childDomNode)) {
-      this.childDomNode = domNode;
-      this.shouldRecreateTooltip = true;
-    }
-
+    this.checkDomNodeChanged();
     this.recreateTooltip();
   }
 
@@ -271,5 +259,20 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const { text } = this.attrs;
 
     return Array.isArray(text) ? extractText(text) : text;
+  }
+
+  /**
+   * Checks if the tooltip DOM node has changed.
+   *
+   * If it has, it updates `this.childDomNode` to the new node, and sets
+   * `shouldRecreateTooltip` to `true`.
+   */
+  private checkDomNodeChanged() {
+    const domNode = (this.firstChild as Mithril.VnodeDOM<any, any>).dom as HTMLElement;
+
+    if (domNode && !domNode.isSameNode(this.childDomNode)) {
+      this.childDomNode = domNode;
+      this.shouldRecreateTooltip = true;
+    }
   }
 }

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -61,6 +61,12 @@ export interface TooltipAttrs extends ComponentAttrs {
    * @deprecated
    */
   delay?: number;
+  /**
+   * Used to disable the warning for passing text to the `title` attribute.
+   *
+   * Tooltip text should be passed to the `text` attribute.
+   */
+  ignoreTitleWarning?: boolean;
 }
 
 /**
@@ -94,25 +100,14 @@ export default class Tooltip extends Component<TooltipAttrs> {
   view(vnode) {
     const { children } = vnode;
 
-    if (this.attrs.title) {
+    // We remove these to get the remaining attrs to pass to the DOM element
+    const { text, tooltipVisible, showOnFocus = true, position = 'top', ignoreTitleWarning = false, html = false, delay = 0, ...attrs } = this.attrs;
+
+    if (this.attrs.title && !ignoreTitleWarning) {
       console.warn(
         '`title` attribute was passed to Tooltip component. Was this intentional? Tooltip content should be passed to the `text` attr instead.'
       );
     }
-
-    // We remove these to get the remaining attrs to pass to the DOM element
-    const {
-      text,
-      containerType = 'block',
-      tooltipVisible,
-      showOnFocus = true,
-      position = 'top',
-      html = false,
-      delay = 0,
-      className,
-      class: classes,
-      ...attrs
-    } = this.attrs;
 
     const realText = Array.isArray(text) ? extractText(text) : text;
 

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -1,0 +1,97 @@
+import Component, { ComponentAttrs } from '../Component';
+import type Mithril from 'mithril';
+import classList from '../utils/classList';
+
+export interface TooltipAttrs extends ComponentAttrs {
+  /**
+   * Tooltip textual content.
+   */
+  text: string;
+  /**
+   * If inline, uses a `<span>` container, else uses a `<div>`.
+   *
+   * Default: `false`.
+   */
+  inline?: boolean;
+  /**
+   * Manually show tooltip. `false` will show based on cursor events.
+   *
+   * Default: `false`.
+   */
+  tooltipVisible?: boolean;
+  /**
+   * Whether to show on focus.
+   *
+   * Default: `true`.
+   */
+  showOnFocus?: boolean;
+  /**
+   * Tooltip position around element.
+   */
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  /**
+   * Whether HTML content is allowed in the tooltip.
+   *
+   * **Warning:** this is a possible XSS attack vector. This option shouldn't
+   * be used wherever possible, and will not work when we migrate to CSS-only
+   * tooltips.
+   *
+   * @deprecated
+   */
+  html?: boolean;
+}
+
+/**
+ * The `Tooltip` component is used to create a tooltip for an element. It
+ * surrounds it with a div (or span) which has the required tooltip setup
+ * applied.
+ *
+ * You should use this for any tooltips you create to allow for backwards
+ * compatibility when we switch to pure CSS tooltips instead of Bootstrap
+ * tooltips.
+ *
+ * @example <caption>Correct use of Tooltip component</caption>
+ *          <Tooltip text="You wish!">
+ *            <Button>
+ *              Click for free money!
+ *            </Button>
+ *          </Tooltip>
+ *
+ * @example <caption>Correct use of Tooltip component</caption>
+ *          <Tooltip text="Replies from xxx, yyy, zzz and more.">
+ *            <div>3 replies</div>
+ *          </Tooltip>
+ */
+export default class Tooltip extends Component<TooltipAttrs> {
+  view(vnode: Mithril.Vnode<TooltipAttrs, this>) {
+    const { children } = vnode;
+
+    const {
+      text,
+      inline,
+      tooltipVisible,
+      showOnFocus = true,
+      position = 'top',
+      // This will have no effect when switching to CSS tooltips
+      html = false,
+      ...attrs
+    } = this.attrs;
+
+    attrs['aria-label'] = text;
+
+    // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
+    this.$.tooltip({
+      html,
+      placement: position,
+      title: text,
+      // Fancy "hack" to assemble the trigger string
+      trigger: classList('hover', [showOnFocus && 'focus']),
+    });
+
+    if (inline) {
+      return <span {...attrs}>{children}</span>;
+    }
+
+    return <div {...attrs}>{children}</div>;
+  }
+}

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -158,7 +158,6 @@ export default class Tooltip extends Component<TooltipAttrs> {
     if (this.shouldChangeTooltipVisibility) {
       this.shouldChangeTooltipVisibility = false;
       this.updateVisibility();
-
     }
   }
 

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -82,20 +82,12 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const { children } = vnode;
 
     // We remove these to get the remaining attrs to pass to the DOM element
-    const { text, inline, tooltipVisible, showOnFocus, position, html, delay, ...attrs } = this.attrs;
+    const { text, inline, tooltipVisible, showOnFocus, position, html, delay, className, class: classes, ...attrs } = this.attrs;
 
     const realText = Array.isArray(text) ? extractText(text) : text;
 
-    if (inline) {
-      return (
-        <span title={realText} {...attrs}>
-          {children}
-        </span>
-      );
-    }
-
     return (
-      <div title={realText} {...attrs}>
+      <div title={realText} className={classList('tooltip-container', [inline && 'tooltip-container--inline'], className, classes)} {...attrs}>
         {children}
       </div>
     );

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -79,6 +79,9 @@ export interface TooltipAttrs extends ComponentAttrs {
  *          </Tooltip>
  */
 export default class Tooltip extends Component<TooltipAttrs> {
+  private oldText: string = '';
+  private shouldRecreateTooltip: boolean = false;
+
   view(vnode) {
     const { children } = vnode;
 
@@ -93,6 +96,12 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
     const realText = Array.isArray(text) ? extractText(text) : text;
 
+    // We need to recreate the tooltip if the text has changed
+    if (realText !== this.oldText) {
+      this.oldText = realText;
+      this.shouldRecreateTooltip = true;
+    }
+
     return (
       <div title={realText} className={classList('tooltip-container', `tooltip-container--${containerType}`, className, classes)} {...attrs}>
         {children}
@@ -103,7 +112,18 @@ export default class Tooltip extends Component<TooltipAttrs> {
   oncreate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
     super.oncreate(vnode);
 
-    this.createTooltip();
+    this.recreateTooltip();
+  }
+
+  onupdate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
+    this.recreateTooltip();
+  }
+
+  private recreateTooltip() {
+    if (this.shouldRecreateTooltip) {
+      this.$().tooltip('destroy');
+      this.createTooltip();
+    }
   }
 
   private createTooltip() {

--- a/js/src/common/components/Tooltip.tsx
+++ b/js/src/common/components/Tooltip.tsx
@@ -74,13 +74,6 @@ export interface TooltipAttrs extends ComponentAttrs {
  *          </Tooltip>
  */
 export default class Tooltip extends Component<TooltipAttrs> {
-  /**
-   * Contains the old tooltip text.
-   *
-   * Used to determine whether the tooltip should be recreated.
-   */
-  private oldText: string = '';
-
   view(vnode) {
     const { children } = vnode;
 
@@ -88,33 +81,28 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const { text, inline, tooltipVisible, showOnFocus, position, html, delay, ...attrs } = this.attrs;
 
     if (inline) {
-      return <span {...attrs}>{children}</span>;
+      return (
+        <span title={text} {...attrs}>
+          {children}
+        </span>
+      );
     }
 
-    return <div {...attrs}>{children}</div>;
+    return (
+      <div title={text} {...attrs}>
+        {children}
+      </div>
+    );
   }
 
   oncreate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
     super.oncreate(vnode);
 
-    this.oldText = this.attrs.text;
-
     this.createTooltip();
-  }
-
-  onupdate(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
-    // In case the `text` attr was updated, we need to recreate the tooltip
-    if (this.attrs.text !== this.oldText) {
-      this.oldText = this.attrs.text;
-
-      this.$().tooltip('destroy');
-      this.createTooltip();
-    }
   }
 
   private createTooltip() {
     const {
-      text,
       showOnFocus = true,
       position = 'top',
       delay,
@@ -122,14 +110,11 @@ export default class Tooltip extends Component<TooltipAttrs> {
       html = false,
     } = this.attrs;
 
-    this.attrs['aria-label'] = text;
-
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
     this.$().tooltip({
       html,
       delay,
       placement: position,
-      title: text,
       // Fancy "hack" to assemble the trigger string
       trigger: classList('hover', [showOnFocus && 'focus']) as TooltipCreationOptions['trigger'],
     });

--- a/js/src/common/index.js
+++ b/js/src/common/index.js
@@ -25,3 +25,18 @@ import * as Extend from './extend/index';
 export { Extend };
 
 import './utils/arrayFlatPolyfill';
+
+const tooltipGen = $.fn.tooltip;
+
+// Remove in a future version of Flarum.
+$.fn.tooltip = function (options, caller) {
+  // Show a warning when `$.tooltip` is used outside of the Tooltip component.
+  // This functionality is deprecated and should not be used.
+  if (['DANGEROUS_tooltip_jquery_fn_deprecation_exempt'].includes(caller)) {
+    console.warn(
+      "Calling `$.tooltip` is now deprecated. Please use the `<Tooltip>` component exposed by flarum/core instead. `$.tooltip` may be removed in a future version of Flarum.\n\nIf this component doesn't meet your requirements, please open an issue: https://github.com/flarum/core/issues/new?assignees=davwheat&labels=type/bug,needs-verification&template=bug-report.md&title=Tooltip%20component%20unsuitable%20for%20use%20case"
+    );
+  }
+
+  tooltipGen.bind(this)(options);
+};

--- a/js/src/common/index.js
+++ b/js/src/common/index.js
@@ -32,7 +32,7 @@ const tooltipGen = $.fn.tooltip;
 $.fn.tooltip = function (options, caller) {
   // Show a warning when `$.tooltip` is used outside of the Tooltip component.
   // This functionality is deprecated and should not be used.
-  if (['DANGEROUS_tooltip_jquery_fn_deprecation_exempt'].includes(caller)) {
+  if (!['DANGEROUS_tooltip_jquery_fn_deprecation_exempt'].includes(caller)) {
     console.warn(
       "Calling `$.tooltip` is now deprecated. Please use the `<Tooltip>` component exposed by flarum/core instead. `$.tooltip` may be removed in a future version of Flarum.\n\nIf this component doesn't meet your requirements, please open an issue: https://github.com/flarum/core/issues/new?assignees=davwheat&labels=type/bug,needs-verification&template=bug-report.md&title=Tooltip%20component%20unsuitable%20for%20use%20case"
     );

--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -103,11 +103,12 @@ export default class DiscussionListItem extends Component {
 
         <div className={'DiscussionListItem-content Slidable-content' + (isUnread ? ' unread' : '') + (isRead ? ' read' : '')}>
           <Tooltip
-            className="DiscussionListItem-author"
             text={app.translator.trans('core.forum.discussion_list.started_text', { user, ago: humanTime(discussion.createdAt()) })}
             position="right"
           >
-            <Link href={user ? app.route.user(user) : '#'}>{avatar(user, { title: '' })}</Link>
+            <Link className="DiscussionListItem-author" href={user ? app.route.user(user) : '#'}>
+              {avatar(user, { title: '' })}
+            </Link>
           </Tooltip>
 
           <ul className="DiscussionListItem-badges badges">{listItems(discussion.badges().toArray())}</ul>

--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -16,6 +16,7 @@ import extractText from '../../common/utils/extractText';
 import classList from '../../common/utils/classList';
 import DiscussionPage from './DiscussionPage';
 import escapeRegExp from '../../common/utils/escapeRegExp';
+import Tooltip from '../../common/components/Tooltip';
 
 /**
  * The `DiscussionListItem` component shows a single discussion in the
@@ -101,18 +102,13 @@ export default class DiscussionListItem extends Component {
         </span>
 
         <div className={'DiscussionListItem-content Slidable-content' + (isUnread ? ' unread' : '') + (isRead ? ' read' : '')}>
-          <Link
-            href={user ? app.route.user(user) : '#'}
+          <Tooltip
             className="DiscussionListItem-author"
-            title={extractText(
-              app.translator.trans('core.forum.discussion_list.started_text', { user: user, ago: humanTime(discussion.createdAt()) })
-            )}
-            oncreate={function (vnode) {
-              $(vnode.dom).tooltip({ placement: 'right' });
-            }}
+            text={app.translator.trans('core.forum.discussion_list.started_text', { user, ago: humanTime(discussion.createdAt()) })}
+            position="right"
           >
-            {avatar(user, { title: '' })}
-          </Link>
+            <Link href={user ? app.route.user(user) : '#'}>{avatar(user, { title: '' })}</Link>
+          </Tooltip>
 
           <ul className="DiscussionListItem-badges badges">{listItems(discussion.badges().toArray())}</ul>
 

--- a/js/src/forum/components/PostEdited.js
+++ b/js/src/forum/components/PostEdited.js
@@ -1,6 +1,6 @@
 import Component from '../../common/Component';
 import humanTime from '../../common/utils/humanTime';
-import extractText from '../../common/utils/extractText';
+import Tooltip from '../../common/components/Tooltip';
 
 /**
  * The `PostEdited` component displays information about when and by whom a post
@@ -13,43 +13,21 @@ import extractText from '../../common/utils/extractText';
 export default class PostEdited extends Component {
   oninit(vnode) {
     super.oninit(vnode);
-
-    this.shouldUpdateTooltip = false;
-    this.oldEditedInfo = null;
   }
 
   view() {
     const post = this.attrs.post;
     const editedUser = post.editedUser();
-    const editedInfo = extractText(app.translator.trans('core.forum.post.edited_tooltip', { user: editedUser, ago: humanTime(post.editedAt()) }));
-    if (editedInfo !== this.oldEditedInfo) {
-      this.shouldUpdateTooltip = true;
-      this.oldEditedInfo = editedInfo;
-    }
+    const editedInfo = app.translator.trans('core.forum.post.edited_tooltip', { user: editedUser, ago: humanTime(post.editedAt()) });
 
     return (
-      <span className="PostEdited" title={editedInfo}>
+      <Tooltip containerType="inline" className="PostEdited" text={editedInfo}>
         {app.translator.trans('core.forum.post.edited_text')}
-      </span>
+      </Tooltip>
     );
   }
 
   oncreate(vnode) {
     super.oncreate(vnode);
-
-    this.rebuildTooltip();
-  }
-
-  onupdate(vnode) {
-    super.onupdate(vnode);
-
-    this.rebuildTooltip();
-  }
-
-  rebuildTooltip() {
-    if (this.shouldUpdateTooltip) {
-      this.$().tooltip('destroy').tooltip();
-      this.shouldUpdateTooltip = false;
-    }
   }
 }

--- a/js/src/forum/components/PostEdited.js
+++ b/js/src/forum/components/PostEdited.js
@@ -21,8 +21,8 @@ export default class PostEdited extends Component {
     const editedInfo = app.translator.trans('core.forum.post.edited_tooltip', { user: editedUser, ago: humanTime(post.editedAt()) });
 
     return (
-      <Tooltip containerType="inline" className="PostEdited" text={editedInfo}>
-        {app.translator.trans('core.forum.post.edited_text')}
+      <Tooltip text={editedInfo}>
+        <span class="PostEdited">{app.translator.trans('core.forum.post.edited_text')}</span>
       </Tooltip>
     );
   }

--- a/less/common/Tooltip.less
+++ b/less/common/Tooltip.less
@@ -1,6 +1,10 @@
 // ------------------------------------
 // Tooltips
 
+.tooltip-container--inline {
+  display: inline-block;
+}
+
 // Base class
 .tooltip {
   position: absolute;

--- a/less/common/Tooltip.less
+++ b/less/common/Tooltip.less
@@ -1,8 +1,13 @@
 // ------------------------------------
 // Tooltips
 
-.tooltip-container--inline {
-  display: inline-block;
+.tooltip-container {
+  &--inline {
+    display: inline;
+  }
+  &--inline-block {
+    display: inline-block;
+  }
 }
 
 // Base class

--- a/less/common/Tooltip.less
+++ b/less/common/Tooltip.less
@@ -1,15 +1,6 @@
 // ------------------------------------
 // Tooltips
 
-.tooltip-container {
-  &--inline {
-    display: inline;
-  }
-  &--inline-block {
-    display: inline-block;
-  }
-}
-
 // Base class
 .tooltip {
   position: absolute;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Prevents breaking changes as a result of flarum/framework#2697. Progresses flarum/issue-archive#179.**

**Changes proposed in this pull request:**
This is still WIP. Created as a draft now to allow for any comments to be made while the component is still being made.

This adds a new Tooltip component to core. This should be used by extensions instead of `$.tooltip` to aid in the shift to other tooltip libraries (hopefully CSS tooltips!) in the future.

I've tried to include the main tooltip options that are used by extensions, such as `delay` and `html`, but these won't be easy or possible to keep if we shift to CSS tooltips, so they've been marked as deprecated and only exist to allow extensions to more easily shift to this component.

**Reviewers should focus on:**
Will the deprecation of `html` and `delay` cause an issue with flarum/framework#2697 as they aren't available in that? Do we consider removing deprecated features within a stable release ok, bearing in mind there is a fairly bold warning in the docblock, or should we just not implement them as part of the component in the first place.

I think implementing them as deprecated features will help ext devs migrate to this component faster and more easily now, bearing in mind the large number of other changes they need to perform.

Should we also add a deprecation warning to the tooltip helper when it's called from outside the `Tooltip` component to make this more obvious to devs?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
