### PR TITLE
Replace username with display name in more places

### DIFF
--- a/js/src/forum/utils/UserControls.js
+++ b/js/src/forum/utils/UserControls.js
@@ -124,7 +124,7 @@ export default {
    * @param {string} type
    */
   showDeletionAlert(user, type) {
-    const { username, email } = user.data.attributes;
+    const { displayName: username, email } = user.data.attributes;
     const message = {
       success: 'core.forum.user_controls.delete_success_message',
       error: 'core.forum.user_controls.delete_error_message',

--- a/js/src/forum/utils/UserControls.js
+++ b/js/src/forum/utils/UserControls.js
@@ -124,13 +124,18 @@ export default {
    * @param {string} type
    */
   showDeletionAlert(user, type) {
-    const { displayName: username, email } = user.data.attributes;
     const message = {
       success: 'core.forum.user_controls.delete_success_message',
       error: 'core.forum.user_controls.delete_error_message',
     }[type];
 
-    app.alerts.show({ type }, app.translator.trans(message, { username, email }));
+    app.alerts.show(
+      { type },
+      app.translator.trans(message, {
+        user,
+        email: user.email(),
+      })
+    );
   },
 
   /**

--- a/src/Notification/NotificationMailer.php
+++ b/src/Notification/NotificationMailer.php
@@ -46,7 +46,7 @@ class NotificationMailer
             $blueprint->getEmailView(),
             compact('blueprint', 'user'),
             function (Message $message) use ($blueprint, $user) {
-                $message->to($user->email, $user->username)
+                $message->to($user->email, $user->display_name)
                         ->subject($blueprint->getEmailSubject($this->translator));
             }
         );

--- a/views/frontend/content/discussion.blade.php
+++ b/views/frontend/content/discussion.blade.php
@@ -5,7 +5,7 @@
         @foreach ($posts as $post)
             <div>
                 <?php $user = ! empty($post->relationships->user->data) ? $getResource($post->relationships->user->data) : null; ?>
-                <h3>{{ $user ? $user->attributes->username : $translator->trans('core.lib.username.deleted_text') }}</h3>
+                <h3>{{ $user ? $user->attributes->displayName : $translator->trans('core.lib.username.deleted_text') }}</h3>
                 <div class="Post-body">
                     {!! $post->attributes->contentHtml !!}
                 </div>


### PR DESCRIPTION
**Changes proposed in this pull request:**
Replaces instances of `username` which have not been converted to use display name yet.

The following were fixed:

- Confirmation and error alert box after deleting a user
- Display name in notification email TO header
- Author in discussion nojs view

I don't think any of these had an open issue.

**Reviewers should focus on:**
For the alert change I have kept the existing name `username` for the translation variable. I think that's what we have already done in all previous instances.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).