### PR TITLE
fix: php8.1 deprecation warnings

### DIFF
--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -37,7 +37,6 @@
     },
     "require": {
         "php": ">=7.3",
-        "axy/sourcemap": "^0.1.4",
         "components/font-awesome": "^5.14.0",
         "dflydev/fig-cookies": "^3.0.0",
         "doctrine/dbal": "^2.7",
@@ -75,6 +74,8 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "s9e/text-formatter": "^2.3.6",
+        "sycho/json-api": "^0.5.0",
+        "sycho/sourcemap": "^2.0.0",
         "symfony/config": "^5.2.2",
         "symfony/console": "^5.2.2",
         "symfony/event-dispatcher": "^5.2.2",
@@ -82,7 +83,6 @@
         "symfony/polyfill-intl-messageformatter": "^1.22.0",
         "symfony/translation": "^5.1.5",
         "symfony/yaml": "^5.2.2",
-        "tobscure/json-api": "^0.3.0",
         "wikimedia/less.php": "^3.0"
     },
     "require-dev": {

--- a/framework/core/src/Foundation/Config.php
+++ b/framework/core/src/Foundation/Config.php
@@ -53,22 +53,23 @@ class Config implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return Arr::get($this->data, $offset);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return Arr::has($this->data, $offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new RuntimeException('The Config is immutable');
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new RuntimeException('The Config is immutable');
     }


### PR DESCRIPTION
**Fixes #3383**

**Changes proposed in this pull request:**
* Fixes the 4 instances of deprecations with PHP 8.1 on our codebase.
* I have forked `axy/sourcemap` and `tobscure/json-api` and updated them to support PHP 8.1
* The effect cannot be noticed until this is merged: https://github.com/flarum/.github/pull/7

**Reviewers should focus on:**
Do we want to move the newly forked packages under `flarum` ? the packages that needed forking and updating were: `axy/sourcemap` `axy/errors` `axy/codecs-base64vlq` and `tobscure/json-api`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] https://github.com/flarum/.github/pull/7
