### PR TITLE
possibly fixes the issue with post number calculation

### DIFF
--- a/extensions/approval/src/Listener/UnapproveNewContent.php
+++ b/extensions/approval/src/Listener/UnapproveNewContent.php
@@ -24,7 +24,7 @@ class UnapproveNewContent
         $post = $event->post;
 
         if (! $post->exists) {
-            $ability = $post->discussion->post_number_index == 0 ? 'startWithoutApproval' : 'replyWithoutApproval';
+            $ability = $post->discussion->first_post_id === null ? 'startWithoutApproval' : 'replyWithoutApproval';
 
             if ($event->actor->can($ability, $post->discussion)) {
                 if ($post->is_approved === null) {

--- a/framework/core/src/Discussion/Discussion.php
+++ b/framework/core/src/Discussion/Discussion.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Str;
  * @property string $slug
  * @property int $comment_count
  * @property int $participant_count
- * @property int $post_number_index
+ * @property int $post_number_index !!DEPRECATED!!
  * @property \Carbon\Carbon $created_at
  * @property int|null $user_id
  * @property int|null $first_post_id

--- a/framework/core/src/Post/Command/PostReplyHandler.php
+++ b/framework/core/src/Post/Command/PostReplyHandler.php
@@ -74,7 +74,7 @@ class PostReplyHandler
 
         // If this is the first post in the discussion, it's technically not a
         // "reply", so we won't check for that permission.
-        if ($discussion->post_number_index > 0) {
+        if ($discussion->first_post_id !== null) {
             $actor->assertCan('reply', $discussion);
         }
 

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -99,7 +99,7 @@ class Post extends AbstractModel
             $post->number = new Expression('('.$db
                     ->table('posts', 'pn')
                     ->whereRaw('pn.discussion_id = '.intval($post->discussion_id))
-                    ->select($db->raw('max('. $db->getTablePrefix() .'pn.number) + 1'))
+                    ->select($db->raw('max('.$db->getTablePrefix().'pn.number) + 1'))
                     ->toSql()
                 .')');
         });

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -96,9 +96,9 @@ class Post extends AbstractModel
 
             /** @var ConnectionInterface $db */
             $db = static::getConnectionResolver();
-            $post->number = new Expression('('. $db
+            $post->number = new Expression('('.$db
                     ->table('posts', 'pn')
-                    ->whereRaw('pn.discussion_id = ' . intval($post->discussion_id))
+                    ->whereRaw('pn.discussion_id = '.intval($post->discussion_id))
                     ->select($db->raw('max(pn.number) + 1'))
                     ->toSql()
                 .')');

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -99,7 +99,7 @@ class Post extends AbstractModel
             $post->number = new Expression('('.$db
                     ->table('posts', 'pn')
                     ->whereRaw('pn.discussion_id = '.intval($post->discussion_id))
-                    ->select($db->raw('max(pn.number) + 1'))
+                    ->select($db->raw('max('. $db->getTablePrefix() .'pn.number) + 1'))
                     ->toSql()
                 .')');
         });

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -98,7 +98,7 @@ class Post extends AbstractModel
             $db = static::getConnectionResolver();
             $post->number = new Expression('('.$db
                     ->table('posts', 'pn')
-                    ->whereRaw('pn.discussion_id = '.intval($post->discussion_id))
+                    ->whereRaw($db->getTablePrefix().'pn.discussion_id = '.intval($post->discussion_id))
                     ->select($db->raw('max('.$db->getTablePrefix().'pn.number) + 1'))
                     ->toSql()
                 .')');

--- a/framework/core/tests/integration/api/posts/ListTest.php
+++ b/framework/core/tests/integration/api/posts/ListTest.php
@@ -59,7 +59,7 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals([], $data['data']);
+        $this->assertEqualsCanonicalizing([], $data['data']);
     }
 
     /**
@@ -92,7 +92,7 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals(['1', '2'], Arr::pluck($data['data'], 'id'));
+        $this->assertEqualsCanonicalizing(['1', '2'], Arr::pluck($data['data'], 'id'));
     }
 
     /**
@@ -110,7 +110,7 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals(['1', '2', '3', '4', '5'], Arr::pluck($data['data'], 'id'));
+        $this->assertEqualsCanonicalizing(['1', '2', '3', '4', '5'], Arr::pluck($data['data'], 'id'));
     }
 
     /**
@@ -128,7 +128,7 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals(['1', '3'], Arr::pluck($data['data'], 'id'));
+        $this->assertEqualsCanonicalizing(['1', '3'], Arr::pluck($data['data'], 'id'));
     }
 
     /**
@@ -146,7 +146,7 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals(['5'], Arr::pluck($data['data'], 'id'));
+        $this->assertEqualsCanonicalizing(['5'], Arr::pluck($data['data'], 'id'));
     }
 
     /**
@@ -164,7 +164,7 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals(['3', '4'], Arr::pluck($data['data'], 'id'));
+        $this->assertEqualsCanonicalizing(['3', '4'], Arr::pluck($data['data'], 'id'));
     }
 
     /**
@@ -182,7 +182,7 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals(['4'], Arr::pluck($data['data'], 'id'));
+        $this->assertEqualsCanonicalizing(['4'], Arr::pluck($data['data'], 'id'));
     }
 
     /**
@@ -200,6 +200,6 @@ class ListTests extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertEquals(['1', '3', '5'], Arr::pluck($data['data'], 'id'));
+        $this->assertEqualsCanonicalizing(['1', '3', '5'], Arr::pluck($data['data'], 'id'));
     }
 }


### PR DESCRIPTION
This PR fixes the post number calculation causing exceptions `Integrity constraint violation: 1062 Duplicate entry` as reported by @iPurpl3x and clearly visible in highly volatile communities.

This fix is currently applied to a non-public Flarum instance running in sync with the production community by Bokt (@BartVB). The last error reported was a bit less than 40 minutes ago, with posts happening every second I expect this issue to recur at least a few times the coming 24 hours. If the issue occurs again this PR is invalid.

Will report back.