### PR TITLE
Add extra error handling for avatar file size & large payload

### DIFF
--- a/js/src/common/Application.js
+++ b/js/src/common/Application.js
@@ -382,6 +382,10 @@ export default class Application {
             content = app.translator.trans('core.lib.error.not_found_message');
             break;
 
+          case 413:
+            content = app.translator.trans('core.lib.error.payload_too_large_message');
+            break;
+
           case 429:
             content = app.translator.trans('core.lib.error.rate_limit_exceeded_message');
             break;

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -521,6 +521,7 @@ core:
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
       not_found_message: The requested resource was not found.
+      payload_too_large_message: The request payload was too large.
       permission_denied_message: You do not have permission to do that.
       rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.
 

--- a/locale/validation.yml
+++ b/locale/validation.yml
@@ -28,6 +28,8 @@ validation:
   ends_with: "The :attribute must end with one of the following: :values."
   exists: "The selected :attribute is invalid."
   file: "The :attribute must be a file."
+  file_too_large: "The :attribute is too large."
+  file_uploaded: "The :attribute failed to upload."
   filled: "The :attribute field must have a value."
   gt:
     numeric: "The :attribute must be greater than :value."

--- a/locale/validation.yml
+++ b/locale/validation.yml
@@ -29,7 +29,7 @@ validation:
   exists: "The selected :attribute is invalid."
   file: "The :attribute must be a file."
   file_too_large: "The :attribute is too large."
-  file_uploaded: "The :attribute failed to upload."
+  file_upload_failed: "The :attribute failed to upload."
   filled: "The :attribute field must have a value."
   gt:
     numeric: "The :attribute must be greater than :value."

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -33,15 +33,15 @@ class AvatarValidator extends AbstractValidator
         $error = $file->getError();
 
         if ($error !== UPLOAD_ERR_OK) {
-            if ($error == UPLOAD_ERR_INI_SIZE || $error == UPLOAD_ERR_FORM_SIZE) {
+            if ($error === UPLOAD_ERR_INI_SIZE || $error === UPLOAD_ERR_FORM_SIZE) {
                 $this->raise('file_too_large');
             }
 
-            if ($error == UPLOAD_ERR_PARTIAL) {
-                $this->raise('file_uploaded');
+            if ($error === UPLOAD_ERR_NO_FILE) {
+                $this->raise('required');
             }
 
-            $this->raise('required');
+            $this->raise('file_uploaded');
         }
     }
 

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -41,7 +41,7 @@ class AvatarValidator extends AbstractValidator
                 $this->raise('required');
             }
 
-            $this->raise('file_uploaded');
+            $this->raise('file_upload_failed');
         }
     }
 

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -92,9 +92,4 @@ class AvatarValidator extends AbstractValidator
     {
         return ['jpg', 'png', 'bmp', 'gif'];
     }
-
-    protected function getRules()
-    {
-        return ['avatar' => 'required|file'];
-    }
 }

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -30,7 +30,17 @@ class AvatarValidator extends AbstractValidator
 
     protected function assertFileRequired(UploadedFileInterface $file)
     {
-        if ($file->getError() !== UPLOAD_ERR_OK) {
+        $error = $file->getError();
+
+        if ($error !== UPLOAD_ERR_OK) {
+            if ($error == UPLOAD_ERR_INI_SIZE || $error == UPLOAD_ERR_FORM_SIZE) {
+                $this->raise('file_too_large');
+            }
+
+            if ($error == UPLOAD_ERR_PARTIAL) {
+                $this->raise('file_uploaded');
+            }
+
             $this->raise('required');
         }
     }
@@ -81,5 +91,10 @@ class AvatarValidator extends AbstractValidator
     protected function getAllowedTypes()
     {
         return ['jpg', 'png', 'bmp', 'gif'];
+    }
+
+    protected function getRules()
+    {
+        return ['avatar' => 'required|file'];
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/framework#2888**

**Changes proposed in this pull request:**
- Add separate error messages during upload for `UPLOAD_ERR_INI_SIZE` & `UPLOAD_ERR_FORM_SIZE`, and `UPLOAD_ERR_PARTIAL`
- Add frontend handling of 413 status code (Payload Too Large)

**Reviewers should focus on:**
- Do we perhaps want to say "failed to upload" for the other errors and just "required" for `UPLOAD_ERR_NO_FILE`? That'd make more sense as only NO_FILE is a required issue, and the others are internal so we can say failed.
- This file logic, validation and/or error handling should probably be extracted so that other areas & extensions can use it... out of scope for this however.

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/130323687-800c8df5-78e2-4c0d-8873-3f4ee0baba67.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).