### PR TITLE
fix(a11y): fix a11y warning in alert, and other a11y fixes

### DIFF
--- a/js/src/common/components/Alert.tsx
+++ b/js/src/common/components/Alert.tsx
@@ -43,7 +43,7 @@ export default class Alert<T extends AlertAttrs = AlertAttrs> extends Component<
         <Button
           aria-label={app.translator.trans('core.lib.alert.dismiss_a11y_label')}
           icon="fas fa-times"
-          className="Button Button--link Button--icon Alert-dismiss"
+          class="Button Button--link Button--icon Alert-dismiss"
           onclick={ondismiss}
         />
       );

--- a/js/src/common/components/Alert.tsx
+++ b/js/src/common/components/Alert.tsx
@@ -3,6 +3,8 @@ import Button from './Button';
 import listItems from '../helpers/listItems';
 import extract from '../utils/extract';
 import type Mithril from 'mithril';
+import classList from '../utils/classList';
+import { app } from '..';
 
 export interface AlertAttrs extends ComponentAttrs {
   /** The type of alert this is. Will be used to give the alert a class name of `Alert--{type}`. */
@@ -24,7 +26,7 @@ export default class Alert<T extends AlertAttrs = AlertAttrs> extends Component<
     const attrs = Object.assign({}, this.attrs);
 
     const type = extract(attrs, 'type');
-    attrs.className = 'Alert Alert--' + type + ' ' + (attrs.className || '');
+    attrs.className = classList('Alert', `Alert--${type}`, attrs.className);
 
     const content = extract(attrs, 'content') || vnode.children;
     const controls = (extract(attrs, 'controls') || []) as Mithril.Vnode[];
@@ -37,13 +39,20 @@ export default class Alert<T extends AlertAttrs = AlertAttrs> extends Component<
     const dismissControl: Mithril.Vnode[] = [];
 
     if (dismissible || dismissible === undefined) {
-      dismissControl.push(<Button icon="fas fa-times" className="Button Button--link Button--icon Alert-dismiss" onclick={ondismiss} />);
+      dismissControl.push(
+        <Button
+          aria-label={app.translator.trans('core.lib.alert.dismiss_a11y_label')}
+          icon="fas fa-times"
+          className="Button Button--link Button--icon Alert-dismiss"
+          onclick={ondismiss}
+        />
+      );
     }
 
     return (
       <div {...attrs}>
-        <span className="Alert-body">{content}</span>
-        <ul className="Alert-controls">{listItems(controls.concat(dismissControl))}</ul>
+        <span class="Alert-body">{content}</span>
+        <ul class="Alert-controls">{listItems(controls.concat(dismissControl))}</ul>
       </div>
     );
   }

--- a/js/src/common/components/Alert.tsx
+++ b/js/src/common/components/Alert.tsx
@@ -4,7 +4,7 @@ import listItems from '../helpers/listItems';
 import extract from '../utils/extract';
 import type Mithril from 'mithril';
 import classList from '../utils/classList';
-import { app } from '..';
+import app from '../app';
 
 export interface AlertAttrs extends ComponentAttrs {
   /** The type of alert this is. Will be used to give the alert a class name of `Alert--{type}`. */

--- a/js/src/common/components/AlertManager.js
+++ b/js/src/common/components/AlertManager.js
@@ -18,7 +18,7 @@ export default class AlertManager extends Component {
           const urgent = alert.attrs.type === 'error';
 
           return (
-            <div className="AlertManager-alert" role="alert" aria-live={urgent ? 'assertive' : 'polite'}>
+            <div class="AlertManager-alert" role="alert" aria-live={urgent ? 'assertive' : 'polite'}>
               <alert.componentClass {...alert.attrs} ondismiss={this.state.dismiss.bind(this.state, key)}>
                 {alert.children}
               </alert.componentClass>

--- a/js/src/common/components/AlertManager.js
+++ b/js/src/common/components/AlertManager.js
@@ -1,5 +1,4 @@
 import Component from '../Component';
-import Alert from './Alert';
 
 /**
  * The `AlertManager` component provides an area in which `Alert` components can
@@ -14,14 +13,18 @@ export default class AlertManager extends Component {
 
   view() {
     return (
-      <div className="AlertManager">
-        {Object.entries(this.state.getActiveAlerts()).map(([key, alert]) => (
-          <div className="AlertManager-alert">
-            <alert.componentClass {...alert.attrs} ondismiss={this.state.dismiss.bind(this.state, key)}>
-              {alert.children}
-            </alert.componentClass>
-          </div>
-        ))}
+      <div class="AlertManager">
+        {Object.entries(this.state.getActiveAlerts()).map(([key, alert]) => {
+          const urgent = alert.attrs.type === 'error';
+
+          return (
+            <div className="AlertManager-alert" role="alert" aria-live={urgent ? 'assertive' : 'polite'}>
+              <alert.componentClass {...alert.attrs} ondismiss={this.state.dismiss.bind(this.state, key)}>
+                {alert.children}
+              </alert.componentClass>
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -504,6 +504,10 @@ core:
   lib:
     debug_button: Debug
 
+    # These translations are used in the Alert component.
+    alert:
+      dismiss_a11y_label: Dismiss alert
+
     # These translations are displayed as tooltips for discussion badges.
     badge:
       hidden_tooltip: Hidden


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Progresses flarum/framework#3360, progresses flarum/framework#3365**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- add missing a11y label for alert dismiss button
- use aria live regions to focus screenreader attention on alerts as they appear

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/147590024-ec2a2565-ce9d-482c-9190-0e43541f0091.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
