### PR TITLE
refactor: Modal rewrite to use native HTML Dialog element + polyfill

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -9,6 +9,7 @@
     "clsx": "^1.1.1",
     "color-thief-browser": "^2.0.2",
     "dayjs": "^1.10.7",
+    "dialog-polyfill": "^0.5.6",
     "focus-trap": "^6.7.1",
     "jquery": "^3.6.0",
     "jquery.hotkeys": "^0.1.0",

--- a/js/src/@types/modals/index.d.ts
+++ b/js/src/@types/modals/index.d.ts
@@ -1,0 +1,46 @@
+/**
+ * Only supported natively in Chrome. In testing in Safari Technology Preview.
+ *
+ * Please register modals with the dialog polyfill before use:
+ *
+ * ```js
+ * dialogPolyfill.registerDialog(dialogElementReference);
+ * ```
+ *
+ * ### Events
+ *
+ * Two events are fired by dialogs:
+ * - `cancel` - Fired when the user instructs the browser that they wish to dismiss the current open dialog.
+ * - `close` - Fired when the dialog is closed.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement
+ */
+interface HTMLDialogElement {
+  /**
+   * Shows the `<dialog>` element as a top-layered element in the document.
+   */
+  show(): void;
+  /**
+   * Displays the dialog as a modal, over the top of any other dialogs that
+   * might be present. Interaction outside the dialog is blocked.
+   */
+  showModal(): void;
+  /**
+   * If the `<dialog>` element is currently being shown, dismiss it.
+   *
+   * @param returnValue An optional return value for the dialog to hold. *This is currently unused by Flarum.*
+   */
+  close(returnValue?: string): void;
+
+  /**
+   * A return value for the dialog to hold.
+   *
+   * *This is currently unused by Flarum.*
+   */
+  returnValue: string;
+
+  /**
+   * Whether the dialog is currently open.
+   */
+  open: boolean;
+}

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -8,6 +8,7 @@ import type ModalManagerState from '../states/ModalManagerState';
 import type RequestError from '../utils/RequestError';
 import type ModalManager from './ModalManager';
 import fireDebugWarning from '../helpers/fireDebugWarning';
+import classList from '../utils/classList';
 
 export interface IInternalModalAttrs {
   state: ModalManagerState;
@@ -15,15 +16,62 @@ export interface IInternalModalAttrs {
   animateHide: ModalManager['animateHide'];
 }
 
+export interface IDismissibleOptions {
+  /**
+   * @deprecated Check specific individual attributes instead. Will be removed in Flarum 2.0.
+   */
+  isDismissible: boolean;
+  viaCloseButton: boolean;
+  viaEscKey: boolean;
+  viaBackdropClick: boolean;
+}
+
 /**
  * The `Modal` component displays a modal dialog, wrapped in a form. Subclasses
  * should implement the `className`, `title`, and `content` methods.
  */
 export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IInternalModalAttrs> extends Component<ModalAttrs> {
+  // TODO: [Flarum 2.0] remove `isDismissible` static attribute
   /**
    * Determine whether or not the modal should be dismissible via an 'x' button.
+   *
+   * @deprecated Use the individual `isDismissibleVia...` attributes instead and remove references to this.
    */
   static readonly isDismissible: boolean = true;
+
+  /**
+   * Can the model be dismissed with a close button (X)?
+   *
+   * If `false`, no close button is shown.
+   */
+  protected static readonly isDismissibleViaCloseButton: boolean = true;
+  /**
+   * Can the modal be dismissed by pressing the Esc key on a keyboard?
+   */
+  protected static readonly isDismissibleViaEscKey: boolean = true;
+  /**
+   * Can the modal be dismissed via a click on the backdrop.
+   */
+  protected static readonly isDismissibleViaBackdropClick: boolean = true;
+
+  static get dismissibleOptions(): IDismissibleOptions {
+    // If someone sets this to `false`, provide the same behaviour as previous versions of Flarum.
+    if (!this.isDismissible) {
+      return {
+        isDismissible: false,
+        viaCloseButton: false,
+        viaEscKey: false,
+        viaBackdropClick: false,
+      };
+    }
+
+    return {
+      isDismissible: true,
+      viaCloseButton: this.isDismissibleViaCloseButton,
+      viaEscKey: this.isDismissibleViaEscKey,
+      viaBackdropClick: this.isDismissibleViaBackdropClick,
+    };
+  }
 
   protected loading: boolean = false;
 
@@ -87,16 +135,16 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
     }
 
     return (
-      <div className={'Modal modal-dialog ' + this.className()}>
+      <dialog className={classList('Modal modal-dialog fade', this.className())}>
         <div className="Modal-content">
-          {(this.constructor as typeof Modal).isDismissible && (
+          {this.dismissibleOptions.viaCloseButton && (
             <div className="Modal-close App-backControl">
-              {Button.component({
-                icon: 'fas fa-times',
-                onclick: () => this.hide(),
-                className: 'Button Button--icon Button--link',
-                'aria-label': app.translator.trans('core.lib.modal.close'),
-              })}
+              <Button
+                icon="fas fa-times"
+                onclick={() => this.hide()}
+                className="Button Button--icon Button--link"
+                aria-label={app.translator.trans('core.lib.modal.close')}
+              />
             </div>
           )}
 
@@ -110,7 +158,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
             {this.content()}
           </form>
         </div>
-      </div>
+      </dialog>
     );
   }
 
@@ -174,5 +222,9 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
     } else {
       this.onready();
     }
+  }
+
+  private get dismissibleOptions(): IDismissibleOptions {
+    return (this.constructor as typeof Modal).dismissibleOptions;
   }
 }

--- a/js/src/common/index.js
+++ b/js/src/common/index.js
@@ -3,9 +3,12 @@ import 'expose-loader?exposes=$,jQuery!jquery';
 import 'expose-loader?exposes=m!mithril';
 import 'expose-loader?exposes=dayjs!dayjs';
 
+// HTML dialog element polyfill from the Chrome Dev team: https://github.com/GoogleChrome/dialog-polyfill
+import dialogPolyfill from 'dialog-polyfill';
+window.dialogPolyfill = dialogPolyfill;
+
 import 'bootstrap/js/affix';
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/modal';
 import 'bootstrap/js/tooltip';
 import 'bootstrap/js/transition';
 import 'jquery.hotkeys/jquery.hotkeys';

--- a/js/src/common/states/ModalManagerState.ts
+++ b/js/src/common/states/ModalManagerState.ts
@@ -1,5 +1,5 @@
 import type Component from '../Component';
-import Modal from '../components/Modal';
+import Modal, { IDismissibleOptions } from '../components/Modal';
 
 /**
  * Ideally, `show` would take a higher-kinded generic, ala:
@@ -8,7 +8,7 @@ import Modal from '../components/Modal';
  * https://github.com/Microsoft/TypeScript/issues/1213
  * Therefore, we have to use this ugly, messy workaround.
  */
-type UnsafeModalClass = ComponentClass<any, Modal> & { isDismissible: boolean; component: typeof Component.component };
+type UnsafeModalClass = ComponentClass<any, Modal> & { get dismissibleOptions(): IDismissibleOptions; component: typeof Component.component };
 
 /**
  * Class used to manage modal state.

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1401,6 +1401,7 @@ __metadata:
     color-thief-browser: ^2.0.2
     cross-env: ^7.0.3
     dayjs: ^1.10.7
+    dialog-polyfill: ^0.5.6
     expose-loader: ^3.1.0
     flarum-tsconfig: ^1.0.2
     flarum-webpack-config: ^2.0.0
@@ -2307,6 +2308,13 @@ __metadata:
   dependencies:
     object-keys: ^1.0.12
   checksum: da80dba55d0cd76a5a7ab71ef6ea0ebcb7b941f803793e4e0257b384cb772038faa0c31659d244e82c4342edef841c1a1212580006a05a5068ee48223d787317
+  languageName: node
+  linkType: hard
+
+"dialog-polyfill@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "dialog-polyfill@npm:0.5.6"
+  checksum: dde8d4b6a62b63b710e0d0d70b615d92ff08f3cb2b521e1f99b17e8220d9d55d0fdf9fc17fbe77b0ff1be817094e14b60c4c4bacd5456fba427ede48d2d90230
   languageName: node
   linkType: hard
 

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -6,8 +6,24 @@
   overflow: hidden;
 }
 
-// Modal background
-.ModalManager dialog {
+.Modal {
+  border-width: 0;
+  padding: 0;
+  overflow: visible;
+  border-radius: @border-radius;
+
+  transform: scale(0.9);
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+
+  // only in polyfilled browsers
+  &[role] {
+    top: 0 !important;
+  }
+
+  &.in {
+    transform: scale(1);
+  }
+
   //! These MUST be defined separately
   //
   // When browsers do not understand a pseudoselector, the entire block is ignored,
@@ -22,24 +38,11 @@
 
   + .backdrop {
     background: var(--overlay-bg);
-  }
-}
-
-// Container that the modal scrolls within
-.ModalManager {
-  // When fading in the modal, animate it to slide down
-  dialog {
-    border-width: 0;
-    padding: 0;
-    overflow: visible;
-    border-radius: @border-radius;
-
-    transform: scale(0.9);
-    transition: transform 0.2s ease-out, opacity 0.2s ease-out;
-
-    &.in {
-      transform: scale(1);
-    }
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
   }
 }
 
@@ -159,12 +162,11 @@
 }
 
 @media @tablet-up {
-  .ModalManager dialog {
+  .Modal {
     border-radius: var(--border-radius);
     box-shadow: 0 7px 15px var(--shadow-color);
     width: 100%;
-  }
-  .Modal {
+    max-width: 600px;
     margin: 120px auto;
   }
   .Modal-close {

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -128,13 +128,7 @@
     bottom: 0;
     top: 0;
     overflow: auto;
-    transition: transform 0.2s ease-out;
-    transform: translate(0, 100vh);
 
-    &.in {
-      -webkit-transform: none !important;
-              transform: none !important;
-    }
     &:before {
       content: " ";
       .header-background();

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -7,54 +7,40 @@
 }
 
 // Modal background
-.modal-backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: var(--zindex-modal-background);
-  background-color: var(--overlay-bg);
-  opacity: 0;
-  transition: opacity 0.2s;
+.ModalManager dialog {
+  //! These MUST be defined separately
+  //
+  // When browsers do not understand a pseudoselector, the entire block is ignored,
+  // meaning no backdrop would be visible at all.
+  &::backdrop {
+    // `::backdrop` does not inherit anything from parents, so we need to declare this here.
+    // See: https://stackoverflow.com/a/63322762/11091039
 
-  &.in {
-    opacity: 1;
+    --overlay-bg: @overlay-bg;
+    background: var(--overlay-bg);
+  }
+
+  + .backdrop {
+    background: var(--overlay-bg);
   }
 }
 
 // Container that the modal scrolls within
 .ModalManager {
-  display: none;
-  overflow: hidden;
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: var(--zindex-modal);
-  -webkit-overflow-scrolling: touch;
-
   // When fading in the modal, animate it to slide down
-  .Modal {
-    transform: scale(0.9);
-    transition: transform 0.2s ease-out;
-  }
-  &.in .Modal {
-    transform: scale(1);
-  }
-}
-.modal-open .ModalManager {
-  overflow-x: hidden;
-  overflow-y: auto;
-}
+  dialog {
+    border-width: 0;
+    padding: 0;
+    overflow: visible;
+    border-radius: @border-radius;
 
-// Shell div to position the modal with bottom padding
-.Modal {
-  position: relative;
-  width: auto;
-  margin: 10px;
-  max-width: 600px;
+    transform: scale(0.9);
+    transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+
+    &.in {
+      transform: scale(1);
+    }
+  }
 }
 
 // Actual modal
@@ -173,6 +159,11 @@
 }
 
 @media @tablet-up {
+  .ModalManager dialog {
+    border-radius: var(--border-radius);
+    box-shadow: 0 7px 15px var(--shadow-color);
+    width: 100%;
+  }
   .Modal {
     margin: 120px auto;
   }
@@ -183,10 +174,7 @@
     z-index: 1;
   }
   .Modal-content {
-
-    border: 0;
     border-radius: var(--border-radius);
-    box-shadow: 0 7px 15px var(--shadow-color);
   }
   .Modal--small {
     max-width: 375px;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/issue-archive#124**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Replaces Bootstrap modals with HTML5 Dialog element and polyfill.

This reduces our bundle, and improves accessibility.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Testing extension modal implementations work with these changes.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
