### PR TITLE
[1.x] Throw a validation error on `ico` favicons.

### DIFF
--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -9,15 +9,35 @@
 
 namespace Flarum\Api\Controller;
 
+use Flarum\Foundation\ValidationException;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Filesystem\Factory;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use Psr\Http\Message\UploadedFileInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UploadFaviconController extends UploadImageController
 {
     protected $filePathSettingKey = 'favicon_path';
 
     protected $filenamePrefix = 'favicon';
+
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @param SettingsRepositoryInterface $settings
+     * @param Factory $filesystemFactory
+     */
+    public function __construct(SettingsRepositoryInterface $settings, Factory $filesystemFactory, TranslatorInterface $translator)
+    {
+        parent::__construct($settings, $filesystemFactory);
+
+        $this->translator = $translator;
+    }
 
     /**
      * {@inheritdoc}
@@ -27,17 +47,23 @@ class UploadFaviconController extends UploadImageController
         $this->fileExtension = pathinfo($file->getClientFilename(), PATHINFO_EXTENSION);
 
         if ($this->fileExtension === 'ico') {
-            $encodedImage = $file->getStream();
-        } else {
-            $manager = new ImageManager();
-
-            $encodedImage = $manager->make($file->getStream())->resize(64, 64, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->encode('png');
-
-            $this->fileExtension = 'png';
+            // @todo remove in 2.0
+            throw new ValidationException([
+                'message' => strtr($this->translator->trans('validation.mimes'), [
+                    ':attribute' => 'favicon',
+                    ':values' => 'jpeg,png,gif,webp',
+                ])
+            ]);
         }
+
+        $manager = new ImageManager();
+
+        $encodedImage = $manager->make($file->getStream())->resize(64, 64, function ($constraint) {
+            $constraint->aspectRatio();
+            $constraint->upsize();
+        })->encode('png');
+
+        $this->fileExtension = 'png';
 
         return $encodedImage;
     }


### PR DESCRIPTION
**Part of flarum/issue-archive#73**

**Changes proposed in this pull request:**
As mentioned in the issue, since we can't fix the problem in an unbreaking way, we at least throw a validation error instead of a 500.

**Reviewers should focus on:**
Code quality.
Are there any better alternatives.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
