### PR TITLE
chore: remove unneeded CSS vendor prefixes

### DIFF
--- a/less/admin/PermissionsPage.less
+++ b/less/admin/PermissionsPage.less
@@ -50,7 +50,6 @@
     color: var(--muted-color);
   }
   thead th {
-    position: -webkit-sticky;
     position: sticky;
     top: 0;
     padding-bottom: 10px;
@@ -74,7 +73,6 @@
   }
   tbody {
     th {
-      position: -webkit-sticky;
       position: sticky;
       left: 0;
       padding-right: 50px;

--- a/less/common/App.less
+++ b/less/common/App.less
@@ -27,16 +27,13 @@
       box-shadow: 0 2px 6px var(--shadow-color);
     }
   }
-  .App-primaryControl,
-  .App-titleControl,
-  .App-backControl {
+  .App-primaryControl, .App-titleControl, .App-backControl {
     position: absolute !important;
     z-index: calc(~"var(--zindex-header) + 1");
     top: 0 !important;
     margin: 0;
 
-    .App.affix &,
-    .Composer & {
+    .App.affix &, .Composer & {
       position: fixed !important;
     }
 
@@ -62,18 +59,15 @@
     right: 0;
 
     &.Dropdown {
-      .Button,
-      .Button-caret {
+      .Button, .Button-caret {
         display: none !important;
       }
-      .Dropdown-toggle,
-      .Button-icon {
+      .Dropdown-toggle, .Button-icon {
         display: block !important;
       }
     }
   }
-  .App-primaryControl,
-  .App-backControl {
+  .App-primaryControl, .App-backControl {
     margin: 0 !important;
 
     > .Button {
@@ -96,8 +90,7 @@
     text-align: center;
     color: var(--header-color) !important;
 
-    &,
-    > .Button {
+    &, > .Button {
       font-size: 16px;
     }
     > .Button {
@@ -206,15 +199,12 @@
     > li {
       padding: 0 10px 0;
     }
-    .FormControl,
-    .ButtonGroup,
-    .Button {
+    .FormControl, .ButtonGroup, .Button {
       width: 100%;
       text-align: left;
     }
     .Dropdown-menu {
-      .ButtonGroup,
-      .Button {
+      .ButtonGroup, .Button {
         width: auto;
       }
     }
@@ -230,7 +220,7 @@
 @media @phone {
   .App-drawer {
     & when (@config-colored-header = true) {
-      .light-contents(@name: "header-colored");
+      .light-contents(@name: 'header-colored');
     }
   }
 }
@@ -254,7 +244,7 @@
     }
 
     & when (@config-colored-header = true) {
-      .light-contents(@name: "header-colored");
+      .light-contents(@name: 'header-colored');
     }
   }
 
@@ -263,8 +253,7 @@
     margin-right: 25px;
   }
   .Header-controls {
-    &,
-    > li {
+    &, > li {
       display: inline-block;
       vertical-align: middle;
     }

--- a/less/common/App.less
+++ b/less/common/App.less
@@ -27,13 +27,16 @@
       box-shadow: 0 2px 6px var(--shadow-color);
     }
   }
-  .App-primaryControl, .App-titleControl, .App-backControl {
+  .App-primaryControl,
+  .App-titleControl,
+  .App-backControl {
     position: absolute !important;
     z-index: calc(~"var(--zindex-header) + 1");
     top: 0 !important;
     margin: 0;
 
-    .App.affix &, .Composer & {
+    .App.affix &,
+    .Composer & {
       position: fixed !important;
     }
 
@@ -59,15 +62,18 @@
     right: 0;
 
     &.Dropdown {
-      .Button, .Button-caret {
+      .Button,
+      .Button-caret {
         display: none !important;
       }
-      .Dropdown-toggle, .Button-icon {
+      .Dropdown-toggle,
+      .Button-icon {
         display: block !important;
       }
     }
   }
-  .App-primaryControl, .App-backControl {
+  .App-primaryControl,
+  .App-backControl {
     margin: 0 !important;
 
     > .Button {
@@ -90,7 +96,8 @@
     text-align: center;
     color: var(--header-color) !important;
 
-    &, > .Button {
+    &,
+    > .Button {
       font-size: 16px;
     }
     > .Button {
@@ -142,8 +149,7 @@
     z-index: var(--zindex-modal);
 
     .drawerOpen & {
-      -webkit-transform: none !important;
-              transform: none !important;
+      transform: none !important;
     }
   }
   .drawer-backdrop {
@@ -200,12 +206,15 @@
     > li {
       padding: 0 10px 0;
     }
-    .FormControl, .ButtonGroup, .Button {
+    .FormControl,
+    .ButtonGroup,
+    .Button {
       width: 100%;
       text-align: left;
     }
     .Dropdown-menu {
-      .ButtonGroup, .Button {
+      .ButtonGroup,
+      .Button {
         width: auto;
       }
     }
@@ -221,7 +230,7 @@
 @media @phone {
   .App-drawer {
     & when (@config-colored-header = true) {
-      .light-contents(@name: 'header-colored');
+      .light-contents(@name: "header-colored");
     }
   }
 }
@@ -245,7 +254,7 @@
     }
 
     & when (@config-colored-header = true) {
-      .light-contents(@name: 'header-colored');
+      .light-contents(@name: "header-colored");
     }
   }
 
@@ -254,7 +263,8 @@
     margin-right: 25px;
   }
   .Header-controls {
-    &, > li {
+    &,
+    > li {
       display: inline-block;
       vertical-align: middle;
     }

--- a/less/common/Dropdown.less
+++ b/less/common/Dropdown.less
@@ -24,7 +24,9 @@
   }
 
   > li {
-    > a, > button, > span {
+    > a,
+    > button,
+    > span {
       padding: 8px 15px;
       display: block;
       width: 100%;
@@ -59,13 +61,15 @@
         background: none !important;
       }
     }
-    > a, > button {
+    > a,
+    > button {
       &:hover {
         background: var(--control-bg);
       }
     }
     &.active {
-      > a, > button {
+      > a,
+      > button {
         background: var(--control-bg);
       }
     }
@@ -100,7 +104,6 @@
   height: 1px;
 }
 
-
 .dropdown-backdrop {
   position: fixed;
   left: 0;
@@ -109,7 +112,6 @@
   top: 0;
   z-index: calc(~"var(--zindex-dropdown) - 10");
 }
-
 
 .Dropdown--split {
   .Dropdown-toggle .Button-icon {
@@ -131,7 +133,8 @@
 
   @media @tablet-up {
     .Dropdown-menu li:first-child {
-      &, + li.Dropdown-separator {
+      &,
+      + li.Dropdown-separator {
         display: none;
       }
     }
@@ -156,7 +159,6 @@
   }
 }
 
-
 @media @phone {
   .Dropdown.open {
     z-index: var(--zindex-modal);
@@ -177,12 +179,12 @@
     box-shadow: 0 2px 6px var(--shadow-color);
     visibility: hidden;
     overflow: auto;
-    -webkit-overflow-scrolling: touch;
     transform: translate(0, 70vh);
     transition: transform 0.3s, visibility 0s 0.3s;
 
     > li {
-      > a, > button {
+      > a,
+      > button {
         background: var(--body-bg);
         font-size: 16px;
         padding: 15px 20px;
@@ -200,16 +202,17 @@
       }
     }
     > .active {
-      > a, > button {
-        &, &:hover {
+      > a,
+      > button {
+        &,
+        &:hover {
           background: var(--primary-color) !important;
           color: #fff !important;
         }
       }
     }
     .open& {
-      -webkit-transform: none;
-              transform: none;
+      transform: none;
       visibility: visible;
       transition-delay: 0s;
     }

--- a/less/common/Dropdown.less
+++ b/less/common/Dropdown.less
@@ -24,9 +24,7 @@
   }
 
   > li {
-    > a,
-    > button,
-    > span {
+    > a, > button, > span {
       padding: 8px 15px;
       display: block;
       width: 100%;
@@ -61,15 +59,13 @@
         background: none !important;
       }
     }
-    > a,
-    > button {
+    > a, > button {
       &:hover {
         background: var(--control-bg);
       }
     }
     &.active {
-      > a,
-      > button {
+      > a, > button {
         background: var(--control-bg);
       }
     }
@@ -104,6 +100,7 @@
   height: 1px;
 }
 
+
 .dropdown-backdrop {
   position: fixed;
   left: 0;
@@ -112,6 +109,7 @@
   top: 0;
   z-index: calc(~"var(--zindex-dropdown) - 10");
 }
+
 
 .Dropdown--split {
   .Dropdown-toggle .Button-icon {
@@ -133,8 +131,7 @@
 
   @media @tablet-up {
     .Dropdown-menu li:first-child {
-      &,
-      + li.Dropdown-separator {
+      &, + li.Dropdown-separator {
         display: none;
       }
     }
@@ -158,6 +155,7 @@
     box-shadow: none;
   }
 }
+
 
 @media @phone {
   .Dropdown.open {
@@ -183,8 +181,7 @@
     transition: transform 0.3s, visibility 0s 0.3s;
 
     > li {
-      > a,
-      > button {
+      > a, > button {
         background: var(--body-bg);
         font-size: 16px;
         padding: 15px 20px;
@@ -202,10 +199,8 @@
       }
     }
     > .active {
-      > a,
-      > button {
-        &,
-        &:hover {
+      > a, > button {
+        &, &:hover {
           background: var(--primary-color) !important;
           color: #fff !important;
         }

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -33,7 +33,6 @@
   bottom: 0;
   left: 0;
   z-index: var(--zindex-modal);
-  -webkit-overflow-scrolling: touch;
 
   // When fading in the modal, animate it to slide down
   .Modal {
@@ -143,8 +142,7 @@
     transform: translate(0, 100vh);
 
     &.in {
-      -webkit-transform: none !important;
-              transform: none !important;
+      transform: none !important;
     }
     &:before {
       content: " ";
@@ -155,8 +153,7 @@
   .Modal {
     max-width: 100%;
     margin: 0;
-    -webkit-transform: none !important;
-            transform: none !important;
+    transform: none !important;
   }
   .Modal-content {
     border-radius: 0;
@@ -183,7 +180,6 @@
     z-index: 1;
   }
   .Modal-content {
-
     border: 0;
     border-radius: var(--border-radius);
     box-shadow: 0 7px 15px var(--shadow-color);

--- a/less/common/Select.less
+++ b/less/common/Select.less
@@ -6,7 +6,6 @@
     display: inline-block;
     width: auto;
     -webkit-appearance: none;
-    -moz-appearance: none;
     padding-right: 30px;
     cursor: pointer;
     line-height: 1;

--- a/less/common/mixins/vendor-prefixes.less
+++ b/less/common/mixins/vendor-prefixes.less
@@ -65,11 +65,7 @@
 // CSS3 Content Columns
 /** @deprecated */
 .content-columns(@column-count; @column-gap: @grid-gutter-width) {
-  // Safari
-  -webkit-column-count: @column-count;
   column-count: @column-count;
-  // Safari
-  -webkit-column-gap: @column-gap;
   column-gap: @column-gap;
 }
 
@@ -85,7 +81,6 @@
 // Placeholder text
 .placeholder(@color) {
   // Safari
-  &::-webkit-input-placeholder,
   &::placeholder {
     color: @color;
   }
@@ -176,7 +171,7 @@
 // User select
 // For selecting text on the page
 .user-select(@select) {
-  // Safari + MS Edge
+  // Safari
   -webkit-user-select: @select;
   user-select: @select;
 }

--- a/less/common/sideNav.less
+++ b/less/common/sideNav.less
@@ -60,8 +60,7 @@
     flex-shrink: 0;
     margin-right: 50px;
 
-    &,
-    > ul {
+    &, > ul {
       width: 190px;
     }
     > ul {
@@ -91,8 +90,7 @@
     border-bottom: 1px solid var(--control-bg);
   }
 
-  > ul > li,
-  .Dropdown-menu > li {
+  > ul > li, .Dropdown-menu > li {
     display: inline-block;
     margin: 0 20px 0 0;
     vertical-align: top;

--- a/less/common/sideNav.less
+++ b/less/common/sideNav.less
@@ -60,7 +60,8 @@
     flex-shrink: 0;
     margin-right: 50px;
 
-    &, > ul {
+    &,
+    > ul {
       width: 190px;
     }
     > ul {
@@ -80,7 +81,6 @@
   padding: 15px 0;
   white-space: nowrap;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
 
   &:after {
     content: " ";
@@ -91,7 +91,8 @@
     border-bottom: 1px solid var(--control-bg);
   }
 
-  > ul > li, .Dropdown-menu > li {
+  > ul > li,
+  .Dropdown-menu > li {
     display: inline-block;
     margin: 0 20px 0 0;
     vertical-align: top;

--- a/views/install/app.php
+++ b/views/install/app.php
@@ -107,25 +107,15 @@
       }
 
       .animated {
-        -webkit-animation-fill-mode: both;
         animation-fill-mode: both;
-
-        -webkit-animation-duration: 0.5s;
         animation-duration: 0.5s;
-
         animation-delay: 1.7s;
-        -webkit-animation-delay: 1.7s;
-      }
-      @-webkit-keyframes fadeIn {
-        0% {opacity: 0}
-        100% {opacity: 1}
       }
       @keyframes fadeIn {
         0% {opacity: 0}
         100% {opacity: 1}
       }
       .fadeIn {
-        -webkit-animation-name: fadeIn;
         animation-name: fadeIn;
       }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Removes a few more unneeded vendor prefixes. Most are needed for only pre-iOS 11, which our code does not support.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Any I've missed?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
