### PR TITLE
feat: allow multiple children to be passed to ConfirmDocumentUnload component

### DIFF
--- a/framework/core/js/src/common/components/ConfirmDocumentUnload.js
+++ b/framework/core/js/src/common/components/ConfirmDocumentUnload.js
@@ -9,12 +9,6 @@ import Component from '../Component';
  *
  * - `when` - a callback returning true when the browser should prompt for
  *            confirmation before closing the window/tab
- *
- * ### Children
- *
- * NOTE: Only the first child will be rendered. (Use this component to wrap
- * another component / DOM element.)
- *
  */
 export default class ConfirmDocumentUnload extends Component {
   handler() {
@@ -37,6 +31,6 @@ export default class ConfirmDocumentUnload extends Component {
   view(vnode) {
     // To avoid having to render another wrapping <div> here, we assume that
     // this component is only wrapped around a single element / component.
-    return vnode.children[0];
+    return <>{vnode.children}</>;
   }
 }

--- a/framework/core/js/src/common/components/ConfirmDocumentUnload.js
+++ b/framework/core/js/src/common/components/ConfirmDocumentUnload.js
@@ -29,8 +29,6 @@ export default class ConfirmDocumentUnload extends Component {
   }
 
   view(vnode) {
-    // To avoid having to render another wrapping <div> here, we assume that
-    // this component is only wrapped around a single element / component.
     return <>{vnode.children}</>;
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Lets you pass multiple children to the ConfirmDocumentUnload component through the use of a Mithril fragment.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
As far as I can see, the only reason this was not done before was because of the impression that this could only be done through a wrapping DOM component rather than a fragment.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
