### PR TITLE
a11y: use `feed` aria role for DiscussionList

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionList.js
+++ b/framework/core/js/src/forum/components/DiscussionList.js
@@ -49,11 +49,12 @@ export default class DiscussionList extends Component {
         <ul role="feed" aria-busy={isLoading} className="DiscussionList-discussions">
           {state.getPages().map((pg, pageNum) => {
             return pg.items.map((discussion, itemNum) => (
-              <li key={discussion.id()}
-                  data-id={discussion.id()} 
-                  role="article"
-                  aria-setsize="-1"
-                  aria-posinset={pageNum * pageSize + itemNum}
+              <li
+                key={discussion.id()}
+                data-id={discussion.id()} 
+                role="article"
+                aria-setsize="-1"
+                aria-posinset={pageNum * pageSize + itemNum}
               >
                 <DiscussionListItem discussion={discussion} params={params} />
               </li>

--- a/framework/core/js/src/forum/components/DiscussionList.js
+++ b/framework/core/js/src/forum/components/DiscussionList.js
@@ -4,6 +4,7 @@ import DiscussionListItem from './DiscussionListItem';
 import Button from '../../common/components/Button';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Placeholder from '../../common/components/Placeholder';
+import classList from '../../common/utils/classList';
 
 /**
  * The `DiscussionList` component displays a list of discussions.
@@ -20,9 +21,11 @@ export default class DiscussionList extends Component {
     const state = this.attrs.state;
 
     const params = state.getParams();
+    const isLoading = state.isInitialLoading() || state.isLoadingNext();
+
     let loading;
 
-    if (state.isInitialLoading() || state.isLoadingNext()) {
+    if (isLoading) {
       loading = <LoadingIndicator />;
     } else if (state.hasNext()) {
       loading = Button.component(
@@ -40,7 +43,7 @@ export default class DiscussionList extends Component {
     }
 
     return (
-      <div className={'DiscussionList' + (state.isSearchResults() ? ' DiscussionList--searchResults' : '')}>
+      <div role="feed" aria-busy={isLoading} class={classList('DiscussionList', { 'DiscussionList--searchResults': state.isSearchResults() })}>
         <ul className="DiscussionList-discussions">
           {state.getPages().map((pg) => {
             return pg.items.map((discussion) => (

--- a/framework/core/js/src/forum/components/DiscussionList.js
+++ b/framework/core/js/src/forum/components/DiscussionList.js
@@ -49,13 +49,7 @@ export default class DiscussionList extends Component {
         <ul role="feed" aria-busy={isLoading} className="DiscussionList-discussions">
           {state.getPages().map((pg, pageNum) => {
             return pg.items.map((discussion, itemNum) => (
-              <li
-                key={discussion.id()}
-                data-id={discussion.id()} 
-                role="article"
-                aria-setsize="-1"
-                aria-posinset={pageNum * pageSize + itemNum}
-              >
+              <li key={discussion.id()} data-id={discussion.id()} role="article" aria-setsize="-1" aria-posinset={pageNum * pageSize + itemNum}>
                 <DiscussionListItem discussion={discussion} params={params} />
               </li>
             ));

--- a/framework/core/js/src/forum/components/DiscussionList.js
+++ b/framework/core/js/src/forum/components/DiscussionList.js
@@ -42,13 +42,20 @@ export default class DiscussionList extends Component {
       return <div className="DiscussionList">{Placeholder.component({ text })}</div>;
     }
 
+    const pageSize = state.pageSize;
+
     return (
-      <div role="feed" aria-busy={isLoading} class={classList('DiscussionList', { 'DiscussionList--searchResults': state.isSearchResults() })}>
-        <ul className="DiscussionList-discussions">
-          {state.getPages().map((pg) => {
-            return pg.items.map((discussion) => (
-              <li key={discussion.id()} data-id={discussion.id()}>
-                {DiscussionListItem.component({ discussion, params })}
+      <div class={classList('DiscussionList', { 'DiscussionList--searchResults': state.isSearchResults() })}>
+        <ul role="feed" aria-busy={isLoading} className="DiscussionList-discussions">
+          {state.getPages().map((pg, pageNum) => {
+            return pg.items.map((discussion, itemNum) => (
+              <li key={discussion.id()}
+                  data-id={discussion.id()} 
+                  role="article"
+                  aria-setsize="-1"
+                  aria-posinset={pageNum * pageSize + itemNum}
+              >
+                <DiscussionListItem discussion={discussion} params={params} />
               </li>
             ));
           })}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**FIxes flarum/framework#3363**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Uses `role=feed` on discussion list

Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role

> If the number of articles is known, set [aria-setsize](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) on the articles themselves. However, if the total number is extremely large, indefinite, or changes often, set aria-setsize="-1" to indicate that the size of the feed is not known.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] ~~Backend changes: tests are green (run `composer test`).~~
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
