### PR TITLE
fix: first posts having `NULL` as value for number column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+vendor
+composer.lock

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -99,6 +99,7 @@ class Post extends AbstractModel
             $post->number = new Expression('('.
                 $db->table('posts', 'pn')
                     ->whereRaw($db->getTablePrefix().'pn.discussion_id = '.intval($post->discussion_id))
+                    // IFNULL only works on MySQL/MariaDB
                     ->selectRaw('IFNULL(MAX('.$db->getTablePrefix().'pn.number), 0) + 1')
                     ->toSql()
             .')');

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -96,12 +96,12 @@ class Post extends AbstractModel
 
             /** @var ConnectionInterface $db */
             $db = static::getConnectionResolver();
-            $post->number = new Expression('('.$db
-                    ->table('posts', 'pn')
+            $post->number = new Expression('('.
+                $db->table('posts', 'pn')
                     ->whereRaw($db->getTablePrefix().'pn.discussion_id = '.intval($post->discussion_id))
-                    ->select($db->raw('max('.$db->getTablePrefix().'pn.number) + 1'))
+                    ->selectRaw('IFNULL(MAX('.$db->getTablePrefix().'pn.number), 0) + 1')
                     ->toSql()
-                .')');
+            .')');
         });
 
         static::created(function (self $post) {


### PR DESCRIPTION
**Introduced in #3358** 

**Changes proposed in this pull request:**
We didn't account for new discussions (first posts) at that point the max returns `NULL` since there are no posts for that discussion yet. So this PR introduces a fallback value of 0.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
