### PR TITLE
[2.0] Recover support for `ico` favicons.

### DIFF
--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Api\Controller;
 
-use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use Psr\Http\Message\UploadedFileInterface;
 

--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -22,12 +22,13 @@ class UploadFaviconController extends UploadImageController
     /**
      * {@inheritdoc}
      */
-    protected function makeImage(UploadedFileInterface $file): Image
+    protected function makeImage(UploadedFileInterface $file)
     {
         $this->fileExtension = pathinfo($file->getClientFilename(), PATHINFO_EXTENSION);
 
         if ($this->fileExtension === 'ico') {
             $encodedImage = $file->getStream();
+            error_log(get_class($encodedImage));
         } else {
             $manager = new ImageManager();
 

--- a/src/Api/Controller/UploadImageController.php
+++ b/src/Api/Controller/UploadImageController.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Intervention\Image\Image;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Tobscure\JsonApi\Document;
@@ -83,7 +84,7 @@ abstract class UploadImageController extends ShowForumController
 
     /**
      * @param UploadedFileInterface $file
-     * @return Image
+     * @return Image|Stream
      */
-    abstract protected function makeImage(UploadedFileInterface $file): Image;
+    abstract protected function makeImage(UploadedFileInterface $file);
 }

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Api\Controller;
 
-use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use Psr\Http\Message\UploadedFileInterface;
 
@@ -22,7 +21,7 @@ class UploadLogoController extends UploadImageController
     /**
      * {@inheritdoc}
      */
-    protected function makeImage(UploadedFileInterface $file): Image
+    protected function makeImage(UploadedFileInterface $file)
     {
         $manager = new ImageManager();
 


### PR DESCRIPTION
**DO NOT MERGE!!** will be redirected at a `2.x` branch soon.

**Fixes flarum/issue-archive#73**

**Changes proposed in this pull request:**
Remove explicit typehint from `makeImage` method so that we can return the `ico` favicon's file stream.

**Reviewers should focus on:**
Code quality.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).