### PR TITLE
fix: incorrect tooltip docs for `tooltipVisible` attr

### DIFF
--- a/framework/core/js/src/common/components/Tooltip.tsx
+++ b/framework/core/js/src/common/components/Tooltip.tsx
@@ -12,9 +12,9 @@ export interface TooltipAttrs extends Mithril.CommonAttributes<TooltipAttrs, Too
    */
   text: string | string[];
   /**
-   * Manually show tooltip. `false` will show based on cursor events.
+   * Use to manually show or hide the tooltip. `undefined` will show based on cursor events.
    *
-   * Default: `false`.
+   * Default: `undefined`.
    */
   tooltipVisible?: boolean;
   /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- fixes incorrect info in docblock for `tooltipVisible` attr

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
