### PR TITLE
fix: `Post--by-start-user` not working

### DIFF
--- a/framework/core/js/src/forum/components/Post.tsx
+++ b/framework/core/js/src/forum/components/Post.tsx
@@ -132,7 +132,7 @@ export default abstract class Post<CustomAttrs extends IPostAttrs = IPostAttrs> 
       classes.push('Post--by-actor');
     }
 
-    if (user && user?.id() === discussion.attribute('startUserId')) {
+    if (user && user === discussion.user()) {
       classes.push('Post--by-start-user');
     }
 

--- a/framework/core/src/Api/Controller/ShowDiscussionController.php
+++ b/framework/core/src/Api/Controller/ShowDiscussionController.php
@@ -48,6 +48,7 @@ class ShowDiscussionController extends AbstractShowController
      * {@inheritdoc}
      */
     public $include = [
+        'user',
         'posts',
         'posts.discussion',
         'posts.user',


### PR DESCRIPTION
**Changes proposed in this pull request:**
This is an odd one, https://github.com/flarum/framework/pull/3170 was supposed to fix this, but I'm not sure where I got `startUserId` from, that has never been part of the discussion frontend attributes. (and the title of that fix refers to the wrong class as well).

This PR loads the author relationship by default to compare against.

**Reviewers should focus on:**
We could also just introduce the attribute above, instead of loading the relationship.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
