### PR TITLE
[fix] Extract sortmap options to container

### DIFF
--- a/src/Extend/Sortmap.php
+++ b/src/Extend/Sortmap.php
@@ -16,7 +16,7 @@ class Sortmap implements ExtenderInterface
 {
     private $sortFields = [];
 
-    public function addSort(string $key, string $value):self
+    public function addSort(string $key, string $value): self
     {
         $this->sortFields[$key] = $value;
 

--- a/src/Extend/Sortmap.php
+++ b/src/Extend/Sortmap.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Illuminate\Contracts\Container\Container;
+
+class Sortmap implements ExtenderInterface
+{
+    private $sortFields = [];
+
+    public function addSort(string $key, string $value):self
+    {
+        $this->sortFields[$key] = $value;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        $container->extend('flarum.forum.sortmap', function (array $sortFields) {
+            return array_merge($sortFields, $this->sortFields);
+        });
+    }
+}

--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -70,7 +70,7 @@ class Index
         $page = max(1, intval(Arr::pull($queryParams, 'page')));
         $filters = Arr::pull($queryParams, 'filter', []);
 
-        $sortMap = $this->getSortMap();
+        $sortMap = resolve('flarum.forum.sortmap');
 
         $params = [
             'sort' => $sort && isset($sortMap[$sort]) ? $sortMap[$sort] : '',
@@ -94,21 +94,6 @@ class Index
         $document->hasNextPage = isset($apiDocument->links->next);
 
         return $document;
-    }
-
-    /**
-     * Get a map of sort query param values and their API sort params.
-     *
-     * @return array
-     */
-    private function getSortMap()
-    {
-        return [
-            'latest' => '-lastPostedAt',
-            'top' => '-commentCount',
-            'newest' => '-createdAt',
-            'oldest' => 'createdAt'
-        ];
     }
 
     /**

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -129,6 +129,15 @@ class ForumServiceProvider extends AbstractServiceProvider
         $this->container->bind('flarum.frontend.forum', function (Container $container) {
             return $container->make('flarum.frontend.factory')('forum');
         });
+
+        $this->container->singleton('flarum.forum.sortmap', function (Container $container) {
+            return [
+                'latest' => '-lastPostedAt',
+                'top' => '-commentCount',
+                'newest' => '-createdAt',
+                'oldest' => 'createdAt'
+            ];
+        });
     }
 
     public function boot(Container $container, Dispatcher $events, Factory $view)

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -130,7 +130,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             return $container->make('flarum.frontend.factory')('forum');
         });
 
-        $this->container->singleton('flarum.forum.sortmap', function (Container $container) {
+        $this->container->singleton('flarum.forum.sortmap', function () {
             return [
                 'latest' => '-lastPostedAt',
                 'top' => '-commentCount',


### PR DESCRIPTION
**Partially addresses flarum/issue-archive#70 **

**Changes proposed in this pull request:**
Make the backend sort options list a container binding so extensions can modify it.
Add a new extender `Extend\Sortmap` to register additional sort mapping options

**Reviewers should focus on:**
I don't think we should go further for the moment (ie serializing to the frontend, etc) until https://github.com/flarum/core/pull/3133 is merged also. This change proposed here will at least allow extensions to properly add additional sort options

Documentation - what level is detail would you like to see here?

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
