### PR TITLE
Up font-awesome version to ^6.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php": ">=7.3",
         "axy/sourcemap": "^0.1.4",
-        "components/font-awesome": "^5.14.0",
+        "components/font-awesome": "^6.0.0",
         "dflydev/fig-cookies": "^3.0.0",
         "doctrine/dbal": "^2.7",
         "dragonmantank/cron-expression": "^3.1.0",


### PR DESCRIPTION
I have pushed a PR (https://github.com/components/font-awesome/pull/55) for the FA6 update in `components/font-awesome`, the new version is already tagged (https://github.com/components/font-awesome/releases/tag/6.0.0). This PR is just to push the requirement to version 6.0.0.

