### PR TITLE
feat: Add delete all notifications option

### DIFF
--- a/js/src/forum/components/NotificationList.js
+++ b/js/src/forum/components/NotificationList.js
@@ -6,6 +6,7 @@ import Link from '../../common/components/Link';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Discussion from '../../common/models/Discussion';
 import ItemList from '../../common/utils/ItemList';
+import Tooltip from '../../common/components/Tooltip';
 
 /**
  * The `NotificationList` component displays a list of the logged-in user's
@@ -34,13 +35,34 @@ export default class NotificationList extends Component {
 
     items.add(
       'mark_all_as_read',
-      <Button
-        className="Button Button--link"
-        icon="fas fa-check"
-        title={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')}
-        onclick={state.markAllAsRead.bind(state)}
-      />,
+      <Tooltip text={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')}>
+        <Button
+          className="Button Button--link"
+          data-container=".NotificationList"
+          icon="fas fa-check"
+          title={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')}
+          onclick={state.markAllAsRead.bind(state)}
+        />
+      </Tooltip>,
       70
+    );
+
+    items.add(
+      'delete_all',
+      <Tooltip text={app.translator.trans('core.forum.notifications.delete_all_tooltip')}>
+        <Button
+          className="Button Button--link"
+          data-container=".NotificationList"
+          icon="fas fa-trash-alt"
+          title={app.translator.trans('core.forum.notifications.delete_all_tooltip')}
+          onclick={() => {
+            if (confirm(app.translator.trans('core.forum.notifications.delete_all_confirm'))) {
+              state.deleteAll.call(state);
+            }
+          }}
+        />
+      </Tooltip>,
+      50
     );
 
     return items;

--- a/js/src/forum/states/NotificationListState.ts
+++ b/js/src/forum/states/NotificationListState.ts
@@ -59,7 +59,7 @@ export default class NotificationListState extends PaginatedListState<Notificati
 
     return app.request({
       url: app.forum.attribute('apiUrl') + '/notifications/delete',
-      method: 'POST',
+      method: 'DELETE',
     });
   }
 }

--- a/js/src/forum/states/NotificationListState.ts
+++ b/js/src/forum/states/NotificationListState.ts
@@ -46,4 +46,20 @@ export default class NotificationListState extends PaginatedListState<Notificati
       method: 'POST',
     });
   }
+
+  /**
+   * Delete all of the notifications for this user.
+   */
+  deleteAll() {
+    if (this.pages.length === 0) return;
+
+    app.session.user?.pushAttributes({ unreadNotificationCount: 0 });
+
+    this.pages = [];
+
+    return app.request({
+      url: app.forum.attribute('apiUrl') + '/notifications/delete',
+      method: 'POST',
+    });
+  }
 }

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -1,6 +1,10 @@
 .NotificationList {
   overflow: hidden;
 
+  .App-primaryControl > button:not(:last-of-type) {
+    margin-right: 4px;
+  }
+
   &-header {
     @media @tablet-up {
       padding: 12px 15px;

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -393,6 +393,8 @@ core:
 
     # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
+      delete_all_confirm: Are you sure you want to delete all notifications? This action is not reversable
+      delete_all_tooltip: Delete all notifications
       discussion_renamed_text: "{username} changed the title"
       empty_text: No Notifications
       mark_all_as_read_tooltip: => core.ref.mark_all_as_read

--- a/src/Api/Controller/DeleteAllNotificationsController.php
+++ b/src/Api/Controller/DeleteAllNotificationsController.php
@@ -14,7 +14,7 @@ use Flarum\Notification\Command\DeleteAllNotifications;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ReadAllNotificationsController extends AbstractDeleteController
+class DeleteAllNotificationsController extends AbstractDeleteController
 {
     /**
      * @var Dispatcher

--- a/src/Api/Controller/ReadAllNotificationsController.php
+++ b/src/Api/Controller/ReadAllNotificationsController.php
@@ -10,7 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Http\RequestUtil;
-use Flarum\Notification\Command\DeleteAllNotifications;
+use Flarum\Notification\Command\ReadAllNotifications;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -35,7 +35,7 @@ class ReadAllNotificationsController extends AbstractDeleteController
     protected function delete(ServerRequestInterface $request)
     {
         $this->bus->dispatch(
-            new DeleteAllNotifications(RequestUtil::getActor($request))
+            new ReadAllNotifications(RequestUtil::getActor($request))
         );
     }
 }

--- a/src/Api/routes.php
+++ b/src/Api/routes.php
@@ -122,6 +122,13 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\UpdateNotificationController::class)
     );
 
+    // Delete all notifications for the current user.
+    $map->post(
+        '/notifications/delete',
+        'notifications.deleteAll',
+        $route->toController(Controller\DeleteAllNotificationsController::class)
+    );
+
     /*
     |--------------------------------------------------------------------------
     | Discussions

--- a/src/Api/routes.php
+++ b/src/Api/routes.php
@@ -123,7 +123,7 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
     );
 
     // Delete all notifications for the current user.
-    $map->post(
+    $map->delete(
         '/notifications/delete',
         'notifications.deleteAll',
         $route->toController(Controller\DeleteAllNotificationsController::class)

--- a/src/Notification/Command/DeleteAllNotifications.php
+++ b/src/Notification/Command/DeleteAllNotifications.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Command;
+
+use Flarum\User\User;
+
+class DeleteAllNotifications
+{
+    /**
+     * The user performing the action.
+     *
+     * @var User
+     */
+    public $actor;
+
+    /**
+     * @param User $actor The user performing the action.
+     */
+    public function __construct(User $actor)
+    {
+        $this->actor = $actor;
+    }
+}

--- a/src/Notification/Command/DeleteAllNotificationsHandler.php
+++ b/src/Notification/Command/DeleteAllNotificationsHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Command;
+
+use Flarum\Notification\Event\DeletedAll;
+use Flarum\Notification\NotificationRepository;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Carbon;
+
+class DeleteAllNotificationsHandler
+{
+    /**
+     * @var NotificationRepository
+     */
+    protected $notifications;
+
+    /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
+     * @param NotificationRepository $notifications
+     * @param Dispatcher $events
+     */
+    public function __construct(NotificationRepository $notifications, Dispatcher $events)
+    {
+        $this->notifications = $notifications;
+        $this->events = $events;
+    }
+
+    /**
+     * @param DeleteAllNotifications $command
+     * @throws \Flarum\User\Exception\PermissionDeniedException
+     */
+    public function handle(DeleteAllNotifications $command)
+    {
+        $actor = $command->actor;
+
+        $actor->assertRegistered();
+
+        $this->notifications->deleteAll($actor);
+
+        $this->events->dispatch(new DeletedAll($actor, Carbon::now()));
+    }
+}

--- a/src/Notification/Event/DeletedAll.php
+++ b/src/Notification/Event/DeletedAll.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Event;
+
+use DateTime;
+use Flarum\User\User;
+
+class DeletedAll
+{
+    /**
+     * @var User
+     */
+    public $actor;
+
+    /**
+     * @var DateTime
+     */
+    public $timestamp;
+
+    public function __construct(User $user, DateTime $timestamp)
+    {
+        $this->user = $user;
+        $this->timestamp = $timestamp;
+    }
+}

--- a/src/Notification/NotificationRepository.php
+++ b/src/Notification/NotificationRepository.php
@@ -54,4 +54,9 @@ class NotificationRepository
             ->whereNull('read_at')
             ->update(['read_at' => Carbon::now()]);
     }
+
+    public function deleteAll(User $user)
+    {
+        Notification::where('user_id', $user->id)->delete();
+    }
 }


### PR DESCRIPTION
Depends on https://github.com/flarum/core/pull/3203

**Changes proposed in this pull request:**
Using the existing convention for marking all notifications as read, this PR proposes an additional option to delete all notifications as well.

Additionally, adds a `Tooltip` to the existing `Mark as Read` button for better clarity

**Screenshot**
![image](https://user-images.githubusercontent.com/16573496/146103504-f711c209-db4f-4958-b0c6-f29f82851e20.png)
![image](https://user-images.githubusercontent.com/16573496/146103528-aac305fa-6f1e-475d-b653-9d0914d78478.png)

![image](https://user-images.githubusercontent.com/16573496/146102966-9f7f5dc9-9acd-4e79-8ddc-1daea5b28d70.png)
![image](https://user-images.githubusercontent.com/16573496/146103008-7e043997-0dba-4317-aee0-9cca838e567d.png)



**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
