### PR TITLE
fix: Composer discussion title not visible with certain colors

### DIFF
--- a/framework/core/less/forum/Composer.less
+++ b/framework/core/less/forum/Composer.less
@@ -39,7 +39,7 @@
   h3 {
     margin: 0;
     line-height: 1.5em;
-    color: var(--secondary-color);
+    color: var(--control-color);
 
     &,
     input,


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
When a secondary color of `#efefef` for example is used, the composer discussion title is not visible when focused out. the control color value should be used instead.

**Screenshot**
Before | After
--- | ---
![Screenshot from 2022-05-06 13-28-55](https://user-images.githubusercontent.com/20267363/167132304-0442bc91-930b-4b09-9f42-3f31df771f13.png) | ![Screenshot from 2022-05-06 13-29-15](https://user-images.githubusercontent.com/20267363/167132325-e4fb0804-72ab-45d9-8dec-e9ae97067b17.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [x] Related documentation PR: (Remove if irrelevant)
- [x] Related core extension PRs: (Remove if irrelevant)
