### PR TITLE
fix: slug transliteration assuming the language is always `en`

### DIFF
--- a/framework/core/src/Discussion/Discussion.php
+++ b/framework/core/src/Discussion/Discussion.php
@@ -18,6 +18,7 @@ use Flarum\Discussion\Event\Renamed;
 use Flarum\Discussion\Event\Restored;
 use Flarum\Discussion\Event\Started;
 use Flarum\Foundation\EventGeneratorTrait;
+use Flarum\Locale\LocaleManager;
 use Flarum\Notification\Notification;
 use Flarum\Post\MergeableInterface;
 use Flarum\Post\Post;
@@ -445,6 +446,6 @@ class Discussion extends AbstractModel
     protected function setTitleAttribute($title)
     {
         $this->attributes['title'] = $title;
-        $this->slug = Str::slug($title);
+        $this->slug = Str::slug($title, '-', resolve(LocaleManager::class)->getLocale());
     }
 }

--- a/framework/core/tests/integration/api/discussions/CreateTest.php
+++ b/framework/core/tests/integration/api/discussions/CreateTest.php
@@ -136,6 +136,35 @@ class CreateTest extends TestCase
     /**
      * @test
      */
+    public function can_create_discussion_with_current_lang_slug_transliteration()
+    {
+        $this->app()->getContainer()->make('flarum.locales')->setLocale('zh');
+
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => '我是一个土豆',
+                            'content' => 'predetermined content for automated testing',
+                        ],
+                    ]
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        /** @var Discussion $discussion */
+        $discussion = Discussion::firstOrFail();
+
+        $this->assertEquals('wo-shi-yi-ge-tu-dou', $discussion->slug);
+    }
+
+    /**
+     * @test
+     */
     public function discussion_creation_limited_by_throttler()
     {
         $this->send(


### PR DESCRIPTION
**Changes proposed in this pull request:**
Right now slugs are generated from transliterated title, but always assuming `en` language. So if a forum is using another language with different characters like Chinese, transliteration doesn't work.

This PR passes the forum's current locale code to the `slug` method of laravel, to properly transliterate into the forum's language.

**Reviewers should focus on:**
The problem however is if a forum uses multiple languages it won't work because laravel's `slug` doesn't detect language on its own, so for example on discuss if someone created a discussion with a Japanese title, the slug will not work, but I believe this is still better than not.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
