### PR TITLE
fix(subscriptions): filter followed discussions when searching

### DIFF
--- a/extensions/subscriptions/js/src/forum/addSubscriptionFilter.js
+++ b/extensions/subscriptions/js/src/forum/addSubscriptionFilter.js
@@ -38,7 +38,13 @@ export default function addSubscriptionFilter() {
 
   extend(DiscussionListState.prototype, 'requestParams', function (params) {
     if (this.params.onFollowing) {
-      params.filter.subscription = 'following';
+      params.filter ||= {};
+
+      if (params.filter.q) {
+        params.filter.q += ' is:following';
+      } else {
+        params.filter.subscription = 'following';
+      }
     }
   });
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3375**

**Changes proposed in this pull request:**
- fix(subscriptions): filter followed discussions when searching in following page
- added `params.filter ||= {}` cause i think we basically rely on tags for it? unsure, may not be needed


**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
- [X] Core developer confirmed locally this works as intended.
- ~~Tests have been added, or are not appropriate here.~~
