### PR TITLE
Handle post rendering errors to avoid bricking

### DIFF
--- a/js/src/common/models/Post.js
+++ b/js/src/common/models/Post.js
@@ -10,9 +10,11 @@ Object.assign(Post.prototype, {
 
   createdAt: Model.attribute('createdAt', Model.transformDate),
   user: Model.hasOne('user'),
+
   contentType: Model.attribute('contentType'),
   content: Model.attribute('content'),
   contentHtml: Model.attribute('contentHtml'),
+  renderFailed: Model.attribute('renderFailed'),
   contentPlain: computed('contentHtml', getPlainContent),
 
   editedAt: Model.attribute('editedAt', Model.transformDate),

--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -100,6 +100,7 @@ export default class CommentPost extends Post {
       ' ' +
       classList({
         CommentPost: true,
+        'Post--renderFailed': post.renderFailed(),
         'Post--hidden': post.isHidden(),
         'Post--edited': post.isEdited(),
         revealContent: this.revealContent,

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -186,7 +186,7 @@
 }
 
 .Post--renderFailed {
-  background-color: @control-danger-color;
+  background-color: @control-danger-bg;
 }
 
 .Post--hidden {

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -185,6 +185,10 @@
   }
 }
 
+.Post--renderFailed {
+  background-color: @control-danger-color;
+}
+
 .Post--hidden {
   .Post-header, .Post-header a, .PostUser h3, .PostUser h3 a {
     color: @muted-more-color;

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -523,7 +523,7 @@ core:
       not_found_message: The requested resource was not found.
       permission_denied_message: You do not have permission to do that.
       rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.
-      render_failed_message: The formatter was unable to format this content due to an error. Please check the Flarum error logs for more information.
+      render_failed_message: Sorry, we encountered an error while displaying this content. If you're a user, please try again later. If you're an administrator, take a look in your Flarum log files for more information.
 
     # These translations are used in the loading indicator component.
     loading_indicator:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -523,6 +523,7 @@ core:
       not_found_message: The requested resource was not found.
       permission_denied_message: You do not have permission to do that.
       rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.
+      render_failed_message: The formatter was unable to format this content due to an error. Please check the Flarum error logs for more information.
 
     # These translations are used in the loading indicator component.
     loading_indicator:

--- a/src/Api/Serializer/BasicPostSerializer.php
+++ b/src/Api/Serializer/BasicPostSerializer.php
@@ -19,6 +19,21 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class BasicPostSerializer extends AbstractSerializer
 {
     /**
+     * @var LogReporter
+     */
+    protected $log;
+    
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    public function __construct(LogReporter $log, TranslatorInterface $translator)
+    {
+        $this->log = $log;
+        $this->translator = $translator;
+    }
+    /**
      * {@inheritdoc}
      */
     protected $type = 'posts';
@@ -48,8 +63,8 @@ class BasicPostSerializer extends AbstractSerializer
                 $attributes['contentHtml'] = $post->formatContent($this->request);
                 $attributes['renderFailed'] = false;
             } catch (Exception $e) {
-                $attributes['contentHtml'] = resolve(TranslatorInterface::class)->trans('core.lib.error.render_failed_message');
-                resolve(LogReporter::class)->report($e);
+                $attributes['contentHtml'] = $this->translator->trans('core.lib.error.render_failed_message');
+                $this->log->report($e);
                 $attributes['renderFailed'] = true;
             }
         } else {

--- a/src/Api/Serializer/BasicPostSerializer.php
+++ b/src/Api/Serializer/BasicPostSerializer.php
@@ -22,7 +22,7 @@ class BasicPostSerializer extends AbstractSerializer
      * @var LogReporter
      */
     protected $log;
-    
+
     /**
      * @var TranslatorInterface
      */

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -116,6 +116,7 @@ class Formatter
             return $renderer->render($xml);
         } catch (Exception $e) {
             resolve(LogReporter::class)->report($e);
+
             return resolve(TranslatorInterface::class)->trans('core.lib.error.render_failed_message');
         }
     }

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -107,19 +107,13 @@ class Formatter
      */
     public function render($xml, $context = null, ServerRequestInterface $request = null)
     {
-        try {
-            $renderer = $this->getRenderer();
+        $renderer = $this->getRenderer();
 
-            foreach ($this->renderingCallbacks as $callback) {
-                $xml = $callback($renderer, $context, $xml, $request);
-            }
-
-            return $renderer->render($xml);
-        } catch (Exception $e) {
-            resolve(LogReporter::class)->report($e);
-
-            return resolve(TranslatorInterface::class)->trans('core.lib.error.render_failed_message');
+        foreach ($this->renderingCallbacks as $callback) {
+            $xml = $callback($renderer, $context, $xml, $request);
         }
+
+        return $renderer->render($xml);
     }
 
     /**

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -10,6 +10,7 @@
 namespace Flarum\Formatter;
 
 use Exception;
+use Flarum\Foundation\ErrorHandling\LogReporter;
 use Illuminate\Contracts\Cache\Repository;
 use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Configurator;

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -9,13 +9,10 @@
 
 namespace Flarum\Formatter;
 
-use Exception;
-use Flarum\Foundation\ErrorHandling\LogReporter;
 use Illuminate\Contracts\Cache\Repository;
 use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Configurator;
 use s9e\TextFormatter\Unparser;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Formatter
 {

--- a/tests/integration/api/posts/ShowTest.php
+++ b/tests/integration/api/posts/ShowTest.php
@@ -12,7 +12,6 @@ namespace Flarum\Tests\integration\api\posts;
 use Carbon\Carbon;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
-use Illuminate\Support\Arr;
 
 class ShowTest extends TestCase
 {

--- a/tests/integration/api/posts/ShowTest.php
+++ b/tests/integration/api/posts/ShowTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\posts;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Support\Arr;
+
+class ShowTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'discussions' => [
+                ['id' => 1, 'title' => 'Discussion with post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>valid</p></t>'],
+                ['id' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<tMALFORMED'],
+            ],
+            'users' => [
+                $this->normalUser(),
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function properly_formatted_post_rendered_correctly()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts/1', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = (string) $response->getBody();
+        $this->assertJson($body);
+
+        $data = json_decode($body, true);
+
+        $this->assertEquals($data['data']['attributes']['contentHtml'], '<p>valid</p>');
+    }
+
+    /**
+     * @test
+     */
+    public function malformed_post_caught_by_renderer()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts/2', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = (string) $response->getBody();
+        $this->assertJson($body);
+
+        $data = json_decode($body, true);
+
+        $this->assertEquals("Sorry, we encountered an error while displaying this content. If you're a user, please try again later. If you're an administrator, take a look in your Flarum log files for more information.", $data['data']['attributes']['contentHtml']);
+    }
+}


### PR DESCRIPTION
**Fixes Part of flarum/issue-archive#85**

**Changes proposed in this pull request:**
Whether it's due to corrupted content, missing tags, caching issues, or other assorted reasons, post content can't be rendered. Currently, this results in an exception that crashes the entire forum and is hard to debug. Instead, we should log the error and show an indicator message that rendering has failed.

**Reviewers should focus on:**
Is the Formatter class level the best place to do this? I also considered handling it directly under the relevant `CommentPost` method. The main benefit of handling per-call-site is that we could include some metadata (like the post ID) in the error message. However, we'd need to handle every possible use case, which is expensive and isn't worth it IMO.

Also, any suggestions on better error text?

**Screenshots**

![image](https://user-images.githubusercontent.com/38059171/131401695-4010f2df-c81f-46d7-8ca1-d7bf5407dede.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
