### PR TITLE
fix: `classes` function including empty strings

### DIFF
--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -132,7 +132,9 @@ export default class Post extends Component {
       'Post--loading': this.loading,
       'Post--by-actor': user === app.session.user,
       'Post--by-start-user': user?.id() === discussion.attribute('startUserId'),
-    }).split(' ').filter(x => !!x);
+    })
+      .split(' ')
+      .filter((x) => !!x);
   }
 
   /**

--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -6,6 +6,7 @@ import PostControls from '../utils/PostControls';
 import listItems from '../../common/helpers/listItems';
 import ItemList from '../../common/utils/ItemList';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
+import classList from '../../common/utils/classList';
 
 /**
  * The `Post` component displays a single post. The basic post template just
@@ -124,27 +125,14 @@ export default class Post extends Component {
    * @returns {string[]}
    */
   classes(existing) {
-    const classes = (existing || '')
-      .split(' ')
-      .filter((x) => x.trim() !== '')
-      .concat(['Post']);
-
     const user = this.attrs.post.user();
     const discussion = this.attrs.post.discussion();
 
-    if (this.loading) {
-      classes.push('Post--loading');
-    }
-
-    if (user && user === app.session.user) {
-      classes.push('Post--by-actor');
-    }
-
-    if (user && user.id() === discussion.attribute('startUserId')) {
-      classes.push('Post--by-start-user');
-    }
-
-    return classes;
+    return classList(existing, 'Post', {
+      'Post--loading': this.loading,
+      'Post--by-actor': user === app.session.user,
+      'Post--by-start-user': user?.id() === discussion.attribute('startUserId'),
+    });
   }
 
   /**

--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -132,7 +132,7 @@ export default class Post extends Component {
       'Post--loading': this.loading,
       'Post--by-actor': user === app.session.user,
       'Post--by-start-user': user?.id() === discussion.attribute('startUserId'),
-    });
+    }).split(' ').filter(x => !!x);
   }
 
   /**

--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -124,7 +124,10 @@ export default class Post extends Component {
    * @returns {string[]}
    */
   classes(existing) {
-    let classes = (existing || '').split(' ').concat(['Post']);
+    const classes = (existing || '')
+      .split(' ')
+      .filter((x) => x.trim() !== '')
+      .concat(['Post']);
 
     const user = this.attrs.post.user();
     const discussion = this.attrs.post.discussion();


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
If the existing classes passed has one or more spaces in a row (e.g. `MyCoolPost   MyCoolPost--megaCool`), then the `classes` array would fill up with empty strings (e.g. `['MyCoolPost', '', '', 'MyCoolPost--megaCool']`) despite these not actually being classes.

This PR filters out empty strings from the array to prevent this.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
