### PR TITLE
fix: extension listeners added before core listeners

### DIFF
--- a/framework/core/src/Extend/Event.php
+++ b/framework/core/src/Extend/Event.php
@@ -60,13 +60,13 @@ class Event implements ExtenderInterface
     {
         $events = $container->make(Dispatcher::class);
 
-        foreach ($this->listeners as $listener) {
-            $events->listen($listener[0], $listener[1]);
-        }
-
         $app = $container->make('flarum');
 
         $app->booted(function () use ($events) {
+            foreach ($this->listeners as $listener) {
+                $events->listen($listener[0], $listener[1]);
+            }
+
             foreach ($this->subscribers as $subscriber) {
                 $events->subscribe($subscriber);
             }


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Currently, extension listeners are registered very early in the process, before core listeners, which seems unideal as extensions might expect core behavior to happen first in certain cases.

**Reviewers should focus on:**
That said, this may or may not break certain extension behaviors that might rely on the current order. So we might want to actually play it safe and do this in 2.0, need additional thoughts on this.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.