### PR TITLE
Add config.php option not to boot extensions

### DIFF
--- a/js/src/common/Application.js
+++ b/js/src/common/Application.js
@@ -168,7 +168,9 @@ export default class Application {
   }
 
   boot() {
-    this.initializers.toArray().forEach((initializer) => initializer(this));
+    if (this.data.attributes.bootExtensions) {
+      this.initializers.toArray().forEach((initializer) => initializer(this));
+    }
 
     this.store.pushPayload({ data: this.data.resources });
 

--- a/src/Api/Serializer/ForumSerializer.php
+++ b/src/Api/Serializer/ForumSerializer.php
@@ -77,6 +77,7 @@ class ForumSerializer extends AbstractSerializer
             'baseUrl' => $url = $this->url->to('forum')->base(),
             'basePath' => parse_url($url, PHP_URL_PATH) ?: '',
             'debug' => $this->config->inDebugMode(),
+            'bootExtensions' => $this->config->bootExtensions(),
             'apiUrl' => $this->url->to('api')->base(),
             'welcomeTitle' => $this->settings->get('welcome_title'),
             'welcomeMessage' => $this->settings->get('welcome_message'),

--- a/src/Extension/ExtensionServiceProvider.php
+++ b/src/Extension/ExtensionServiceProvider.php
@@ -31,7 +31,7 @@ class ExtensionServiceProvider extends AbstractServiceProvider
         $this->container['flarum']->booting(function () {
             /** @var Config */
             $config = $this->container->make(Config::class);
-            
+
             if ($config->bootExtensions()) {
                 $this->container->make('flarum.extensions')->extend($this->container);
             }

--- a/src/Extension/ExtensionServiceProvider.php
+++ b/src/Extension/ExtensionServiceProvider.php
@@ -11,6 +11,7 @@ namespace Flarum\Extension;
 
 use Flarum\Extension\Event\Disabling;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Config;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class ExtensionServiceProvider extends AbstractServiceProvider
@@ -28,7 +29,12 @@ class ExtensionServiceProvider extends AbstractServiceProvider
         // below, so that extensions have a chance to register things on the
         // container before the core boots up (and starts resolving services).
         $this->container['flarum']->booting(function () {
-            $this->container->make('flarum.extensions')->extend($this->container);
+            /** @var Config */
+            $config = $this->container->make(Config::class);
+            
+            if ($config->bootExtensions()) {
+                $this->container->make('flarum.extensions')->extend($this->container);
+            }
         });
     }
 

--- a/src/Foundation/Config.php
+++ b/src/Foundation/Config.php
@@ -41,6 +41,11 @@ class Config implements ArrayAccess
     {
         return $this->data['offline'] ?? false;
     }
+    
+    public function bootExtensions(): bool
+    {
+        return $this->data['boot_extensions'] ?? true;
+    }
 
     private function requireKeys(...$keys)
     {

--- a/src/Foundation/Config.php
+++ b/src/Foundation/Config.php
@@ -41,7 +41,7 @@ class Config implements ArrayAccess
     {
         return $this->data['offline'] ?? false;
     }
-    
+
     public function bootExtensions(): bool
     {
         return $this->data['boot_extensions'] ?? true;


### PR DESCRIPTION
If the `boot_extensions` key is set to false, core will not boot any extensions in the backend, or run any initializers in the frontend. This allows admins to recover their forum without SSH access by disabling extension boot, going to the admin panel, and turning off offending extensions.

**Questions/Concerns for Reviewers**:

- Should we somehow signal to admins that this mode is enabled, possibly via alert? Otherwise, it might be confusing why extensions are indicated as enabled in the admin dashboard. This is challenging, as the alerts we currently have are in `content.blade.php`, and that view does not have access to payload/config.
- Should this require maintenance mode? If we disable all extensions (e.g. tags), some restricted discussions / content will immediately become public. This could lead to leaks via web scraping.