### PR TITLE
fix: Add a11y labels to auth modal inputs

### DIFF
--- a/js/src/forum/components/ForgotPasswordModal.tsx
+++ b/js/src/forum/components/ForgotPasswordModal.tsx
@@ -52,6 +52,8 @@ export default class ForgotPasswordModal<CustomAttrs extends IForgotPasswordModa
       );
     }
 
+    const emailLabel = extractText(app.translator.trans('core.forum.forgot_password.email_placeholder'));
+
     return (
       <div className="Modal-body">
         <div className="Form Form--centered">
@@ -61,7 +63,8 @@ export default class ForgotPasswordModal<CustomAttrs extends IForgotPasswordModa
               className="FormControl"
               name="email"
               type="email"
-              placeholder={extractText(app.translator.trans('core.forum.forgot_password.email_placeholder'))}
+              placeholder={emailLabel}
+              aria-label={emailLabel}
               bidi={this.email}
               disabled={this.loading}
             />

--- a/js/src/forum/components/LogInModal.tsx
+++ b/js/src/forum/components/LogInModal.tsx
@@ -57,6 +57,9 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
   fields() {
     const items = new ItemList();
 
+    const identificationLabel = extractText(app.translator.trans('core.forum.log_in.username_or_email_placeholder'));
+    const passwordLabel = extractText(app.translator.trans('core.forum.log_in.password_placeholder'));
+
     items.add(
       'identification',
       <div className="Form-group">
@@ -64,7 +67,8 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
           className="FormControl"
           name="identification"
           type="text"
-          placeholder={extractText(app.translator.trans('core.forum.log_in.username_or_email_placeholder'))}
+          placeholder={identificationLabel}
+          aria-label={identificationLabel}
           bidi={this.identification}
           disabled={this.loading}
         />
@@ -80,7 +84,8 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
           name="password"
           type="password"
           autocomplete="current-password"
-          placeholder={extractText(app.translator.trans('core.forum.log_in.password_placeholder'))}
+          placeholder={passwordLabel}
+          aria-label={passwordLabel}
           bidi={this.password}
           disabled={this.loading}
         />

--- a/js/src/forum/components/SignUpModal.tsx
+++ b/js/src/forum/components/SignUpModal.tsx
@@ -68,6 +68,10 @@ export default class SignUpModal<CustomAttrs extends ISignupModalAttrs = ISignup
   fields() {
     const items = new ItemList();
 
+    const usernameLabel = extractText(app.translator.trans('core.forum.sign_up.username_placeholder'));
+    const emailLabel = extractText(app.translator.trans('core.forum.sign_up.email_placeholder'));
+    const passwordLabel = extractText(app.translator.trans('core.forum.sign_up.password_placeholder'));
+
     items.add(
       'username',
       <div className="Form-group">
@@ -75,7 +79,8 @@ export default class SignUpModal<CustomAttrs extends ISignupModalAttrs = ISignup
           className="FormControl"
           name="username"
           type="text"
-          placeholder={extractText(app.translator.trans('core.forum.sign_up.username_placeholder'))}
+          placeholder={usernameLabel}
+          aria-label={usernameLabel}
           bidi={this.username}
           disabled={this.loading || this.isProvided('username')}
         />
@@ -90,7 +95,8 @@ export default class SignUpModal<CustomAttrs extends ISignupModalAttrs = ISignup
           className="FormControl"
           name="email"
           type="email"
-          placeholder={extractText(app.translator.trans('core.forum.sign_up.email_placeholder'))}
+          placeholder={emailLabel}
+          aria-label={emailLabel}
           bidi={this.email}
           disabled={this.loading || this.isProvided('email')}
         />
@@ -107,7 +113,8 @@ export default class SignUpModal<CustomAttrs extends ISignupModalAttrs = ISignup
             name="password"
             type="password"
             autocomplete="new-password"
-            placeholder={extractText(app.translator.trans('core.forum.sign_up.password_placeholder'))}
+            placeholder={passwordLabel}
+            aria-label={passwordLabel}
             bidi={this.password}
             disabled={this.loading}
           />


### PR DESCRIPTION
**Part of flarum/framework#3360**

**Changes proposed in this pull request:**
Adds aria labels to auth modal inputs which only have placeholders.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
