### PR TITLE
Add ability to set email confirmation state to false

### DIFF
--- a/src/User/Command/ConfirmEmailHandler.php
+++ b/src/User/Command/ConfirmEmailHandler.php
@@ -41,10 +41,11 @@ class ConfirmEmailHandler
         /** @var EmailToken $token */
         $token = EmailToken::validOrFail($command->token);
 
+        /** @var \Flarum\User\User */
         $user = $token->user;
         $user->changeEmail($token->email);
 
-        $user->activate();
+        $user->confirmEmail();
 
         $user->save();
         $this->dispatchEventsFor($user);

--- a/src/User/Command/EditUserHandler.php
+++ b/src/User/Command/EditUserHandler.php
@@ -86,9 +86,9 @@ class EditUserHandler
             $actor->assertAdmin();
 
             if ($attributes['isEmailConfirmed'] === false) {
-                $user->deactivate();
+                $user->unconfirmEmail();
             } else {
-                $user->activate();
+                $user->confirmEmail();
             }
         }
 

--- a/src/User/Command/EditUserHandler.php
+++ b/src/User/Command/EditUserHandler.php
@@ -82,9 +82,14 @@ class EditUserHandler
             }
         }
 
-        if (! empty($attributes['isEmailConfirmed'])) {
+        if (isset($attributes['isEmailConfirmed'])) {
             $actor->assertAdmin();
-            $user->activate();
+
+            if ($attributes['isEmailConfirmed'] === false) {
+                $user->is_email_confirmed = false;
+            } else {
+                $user->activate();
+            }
         }
 
         if (isset($attributes['password'])) {

--- a/src/User/Command/EditUserHandler.php
+++ b/src/User/Command/EditUserHandler.php
@@ -86,7 +86,7 @@ class EditUserHandler
             $actor->assertAdmin();
 
             if ($attributes['isEmailConfirmed'] === false) {
-                $user->is_email_confirmed = false;
+                $user->deactivate();
             } else {
                 $user->activate();
             }

--- a/src/User/Command/RegisterUserHandler.php
+++ b/src/User/Command/RegisterUserHandler.php
@@ -107,7 +107,7 @@ class RegisterUserHandler
         }
 
         if ($actor->isAdmin() && Arr::get($data, 'attributes.isEmailConfirmed')) {
-            $user->activate();
+            $user->confirmEmail();
         }
 
         $this->events->dispatch(
@@ -138,7 +138,7 @@ class RegisterUserHandler
             $user->$k = $v;
 
             if ($k === 'email') {
-                $user->activate();
+                $user->confirmEmail();
             }
         }
 

--- a/src/User/Event/Deactivated.php
+++ b/src/User/Event/Deactivated.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\Event;
+
+use Flarum\User\User;
+
+class Deactivated
+{
+    /**
+     * @var User
+     */
+    public $user;
+
+    /**
+     * @var User
+     */
+    public $actor;
+
+    /**
+     * @param User $user
+     * @param User $actor
+     */
+    public function __construct(User $user, User $actor = null)
+    {
+        $this->user = $user;
+        $this->actor = $actor;
+    }
+}

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -352,12 +352,26 @@ class User extends AbstractModel
         return $valid;
     }
 
+    // TODO: remove this in Flarum 2.0
+    /**
+     * Activate the user's account.
+     * 
+     * Please use `->confirmEmail()` instead.
+     *
+     * @return $this
+     * @deprecated
+     */
+    public function activate()
+    {
+        return $this->confirmEmail();
+    }
+
     /**
      * Activate the user's account.
      *
      * @return $this
      */
-    public function activate()
+    public function confirmEmail()
     {
         if (! $this->is_email_confirmed) {
             $this->is_email_confirmed = true;
@@ -373,7 +387,7 @@ class User extends AbstractModel
      *
      * @return $this
      */
-    public function deactivate()
+    public function unconfirmEmail()
     {
         if ($this->is_email_confirmed !== false) {
             $this->is_email_confirmed = false;

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -355,7 +355,7 @@ class User extends AbstractModel
     // TODO: remove this in Flarum 2.0
     /**
      * Activate the user's account.
-     * 
+     *
      * Please use `->confirmEmail()` instead.
      *
      * @return $this

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -367,7 +367,7 @@ class User extends AbstractModel
     }
 
     /**
-     * Activate the user's account.
+     * Mark the user's email as confirmed.
      *
      * @return $this
      */
@@ -383,7 +383,7 @@ class User extends AbstractModel
     }
 
     /**
-     * Deactivate the user's account.
+     * Mark the user's email as not confirmed.
      *
      * @return $this
      */

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -23,6 +23,7 @@ use Flarum\Post\Post;
 use Flarum\User\DisplayName\DriverInterface;
 use Flarum\User\Event\Activated;
 use Flarum\User\Event\AvatarChanged;
+use Flarum\User\Event\Deactivated;
 use Flarum\User\Event\Deleted;
 use Flarum\User\Event\EmailChanged;
 use Flarum\User\Event\EmailChangeRequested;
@@ -362,6 +363,22 @@ class User extends AbstractModel
             $this->is_email_confirmed = true;
 
             $this->raise(new Activated($this));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Deactivate the user's account.
+     *
+     * @return $this
+     */
+    public function deactivate()
+    {
+        if ($this->is_email_confirmed !== false) {
+            $this->is_email_confirmed = false;
+
+            $this->raise(new Deactivated($this));
         }
 
         return $this;

--- a/tests/integration/api/users/UpdateTest.php
+++ b/tests/integration/api/users/UpdateTest.php
@@ -380,7 +380,7 @@ class UpdateTest extends TestCase
     public function users_cant_deactivate_others_without_permission()
     {
         $response = $this->send(
-            $this->request('PATCH', '/api/users/2', [
+            $this->request('PATCH', '/api/users/3', [
                 'authenticatedAs' => 2,
                 'json' => [
                     'data' => [
@@ -621,7 +621,7 @@ class UpdateTest extends TestCase
     {
         $this->giveNormalUsersEditPerms();
         $response = $this->send(
-            $this->request('PATCH', '/api/users/2', [
+            $this->request('PATCH', '/api/users/3', [
                 'authenticatedAs' => 2,
                 'json' => [
                     'data' => [

--- a/tests/integration/api/users/UpdateTest.php
+++ b/tests/integration/api/users/UpdateTest.php
@@ -253,6 +253,26 @@ class UpdateTest extends TestCase
 
     /**
      * @test
+     */
+    public function users_cant_deactivate_themselves()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/2', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'isEmailConfirmed' => false
+                        ],
+                    ]
+                ],
+            ])
+        );
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
      *
      * This tests the generic user.edit permission used for non-credential/group attributes
      */
@@ -346,6 +366,26 @@ class UpdateTest extends TestCase
                     'data' => [
                         'attributes' => [
                             'isEmailConfirmed' => true
+                        ],
+                    ]
+                ],
+            ])
+        );
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function users_cant_deactivate_others_without_permission()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/2', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'isEmailConfirmed' => false
                         ],
                     ]
                 ],
@@ -577,6 +617,27 @@ class UpdateTest extends TestCase
     /**
      * @test
      */
+    public function users_cant_deactivate_others_even_with_permissions()
+    {
+        $this->giveNormalUsersEditPerms();
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/2', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'isEmailConfirmed' => false
+                        ],
+                    ]
+                ],
+            ])
+        );
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
     public function admins_cant_update_others_preferences()
     {
         $response = $this->send(
@@ -628,6 +689,26 @@ class UpdateTest extends TestCase
                     'data' => [
                         'attributes' => [
                             'isEmailConfirmed' => true
+                        ],
+                    ]
+                ],
+            ])
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function admins_can_deactivate_others()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/2', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'isEmailConfirmed' => false
                         ],
                     ]
                 ],


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Allows admins to set email confirmation state to `false`.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Should we instead add a `deactivate` method to `User.php` and fire a deactivation event, similar to what we do for activation?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
