### PR TITLE
[2.0] feat!: use `ItemList` for the DiscussionListState sorting map

### DIFF
--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -217,34 +217,33 @@ export default class IndexPage extends Page {
    */
   viewItems() {
     const items = new ItemList();
-    const sortMap = app.discussions.sortMap();
 
-    const sortOptions = {};
-    for (const i in sortMap) {
-      sortOptions[i] = app.translator.trans('core.forum.index_sort.' + i + '_button');
-    }
+    const sortOptions = Object.values(app.discussions.sortMap().toObject());
+
+    // Chooses the sort option with highest priority for now
+    const defaultSortMethod = sortOptions.reduce((acc, option) => (acc.priority > option.priority ? acc : option), { priority: -9e10 });
+
+    // Find the selected search method, otherwise heed the default
+    const activeSearchMethod = sortOptions.find((opt) => opt.itemName === app.search.params().sort) || defaultSortMethod;
 
     items.add(
       'sort',
       Dropdown.component(
         {
           buttonClassName: 'Button',
-          label: sortOptions[app.search.params().sort] || Object.keys(sortMap).map((key) => sortOptions[key])[0],
+          label: app.translator.trans(`core.forum.index_sort.${activeSearchMethod.itemName}_button`),
           accessibleToggleLabel: app.translator.trans('core.forum.index_sort.toggle_dropdown_accessible_label'),
         },
-        Object.keys(sortOptions).map((value) => {
-          const label = sortOptions[value];
-          const active = (app.search.params().sort || Object.keys(sortMap)[0]) === value;
-
-          return Button.component(
+        sortOptions.map(({ itemName: sortingId, content: sortType }) =>
+          Button.component(
             {
               icon: active ? 'fas fa-check' : true,
-              onclick: app.search.changeSort.bind(app.search, value),
+              onclick: app.search.changeSort.bind(app.search, sortType),
               active: active,
             },
-            label
-          );
-        })
+            app.translator.trans(`core.forum.index_sort.${sortingId}_button`)
+          )
+        )
       )
     );
 

--- a/js/src/forum/states/DiscussionListState.ts
+++ b/js/src/forum/states/DiscussionListState.ts
@@ -1,6 +1,7 @@
 import app from '../../forum/app';
 import PaginatedListState, { Page } from '../../common/states/PaginatedListState';
 import Discussion from '../../common/models/Discussion';
+import ItemList from '../../common/utils/ItemList';
 
 export default class DiscussionListState extends PaginatedListState<Discussion> {
   protected extraDiscussions: Discussion[] = [];
@@ -45,21 +46,22 @@ export default class DiscussionListState extends PaginatedListState<Discussion> 
   }
 
   /**
-   * Get a map of sort keys (which appear in the URL, and are used for
+   * Get a list of sort keys (which appear in the URL, and are used for
    * translation) to the API sort value that they represent.
    */
-  sortMap() {
-    const map: any = {};
+  sortMap(): ItemList<string> {
+    const sortItems = new ItemList<string>();
 
     if (this.params.q) {
-      map.relevance = '';
+      sortItems.add('relevance', '', 100);
     }
-    map.latest = '-lastPostedAt';
-    map.top = '-commentCount';
-    map.newest = '-createdAt';
-    map.oldest = 'createdAt';
 
-    return map;
+    sortItems.add('latest', '-lastPostedAt', 80);
+    sortItems.add('top', '-commentCount', 60);
+    sortItems.add('newest', '-createdAt', 40);
+    sortItems.add('oldest', 'createdAt', 20);
+
+    return sortItems;
   }
 
   /**

--- a/js/src/forum/states/DiscussionListState.ts
+++ b/js/src/forum/states/DiscussionListState.ts
@@ -17,7 +17,7 @@ export default class DiscussionListState extends PaginatedListState<Discussion> 
   requestParams() {
     const params: any = { include: ['user', 'lastPostedUser'], filter: this.params.filter || {} };
 
-    params.sort = this.sortMap()[this.params.sort];
+    params.sort = this.sortMap().get(this.params.sort);
 
     if (this.params.q) {
       params.filter.q = this.params.q;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
It is currently very difficult to change the ordering of the discussion list sorting options. This change replaces the existing object map with an ItemList, allowing us to use priorities instead.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->


**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
