### PR TITLE
fix: Check for null before attempting ->getRelations()

### DIFF
--- a/extensions/mentions/src/Formatter/FormatUserMentions.php
+++ b/extensions/mentions/src/Formatter/FormatUserMentions.php
@@ -45,7 +45,7 @@ class FormatUserMentions
     public function __invoke(Renderer $renderer, $context, string $xml)
     {
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($context) {
-            $user = (isset($context->getRelations()['mentionsUsers']) || $context instanceof Post)
+            $user = (($context && isset($context->getRelations()['mentionsUsers'])) || $context instanceof Post)
                 ? $context->mentionsUsers->find($attributes['id'])
                 : User::find($attributes['id']);
 

--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -51,7 +51,7 @@ class UnparseUserMentions
     protected function updateUserMentionTags($context, string $xml): string
     {
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($context) {
-            $user = (isset($context->getRelations()['mentionsUsers']) || $context instanceof Post)
+            $user = (($context && isset($context->getRelations()['mentionsUsers'])) || $context instanceof Post)
                 ? $context->mentionsUsers->find($attributes['id'])
                 : User::find($attributes['id']);
 


### PR DESCRIPTION
Follows up on https://github.com/flarum/mentions/pull/79

With this implementation, when a 3rd party extension uses the renderer for a user mention, and does not pass any `context`, an error occurs:

`Call to a member function getRelations() on null in /opt/flarum/vendor/flarum/mentions/src/Formatter/FormatUserMentions.php:48`

This is because `isset` does not first check that `$context` is not null, before attempting to evaluate `->getRelations()`

This PR looks to address this. Locally tested.
