### PR TITLE
feat: Replace ColorPreviewInput preview box with 'color' input

### DIFF
--- a/js/src/common/components/ColorPreviewInput.tsx
+++ b/js/src/common/components/ColorPreviewInput.tsx
@@ -5,23 +5,20 @@ import classList from '../utils/classList';
 import icon from '../helpers/icon';
 
 export default class ColorPreviewInput extends Component {
-  value?: string;
-
   view(vnode: Mithril.Vnode<ComponentAttrs, this>) {
-    const { className, ...attrs } = this.attrs;
-    const value = attrs.bidi?.() || attrs.value;
+    const { className, id, ...attrs } = this.attrs;
 
     attrs.type ||= 'text';
 
     return (
       <div className="ColorInput">
-        <input className={classList('FormControl', className)} {...attrs} />
+        <input className={classList('FormControl', className)} id={id} {...attrs} />
 
         <span className="ColorInput-icon" role="presentation">
           {icon('fas fa-exclamation-circle')}
         </span>
 
-        <div className="ColorInput-preview" style={{ '--input-value': value }} role="presentation" />
+        <input className="ColorInput-preview" {...attrs} type="color" />
       </div>
     );
   }

--- a/less/common/ColorInput.less
+++ b/less/common/ColorInput.less
@@ -7,12 +7,26 @@
     bottom: 8px;
     width: 20px;
     height: 20px;
-    pointer-events: none;
   }
 
   &-preview {
-    background-color: var(--input-value);
+    display: inline-block;
     border-radius: 15%;
+    padding: 0;
+    cursor: pointer;
+    overflow: hidden;
+
+    // Match both the wrapper div and the div with the background color
+    &, &::-webkit-color-swatch-wrapper, &::-webkit-color-swatch {
+      border: none;
+      padding: 0;
+    }
+
+    // This has to be a separate entry so other browsers
+    // don't ignore the entire CSS rule. Thanks Firefox.
+    &::-moz-color-swatch {
+      border: none;
+    }
   }
 
   &-icon {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Replace the preview box with a `color` input that allows for easier modification of colors while still having a text field
- Extracts `id` from attrs so that it's not used for two inputs

**Reviewers should focus on:**
- Do we want a check for whether `color` input is supported? It seems to have good support, but on iOS it is not supported in `UIWebView` (deprecated, removed in iOS 13 I believe)
- Do we want to make this optional or just change the functionality to be usable? I don't see any reason for it to be an option, but we could do that.

**Screenshot**

(Ignore the 'Primary color' label)

https://user-images.githubusercontent.com/6401250/151707985-e4d4a3bb-9d07-4e5c-8513-394bd5f71485.mp4

https://user-images.githubusercontent.com/6401250/151708016-5721f29d-773d-46fb-9069-6e2ff4cfcc70.mp4


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
- [X] Core developer confirmed locally this works as intended.
- ~~Tests have been added, or are not appropriate here.~~
