### PR TITLE
fix: notification timestamp mismatched from other core code

### DIFF
--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -221,7 +221,7 @@ class Notification extends AbstractModel
     public static function notify(array $recipients, BlueprintInterface $blueprint)
     {
         $attributes = static::getBlueprintAttributes($blueprint);
-        $now = Carbon::now('utc')->toDateTimeString();
+        $now = Carbon::now()->toDateTimeString();
 
         static::insert(
             array_map(function (User $user) use ($attributes, $now) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
When running Flarum with a customised config on a server which uses a non-UTC timezone, there is a mismatch with notifications since these are handled as UTC, while other timestamps are handled in local time. This PR changes notifications to use local time, like everything else in core.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Does this present an issue for existing communities? I argue not, as noone else has noticed this until now, so a fix would have just as small of an effect as the current issue has.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
