### PR TITLE
[2.0] Solve php8.1 Deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, '8.0', 8.1]
+        php: ['8.0', 8.1]
         service: ['mysql:5.7', mariadb]
         prefix: ['', flarum_]
 
@@ -21,12 +21,6 @@ jobs:
             prefixStr: (prefix)
 
         exclude:
-          - php: 7.3
-            service: 'mysql:5.7'
-            prefix: flarum_
-          - php: 7.3
-            service: mariadb
-            prefix: flarum_
           - php: 8.0
             service: 'mysql:5.7'
             prefix: flarum_

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
           extensions: curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip
           tools: phpunit, composer:v2
 
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
       # The authentication alter is necessary because newer mysql versions use the `caching_sha2_password` driver,
       # which isn't supported prior to PHP7.4
       # When we drop support for PHP7.3, we should remove this from the setup.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,7 @@ jobs:
           coverage: xdebug
           extensions: curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip
           tools: phpunit, composer:v2
-
-      - name: Setup problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+          ini-values: error_reporting=E_ALL
 
       # The authentication alter is necessary because newer mysql versions use the `caching_sha2_password` driver,
       # which isn't supported prior to PHP7.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, '8.0', '8.1']
+        php: [7.3, 7.4, '8.0', 8.1]
         service: ['mysql:5.7', mariadb]
         prefix: ['', flarum_]
 
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@0b9d33cd0782337377999751fc10ea079fdd7104 # pin@v2
+        uses: shivammathur/setup-php@15b20027cf4e61cb21f2582a8f125cafb1c0492e # pin@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "chat": "https://flarum.org/chat"
     },
     "require": {
-        "php": ">=7.3",
+        "php": "^8.0",
         "axy/sourcemap": "^0.1.4",
         "components/font-awesome": "^5.14.0",
         "dflydev/fig-cookies": "^3.0.0",

--- a/src/Foundation/Config.php
+++ b/src/Foundation/Config.php
@@ -53,22 +53,22 @@ class Config implements ArrayAccess
         }
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return Arr::get($this->data, $offset);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return Arr::has($this->data, $offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new RuntimeException('The Config is immutable');
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new RuntimeException('The Config is immutable');
     }


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Updates our php minimum requirement to php 8.0, necessary to solve the deprecations.

The following packages also need to be updated:
* [ ] tobscure/json-api-php
* [ ] axy/sourcemap

**Reviewers should focus on:**
this is just a wip

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
