### PR TITLE
fix(a11y): Tag selection modal input visibility

### DIFF
--- a/extensions/tags/less/forum/TagDiscussionModal.less
+++ b/extensions/tags/less/forum/TagDiscussionModal.less
@@ -44,6 +44,7 @@
   }
 }
 .TagsInput {
+  .add-keyboard-focus-ring(":focus-within");
   padding-top: 0;
   padding-bottom: 0;
   overflow: hidden;
@@ -57,6 +58,7 @@
     border: 0 !important;
     padding: 0;
     max-width: 100%;
+    min-width: 1ch;
     margin-right: -100%;
     background: transparent !important;
   }
@@ -66,6 +68,7 @@
 }
 .TagsInput-selected {
   .TagsInput-tag {
+    display: inline-flex;
     margin-right: 5px;
 
     &:last-child {


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
The tag selection modal input contains misaligned selected tags and the cursor is not visible on the input. There is also no focus ring indicating that it is an input.

**Screenshot**
Before | After
--- | ---
![Screenshot from 2022-05-06 11-33-55](https://user-images.githubusercontent.com/20267363/167119038-9cb9ec99-7c18-4736-bd57-7e3035a7cf1a.png) | ![Screenshot from 2022-05-06 11-55-28](https://user-images.githubusercontent.com/20267363/167119051-8be9625f-cb2f-4410-9e6c-a2c06ec7bfd9.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
