### PR TITLE
fix: specify Config.php return types

### DIFF
--- a/src/Foundation/Config.php
+++ b/src/Foundation/Config.php
@@ -53,22 +53,22 @@ class Config implements ArrayAccess
         }
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return Arr::get($this->data, $offset);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return Arr::has($this->data, $offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new RuntimeException('The Config is immutable');
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new RuntimeException('The Config is immutable');
     }


### PR DESCRIPTION
This fixes some deprecation warnings for PHP 8.1.

Fixes https://github.com/flarum/core/issues/3270