### PR TITLE
feat: Graceful frontend extension initialization failure

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -33,6 +33,7 @@ import type Mithril from 'mithril';
 import type Component from './Component';
 import type { ComponentAttrs } from './Component';
 import Model, { SavedModelData } from './Model';
+import fireApplicationError from "./helpers/fireApplicationError";
 
 export type FlarumScreens = 'phone' | 'tablet' | 'desktop' | 'desktop-hd';
 
@@ -262,7 +263,22 @@ export default class Application {
   }
 
   public boot() {
-    this.initializers.toArray().forEach((initializer) => initializer(this));
+    const caughtInitializationErrors: CallableFunction[] = [];
+
+    this.initializers.toArray().forEach((initializer) => {
+      try {
+        initializer(this);
+      } catch (e) {
+        const extension = initializer.itemName.includes('/')
+          ? initializer.itemName.replace(/(\/flarum-ext-)|(\/flarum-)/g, '-')
+          : initializer.itemName;
+
+        caughtInitializationErrors.push(() => fireApplicationError({
+          userTitle: extractText(app.translator.trans('core.lib.error.extension_initialiation_failed_message', { extension })),
+          consoleTitle: `${extension} failed to initialize`,
+        }, e));
+      }
+    });
 
     this.store.pushPayload({ data: this.data.resources });
 
@@ -273,6 +289,8 @@ export default class Application {
     this.mount();
 
     this.initialRoute = window.location.href;
+
+    caughtInitializationErrors.forEach(handler => handler());
   }
 
   // TODO: This entire system needs a do-over for v2

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -33,7 +33,7 @@ import type Mithril from 'mithril';
 import type Component from './Component';
 import type { ComponentAttrs } from './Component';
 import Model, { SavedModelData } from './Model';
-import fireApplicationError from "./helpers/fireApplicationError";
+import fireApplicationError from './helpers/fireApplicationError';
 
 export type FlarumScreens = 'phone' | 'tablet' | 'desktop' | 'desktop-hd';
 
@@ -273,10 +273,13 @@ export default class Application {
           ? initializer.itemName.replace(/(\/flarum-ext-)|(\/flarum-)/g, '-')
           : initializer.itemName;
 
-        caughtInitializationErrors.push(() => fireApplicationError({
-          userTitle: extractText(app.translator.trans('core.lib.error.extension_initialiation_failed_message', { extension })),
-          consoleTitle: `${extension} failed to initialize`,
-        }, e));
+        caughtInitializationErrors.push(() =>
+          fireApplicationError(
+            extractText(app.translator.trans('core.lib.error.extension_initialiation_failed_message', { extension })),
+            `${extension} failed to initialize`,
+            e
+          )
+        );
       }
     });
 
@@ -290,7 +293,7 @@ export default class Application {
 
     this.initialRoute = window.location.href;
 
-    caughtInitializationErrors.forEach(handler => handler());
+    caughtInitializationErrors.forEach((handler) => handler());
   }
 
   // TODO: This entire system needs a do-over for v2

--- a/framework/core/js/src/common/helpers/fireApplicationError.ts
+++ b/framework/core/js/src/common/helpers/fireApplicationError.ts
@@ -19,6 +19,7 @@ export default function fireApplicationError(options: { userTitle: string, conso
   console.groupEnd();
 
   if (app.session?.user?.isAdmin()) {
+    // @TODO in 2.0 use the reusable page alert under the header that'll be introduced.
     app.alerts.show({ type: 'error' }, `${options.userTitle}`);
   }
 }

--- a/framework/core/js/src/common/helpers/fireApplicationError.ts
+++ b/framework/core/js/src/common/helpers/fireApplicationError.ts
@@ -1,0 +1,24 @@
+import app from "../app";
+
+/**
+ * Fire a Flarum error which is shown in the JS console for everyone and in an alert for the admin.
+ *
+ * @param options
+ * {
+ *   userTitle: a user friendly title of the error, should be localized.
+ *   consoleTitle: an error title that goes in the console, doesn't have to be localized.
+ * }
+ * @param errors
+ */
+export default function fireApplicationError(options: { userTitle: string, consoleTitle: string }, ...errors: any) {
+  console.group(
+    `%c${options.consoleTitle}`,
+    'background-color: #d83e3e; color: #ffffff; font-weight: bold;'
+  );
+  console.error(...errors);
+  console.groupEnd();
+
+  if (app.session?.user?.isAdmin()) {
+    app.alerts.show({ type: 'error' }, `${options.userTitle}`);
+  }
+}

--- a/framework/core/js/src/common/helpers/fireApplicationError.ts
+++ b/framework/core/js/src/common/helpers/fireApplicationError.ts
@@ -1,24 +1,18 @@
-import app from "../app";
+import app from '../app';
 
 /**
  * Fire a Flarum error which is shown in the JS console for everyone and in an alert for the admin.
  *
- * @param options
- * {
- *   userTitle: a user friendly title of the error, should be localized.
- *   consoleTitle: an error title that goes in the console, doesn't have to be localized.
- * }
- * @param errors
+ * @param userTitle: a user friendly title of the error, should be localized.
+ * @param consoleTitle: an error title that goes in the console, doesn't have to be localized.
+ * @param error: the error.
  */
-export default function fireApplicationError(options: { userTitle: string, consoleTitle: string }, ...errors: any) {
-  console.group(
-    `%c${options.consoleTitle}`,
-    'background-color: #d83e3e; color: #ffffff; font-weight: bold;'
-  );
-  console.error(...errors);
+export default function fireApplicationError(userTitle: string, consoleTitle: string, error: any) {
+  console.group(`%c${consoleTitle}`, 'background-color: #d83e3e; color: #ffffff; font-weight: bold;');
+  console.error(error);
   console.groupEnd();
 
   if (app.session?.user?.isAdmin()) {
-    app.alerts.show({ type: 'error' }, `${options.userTitle}`);
+    app.alerts.show({ type: 'error' }, `${userTitle}`);
   }
 }

--- a/framework/core/js/src/common/helpers/fireApplicationError.ts
+++ b/framework/core/js/src/common/helpers/fireApplicationError.ts
@@ -19,7 +19,6 @@ export default function fireApplicationError(options: { userTitle: string, conso
   console.groupEnd();
 
   if (app.session?.user?.isAdmin()) {
-    // @TODO in 2.0 use the reusable page alert under the header that'll be introduced.
     app.alerts.show({ type: 'error' }, `${options.userTitle}`);
   }
 }

--- a/framework/core/js/src/common/models/User.tsx
+++ b/framework/core/js/src/common/models/User.tsx
@@ -42,6 +42,10 @@ export default class User extends Model {
     return Model.hasMany<Group>('groups').call(this);
   }
 
+  isAdmin() {
+    return Model.attribute<boolean | undefined>('isAdmin').call(this);
+  }
+
   joinTime() {
     return Model.attribute('joinTime', Model.transformDate).call(this);
   }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -534,6 +534,7 @@ core:
     # These translations are displayed as error messages.
     error:
       dependent_extensions_message: "Cannot disable {extension} until the following dependent extensions are disabled: {extensions}"
+      extension_initialiation_failed_message: "{extension} failed to initialize, check the console for further information."
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
       not_found_message: The requested resource was not found.

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -534,7 +534,7 @@ core:
     # These translations are displayed as error messages.
     error:
       dependent_extensions_message: "Cannot disable {extension} until the following dependent extensions are disabled: {extensions}"
-      extension_initialiation_failed_message: "{extension} failed to initialize, check the console for further information."
+      extension_initialiation_failed_message: "{extension} failed to initialize, check the browser console for further information."
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
       not_found_message: The requested resource was not found.

--- a/framework/core/src/Api/Serializer/CurrentUserSerializer.php
+++ b/framework/core/src/Api/Serializer/CurrentUserSerializer.php
@@ -25,7 +25,8 @@ class CurrentUserSerializer extends UserSerializer
             'markedAllAsReadAt'        => $this->formatDate($user->marked_all_as_read_at),
             'unreadNotificationCount'  => (int) $user->getUnreadNotificationCount(),
             'newNotificationCount'     => (int) $user->getNewNotificationCount(),
-            'preferences'              => (array) $user->preferences
+            'preferences'              => (array) $user->preferences,
+            'isAdmin'                  => $user->isAdmin(),
         ];
 
         return $attributes;


### PR DESCRIPTION
**Part of flarum/issue-archive#85**

**Changes proposed in this pull request:**
Instead of allowing the application's frontend to crash, we can catch the frontend errors when initializing extensions and gracefully fail to minimize the impact and improve user experience.

**Reviewers should focus on:**
The approach, error message formulation, general code quality.

**Screenshot**
Before | After
-- | --
![Screenshot from 2022-03-16 14-17-21](https://user-images.githubusercontent.com/20267363/158599219-42036778-2200-47cd-b0e1-13b776b6ebc7.png) |  ![Screenshot from 2022-03-16 14-12-25](https://user-images.githubusercontent.com/20267363/158599319-bf39f4f4-fbce-4956-9d9a-8604482c0ebf.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
