### PR TITLE
perf: only update last seen time when current > 120s ago

### DIFF
--- a/src/Http/AccessToken.php
+++ b/src/Http/AccessToken.php
@@ -64,6 +64,12 @@ class AccessToken extends AbstractModel
     protected static $lifetime = 0;
 
     /**
+     * Difference from the current `last_activity_at` attribute value before `updateLastSeen()`
+     * will update the attribute on the DB. Measured in seconds.
+     */
+    private const LAST_ACTIVITY_UPDATE_DIFF = 60;
+
+    /**
      * Generate an access token for the specified user.
      *
      * @param int $userId
@@ -98,7 +104,7 @@ class AccessToken extends AbstractModel
         $now = Carbon::now();
 
         // Only update if the current timestamp >120s ago
-        if ($this->last_activity_at === null || $this->last_activity_at->diffInSeconds($now) > 120) {
+        if ($this->last_activity_at === null || $this->last_activity_at->diffInSeconds($now) > AccessToken::LAST_ACTIVITY_UPDATE_DIFF) {
             $this->last_activity_at = $now;
         }
 

--- a/src/Http/AccessToken.php
+++ b/src/Http/AccessToken.php
@@ -97,6 +97,7 @@ class AccessToken extends AbstractModel
     {
         $now = Carbon::now();
 
+        // Only update if the current timestamp >120s ago
         if ($this->last_activity_at === null || $this->last_activity_at->diffInSeconds() > 120) {
             $this->last_activity_at = $now;
         }

--- a/src/Http/AccessToken.php
+++ b/src/Http/AccessToken.php
@@ -98,7 +98,7 @@ class AccessToken extends AbstractModel
         $now = Carbon::now();
 
         // Only update if the current timestamp >120s ago
-        if ($this->last_activity_at === null || $this->last_activity_at->diffInSeconds() > 120) {
+        if ($this->last_activity_at === null || $this->last_activity_at->diffInSeconds($now) > 120) {
             $this->last_activity_at = $now;
         }
 

--- a/src/Http/AccessToken.php
+++ b/src/Http/AccessToken.php
@@ -95,7 +95,11 @@ class AccessToken extends AbstractModel
      */
     public function touch(ServerRequestInterface $request = null)
     {
-        $this->last_activity_at = Carbon::now();
+        $now = Carbon::now();
+
+        if ($this->last_activity_at === null || $this->last_activity_at->diffInSeconds() > 120) {
+            $this->last_activity_at = $now;
+        }
 
         if ($request) {
             $this->last_ip_address = $request->getAttribute('ipAddress');

--- a/src/Http/AccessToken.php
+++ b/src/Http/AccessToken.php
@@ -67,7 +67,7 @@ class AccessToken extends AbstractModel
      * Difference from the current `last_activity_at` attribute value before `updateLastSeen()`
      * will update the attribute on the DB. Measured in seconds.
      */
-    private const LAST_ACTIVITY_UPDATE_DIFF = 60;
+    private const LAST_ACTIVITY_UPDATE_DIFF = 90;
 
     /**
      * Generate an access token for the specified user.

--- a/src/Http/AccessToken.php
+++ b/src/Http/AccessToken.php
@@ -103,7 +103,6 @@ class AccessToken extends AbstractModel
     {
         $now = Carbon::now();
 
-        // Only update if the current timestamp >120s ago
         if ($this->last_activity_at === null || $this->last_activity_at->diffInSeconds($now) > AccessToken::LAST_ACTIVITY_UPDATE_DIFF) {
             $this->last_activity_at = $now;
         }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -124,7 +124,7 @@ class User extends AbstractModel
      * Difference from the current `last_seen` attribute value before `updateLastSeen()`
      * will update the attribute on the DB. Measured in seconds.
      */
-    private const LAST_SEEN_UPDATE_DIFF = 120;
+    private const LAST_SEEN_UPDATE_DIFF = 180;
 
     /**
      * Boot the model.

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -572,7 +572,6 @@ class User extends AbstractModel
     {
         $now = Carbon::now();
 
-        // Only update if the current timestamp is from a while ago
         if ($this->last_seen_at === null || $this->last_seen_at->diffInSeconds($now) > User::LAST_SEEN_UPDATE_DIFF) {
             $this->last_seen_at = $now;
         }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -121,6 +121,12 @@ class User extends AbstractModel
     protected static $passwordCheckers;
 
     /**
+     * Difference from the current `last_seen` attribute value before `updateLastSeen()`
+     * will update the attribute on the DB. Measured in seconds.
+     */
+    private const LAST_SEEN_UPDATE_DIFF = 120;
+
+    /**
      * Boot the model.
      *
      * @return void
@@ -566,8 +572,8 @@ class User extends AbstractModel
     {
         $now = Carbon::now();
 
-        // Only update if the current timestamp is >120s ago
-        if ($this->last_seen_at === null || $this->last_seen_at->diffInSeconds($now) > 120) {
+        // Only update if the current timestamp is from a while ago
+        if ($this->last_seen_at === null || $this->last_seen_at->diffInSeconds($now) > User::LAST_SEEN_UPDATE_DIFF) {
             $this->last_seen_at = $now;
         }
 

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -564,7 +564,12 @@ class User extends AbstractModel
      */
     public function updateLastSeen()
     {
-        $this->last_seen_at = Carbon::now();
+        $now = Carbon::now();
+
+        // Only update if the current timestamp is >120s ago
+        if ($this->last_seen_at === null || $this->last_seen_at->diffInSeconds($now) > 120) {
+            $this->last_seen_at = $now;
+        }
 
         return $this;
     }

--- a/tests/integration/api/users/UpdateTest.php
+++ b/tests/integration/api/users/UpdateTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\users;
 use Carbon\Carbon;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class UpdateTest extends TestCase
 {
@@ -658,5 +659,36 @@ class UpdateTest extends TestCase
             ])
         );
         $this->assertEquals(403, $response->getStatusCode());
+    }
+    
+    /**
+     * @test
+     */
+    public function last_seen_not_updated_quickly()
+    {
+        $user = User::find(2);
+
+        $lastSeenOriginal = Carbon::now()->subSeconds(10);
+        $expectedLastSeen = $lastSeenOriginal->copy();
+
+        $user->last_seen_at = $lastSeenOriginal;
+        $user->updateLastSeen();
+
+        $this->assertEquals($expectedLastSeen, $user->last_seen_at);
+    }
+
+    /**
+     * @test
+     */
+    public function last_seen_updated_after_long_time()
+    {
+        $user = User::find(2);
+
+        $lastSeenOriginal = Carbon::now()->subHour();
+
+        $user->last_seen_at = $lastSeenOriginal;
+        $user->updateLastSeen();
+
+        $this->assertNotEquals($lastSeenOriginal, $user->last_seen_at);
     }
 }

--- a/tests/integration/api/users/UpdateTest.php
+++ b/tests/integration/api/users/UpdateTest.php
@@ -674,6 +674,8 @@ class UpdateTest extends TestCase
      */
     public function last_seen_not_updated_quickly()
     {
+        $this->app();
+
         $user = User::find(3);
 
         $response = $this->send(
@@ -693,6 +695,8 @@ class UpdateTest extends TestCase
      */
     public function last_seen_updated_after_long_time()
     {
+        $this->app();
+
         $user = User::find(4);
 
         $response = $this->send(


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Ref flarum/issue-archive#121. Fixes flarum/framework#3231.**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Only updates the last seen timestamp when the current value is > 120 seconds ago

This, in a dev environment with Clockwork, reduces the overall request time by approx 5 milliseconds.

We might want to consider a better solution, such as a heartbeat ping from users every x minutes/seconds to update this and other states, rather than this method.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Would it be better to use the `isOnline` timeout value of 5 mins instead?

Also, is it worth adding tests for this?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
