### PR TITLE
Calculate post number via subquery

### DIFF
--- a/src/Database/InsertsViaSubqueryTrait.php
+++ b/src/Database/InsertsViaSubqueryTrait.php
@@ -42,8 +42,9 @@ trait InsertsViaSubqueryTrait
         $insertRowSubquery = static::query()->limit(1);
 
         foreach ($literalAttributes as $attrName => $value) {
-            //! DANGER!!! Literal Injection Vuln!!!
-            $insertRowSubquery->selectRaw("'$value' as $attrName");
+            $parameter = $query->getGrammar()->parameter($value);
+            $insertRowSubquery->addBinding($value, 'select');
+            $insertRowSubquery->selectRaw("'$parameter' as $attrName");
         }
 
         foreach (static::$subqueryAttributes as $attrName => $callback) {

--- a/src/Database/InsertsViaSubqueryTrait.php
+++ b/src/Database/InsertsViaSubqueryTrait.php
@@ -62,5 +62,9 @@ trait InsertsViaSubqueryTrait
         $id = is_numeric($idRaw) ? (int) $idRaw : $idRaw;
 
         $this->setAttribute($keyName, $id);
+
+        // This is necessary to get the computed value of saved attributes.
+        $this->exists = true;
+        $this->refresh();
     }
 }

--- a/src/Database/InsertsViaSubqueryTrait.php
+++ b/src/Database/InsertsViaSubqueryTrait.php
@@ -17,14 +17,14 @@ trait InsertsViaSubqueryTrait
     /**
      * A list that maps attribute names to callables that produce subqueries
      * used to calculate the inserted value.
-     * 
+     *
      * Each callable should take an instance of the model being saved,
      * and return an Eloquent query builder that queries for the subquery
      * generated value. The result of the query should be one row of one column.
-     * 
+     *
      * Subquery attributes should be added in the static `boot` method of models
      * using this trait.
-     * 
+     *
      * @var array<string, callable(AbstractModel): Builder>
      */
     protected static $subqueryAttributes = [];
@@ -63,5 +63,4 @@ trait InsertsViaSubqueryTrait
 
         $this->setAttribute($keyName, $id);
     }
-
 }

--- a/src/Database/InsertsViaSubqueryTrait.php
+++ b/src/Database/InsertsViaSubqueryTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Database;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\MySqlConnection;
+
+trait InsertsViaSubqueryTrait
+{
+    /**
+     * A list that maps attribute names to callables that produce subqueries
+     * used to calculate the inserted value.
+     * 
+     * Each callable should take an instance of the model being saved,
+     * and return an Eloquent query builder that queries for the subquery
+     * generated value. The result of the query should be one row of one column.
+     * 
+     * Subquery attributes should be added in the static `boot` method of models
+     * using this trait.
+     * 
+     * @var array<string, callable(AbstractModel): Builder>
+     */
+    protected static $subqueryAttributes = [];
+
+    /**
+     * Overriden so that some fields can be inserted via subquery.
+     */
+    protected function insertAndSetId(Builder $query, $attributes)
+    {
+        $subqueryAttrNames = array_keys(static::$subqueryAttributes);
+
+        $literalAttributes = array_diff_key($attributes, array_flip($subqueryAttrNames));
+
+        /** @var Builder */
+        $insertRowSubquery = static::query()->limit(1);
+
+        foreach ($literalAttributes as $attrName => $value) {
+            //! DANGER!!! Literal Injection Vuln!!!
+            $insertRowSubquery->selectRaw("'$value' as $attrName");
+        }
+
+        foreach (static::$subqueryAttributes as $attrName => $callback) {
+            $insertRowSubquery->selectSub($callback($this), $attrName);
+        }
+
+        $attrNames = array_merge(array_keys($literalAttributes), $subqueryAttrNames);
+
+        $query->insertUsing($attrNames, $insertRowSubquery);
+
+        // This should be safe, as it's the same mechanism used by Laravel's `insertGetId`.
+        // See https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Query/Processors/Processor.php#L30-L37.
+        /** @var MySqlConnection */
+        $con = $query->getQuery()->getConnection();
+        $idRaw = $con->getPdo()->lastInsertId($keyName = $this->getKeyName());
+        $id = is_numeric($idRaw) ? (int) $idRaw : $idRaw;
+
+        $this->setAttribute($keyName, $id);
+    }
+
+}

--- a/src/Discussion/Discussion.php
+++ b/src/Discussion/Discussion.php
@@ -30,7 +30,6 @@ use Illuminate\Support\Str;
  * @property string $slug
  * @property int $comment_count
  * @property int $participant_count
- * @property int $post_number_index
  * @property \Carbon\Carbon $created_at
  * @property int|null $user_id
  * @property int|null $first_post_id

--- a/src/Post/Command/PostReplyHandler.php
+++ b/src/Post/Command/PostReplyHandler.php
@@ -74,7 +74,7 @@ class PostReplyHandler
 
         // If this is the first post in the discussion, it's technically not a
         // "reply", so we won't check for that permission.
-        if ($discussion->post_number_index > 0) {
+        if ($discussion->first_post_id !== null) {
             $actor->assertCan('reply', $discussion);
         }
 

--- a/src/Post/Post.php
+++ b/src/Post/Post.php
@@ -104,8 +104,8 @@ class Post extends AbstractModel
 
         static::addGlobalScope(new RegisteredTypesScope);
 
-        static::$subqueryAttributes['number'] = function(Post $post) {
-            return static::query()->where('discussion_id', $post->discussion_id)->selectRaw("max(number)+1");
+        static::$subqueryAttributes['number'] = function (Post $post) {
+            return static::query()->where('discussion_id', $post->discussion_id)->selectRaw('max(number)+1');
         };
     }
 

--- a/src/Post/Post.php
+++ b/src/Post/Post.php
@@ -105,11 +105,11 @@ class Post extends AbstractModel
     }
 
     /**
-     * We override this so that we can use custom logic to 
+     * We override this so that we can use custom logic to.
      */
     protected function insertAndSetId(Builder $query, $attributes)
     {
-        $attrsNoNumber = array_filter($attributes, function($key) {
+        $attrsNoNumber = array_filter($attributes, function ($key) {
             return $key !== 'number';
         }, ARRAY_FILTER_USE_KEY);
 


### PR DESCRIPTION
Very WIP

**Fixes flarum/framework#3350**

TODO:
- Fix the very egregious injection vuln
- Inspect the generated SQL query manually
- Deprecate `post_number_index` column on Discussion table.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
