### PR TITLE
fix: slug generation uses actor locale instead of forum default

### DIFF
--- a/framework/core/src/Discussion/Discussion.php
+++ b/framework/core/src/Discussion/Discussion.php
@@ -18,7 +18,6 @@ use Flarum\Discussion\Event\Renamed;
 use Flarum\Discussion\Event\Restored;
 use Flarum\Discussion\Event\Started;
 use Flarum\Foundation\EventGeneratorTrait;
-use Flarum\Locale\LocaleManager;
 use Flarum\Notification\Notification;
 use Flarum\Post\MergeableInterface;
 use Flarum\Post\Post;

--- a/framework/core/src/Discussion/Discussion.php
+++ b/framework/core/src/Discussion/Discussion.php
@@ -22,6 +22,7 @@ use Flarum\Locale\LocaleManager;
 use Flarum\Notification\Notification;
 use Flarum\Post\MergeableInterface;
 use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Support\Str;
 
@@ -446,6 +447,10 @@ class Discussion extends AbstractModel
     protected function setTitleAttribute($title)
     {
         $this->attributes['title'] = $title;
-        $this->slug = Str::slug($title, '-', resolve(LocaleManager::class)->getLocale());
+        $this->slug = Str::slug(
+            $title,
+            '-',
+            resolve(SettingsRepositoryInterface::class)->get('default_locale', 'en')
+        );
     }
 }

--- a/framework/core/tests/integration/api/discussions/CreateTest.php
+++ b/framework/core/tests/integration/api/discussions/CreateTest.php
@@ -169,7 +169,7 @@ class CreateTest extends TestCase
     public function can_create_discussion_with_forum_locale_transliteration()
     {
         // Forum default is traditional Chinese.
-        $this->app()->getContainer()->make('flarum.settings')->set('default_locale', 'zh');
+        $this->setting('default_locale', 'zh');
         // Actor locale is English
         $this->app()->getContainer()->make('flarum.locales')->setLocale('en');
 

--- a/framework/core/tests/integration/api/discussions/CreateTest.php
+++ b/framework/core/tests/integration/api/discussions/CreateTest.php
@@ -165,6 +165,38 @@ class CreateTest extends TestCase
     /**
      * @test
      */
+    public function can_create_discussion_with_forum_locale_transliteration()
+    {
+        // Forum default is traditional Chinese.
+        $this->app()->getContainer()->make('flarum.settings')->set('default_locale', 'zh');
+        // Actor locale is English
+        $this->app()->getContainer()->make('flarum.locales')->setLocale('en');
+
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => '我是一个土豆',
+                            'content' => 'predetermined content for automated testing',
+                        ],
+                    ]
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        /** @var Discussion $discussion */
+        $discussion = Discussion::firstOrFail();
+
+        $this->assertEquals('wo-shi-yi-ge-tu-dou', $discussion->slug);
+    }
+
+    /**
+     * @test
+     */
     public function discussion_creation_limited_by_throttler()
     {
         $this->send(

--- a/framework/core/tests/integration/api/discussions/CreateTest.php
+++ b/framework/core/tests/integration/api/discussions/CreateTest.php
@@ -139,7 +139,7 @@ class CreateTest extends TestCase
     public function can_create_discussion_with_current_lang_slug_transliteration()
     {
         // Forum default is traditional Chinese.
-        $this->app()->getContainer()->make('flarum.settings')->set('default_locale', 'zh');
+        $this->setting('default_locale', 'zh');
 
         $response = $this->send(
             $this->request('POST', '/api/discussions', [

--- a/framework/core/tests/integration/api/discussions/CreateTest.php
+++ b/framework/core/tests/integration/api/discussions/CreateTest.php
@@ -138,7 +138,8 @@ class CreateTest extends TestCase
      */
     public function can_create_discussion_with_current_lang_slug_transliteration()
     {
-        $this->app()->getContainer()->make('flarum.locales')->setLocale('zh');
+        // Forum default is traditional Chinese.
+        $this->app()->getContainer()->make('flarum.settings')->set('default_locale', 'zh');
 
         $response = $this->send(
             $this->request('POST', '/api/discussions', [


### PR DESCRIPTION
Fixes the issue with generating slugs based on actor locale not forum default locale.