### PR TITLE
feat(emoji): support emoji 14 & unicode 14

### DIFF
--- a/extensions/emoji/js/package.json
+++ b/extensions/emoji/js/package.json
@@ -4,18 +4,18 @@
     "version": "0.0.0",
     "prettier": "@flarum/prettier-config",
     "dependencies": {
-        "simple-emoji-map": "^0.4.1",
-        "twemoji": "^13.1.0"
+        "simple-emoji-map": "^0.5.1",
+        "twemoji": "^14.0.2"
     },
     "devDependencies": {
-        "prettier": "^2.5.1",
-        "flarum-webpack-config": "^2.0.0",
-        "webpack": "^5.65.0",
-        "webpack-cli": "^4.9.1",
         "@flarum/prettier-config": "^1.0.0",
         "flarum-tsconfig": "^1.0.2",
+        "flarum-webpack-config": "^2.0.0",
+        "prettier": "^2.5.1",
         "typescript": "^4.5.4",
-        "typescript-coverage-report": "^0.6.1"
+        "typescript-coverage-report": "^0.6.1",
+        "webpack": "^5.65.0",
+        "webpack-cli": "^4.9.1"
     },
     "scripts": {
         "dev": "webpack --mode development --watch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,7 +1520,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1645,16 +1645,16 @@ core-js-compat@^3.20.2, core-js-compat@^3.21.0:
     browserslist "^4.19.1"
     semver "7.0.0"
 
-cosmiconfig@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
-  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+cosmiconfig@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
   dependencies:
     "@types/parse-json" "^4.0.0"
-    import-fresh "^3.1.0"
+    import-fresh "^3.2.1"
     parse-json "^5.0.0"
     path-type "^4.0.0"
-    yaml "^1.7.2"
+    yaml "^1.10.0"
 
 cross-env@^7.0.3:
   version "7.0.3"
@@ -1718,10 +1718,10 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emojibase-data@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/emojibase-data/-/emojibase-data-5.1.1.tgz#0a0d63dd07ce1376b3d27642f28cafa46f651de6"
-  integrity sha512-za/ma5SfogHjwUmGFnDbTvSfm8GGFvFaPS27GPti16YZSp5EPgz+UDsZCATXvJGit+oRNBbG/FtybXHKi2UQgQ==
+emojibase-data@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/emojibase-data/-/emojibase-data-7.0.1.tgz#a81d7fcd12247f7d94a96dcbdb143e6b6dd5c328"
+  integrity sha512-BLZpOdwyFpZ7lzBWyDtnxmKVm/SJMYgAfp1if3o6n1TVUMSXAf0nikONXl90LZuJ/m3XWPBkkubgCet2BsCGGQ==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -2025,7 +2025,7 @@ iframe-resizer@^4.3.2:
   resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.3.2.tgz#42dd88345d18b9e377b6044dddb98c664ab0ce6b"
   integrity sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA==
 
-import-fresh@^3.1.0:
+import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -2827,14 +2827,15 @@ signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-simple-emoji-map@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/simple-emoji-map/-/simple-emoji-map-0.4.1.tgz#1703d1bf49f9700f33ba4e258f7277c6ab3521ca"
-  integrity sha512-K40UJhKs0VGE4gXj4cV/REnBLIUfPJ5n+eLWwpaOWQmjnJnK1+uyw/KIqFAWemD1kpsL2/khUNYRLe48YH9MKA==
+simple-emoji-map@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/simple-emoji-map/-/simple-emoji-map-0.5.1.tgz#d42ceeec8f0dcda574587a62e59adfd087dc91d4"
+  integrity sha512-IBi769OaG3BjXCu0WnweB50OcRgQ18HJMZ1bFdzWits8lepmbgGgCdKF+preHiIAqa+wQyff1nAVVydOXrIhng==
   dependencies:
-    cosmiconfig "^6.0.0"
-    emojibase-data "^5.0.1"
-    twemoji "^13.0.0"
+    chalk "^4.1.2"
+    cosmiconfig "^7.0.1"
+    emojibase-data "^7.0.1"
+    twemoji "^14.0.2"
 
 sirv@^1.0.7:
   version "1.0.19"
@@ -3026,19 +3027,19 @@ tweetnacl@^1.0.3:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
-twemoji-parser@13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-13.1.0.tgz#65e7e449c59258791b22ac0b37077349127e3ea4"
-  integrity sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg==
+twemoji-parser@14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-14.0.0.tgz#13dabcb6d3a261d9efbf58a1666b182033bf2b62"
+  integrity sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA==
 
-twemoji@^13.0.0, twemoji@^13.1.0:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-13.1.1.tgz#6e31409908bb5383cdb1d09c9c8e7856aa6e2e3b"
-  integrity sha512-IIIoq+n1lk1M1+evBKZD3DO0ud02fDQ4ssbgAv8rp3YBWUeNmskjlisFUPPDacQ50XS3bhrd4Kq9Q2gqhxb0dg==
+twemoji@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-14.0.2.tgz#c53adb01dab22bf4870f648ca8cc347ce99ee37e"
+  integrity sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==
   dependencies:
     fs-extra "^8.0.1"
     jsonfile "^5.0.0"
-    twemoji-parser "13.1.0"
+    twemoji-parser "14.0.0"
     universalify "^0.1.2"
 
 type-coverage-core@^2.17.2:
@@ -3243,7 +3244,7 @@ ws@^7.3.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
 
-yaml@^1.7.2:
+yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Update `twemoji` & `simple-emoji-map` for emoji 14 & unicode 14
    - `forum.js`: 63.9 KB to 74.4 KB (wouldn't it be nice to lazy load these for the composer... 😅)

**Reviewers should focus on:**
The shortcodes of emojis changed in `emojibase-data` v6 or v7, which `simple-emoji-map` uses. 
Do we care that there are differences there? In other words, do we want to keep using the legacy shortnames?


The following file would allow the continued use of the old emoji shortcodes with support for the new ones.
(Or use a set other than `emojibase` entirely - https://github.com/milesj/emojibase/tree/emojibase-data%407.0.1/packages/data/en/shortcodes)
<details>

<summary><code>.simple-emoji-map</code></summary>

```json
{
    "shortcodes": {
        "dataset": "emojibase-legacy",
        "fallbackDataset": "emojibase"
    },
}
```

</details>

**Screenshot**
Current vs new emojis (some with new shortnames):

![Artboard](https://user-images.githubusercontent.com/6401250/161637224-9bd308c8-7a34-4d31-ad34-509ce036838f.png)


**Necessity**

- ~~Has the problem that is being solved here been clearly explained?~~
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
- [X] Core developer confirmed locally this works as intended.
- ~~Tests have been added, or are not appropriate here.~~
