### PR TITLE
fix: call abstract `Notification` methods safely with fallback

### DIFF
--- a/framework/core/js/src/forum/components/Notification.tsx
+++ b/framework/core/js/src/forum/components/Notification.tsx
@@ -13,6 +13,8 @@ export interface INotificationAttrs extends ComponentAttrs {
   notification: NotificationModel;
 }
 
+// TODO [Flarum 2.0]: Remove `?.` from abstract function calls.
+
 /**
  * The `Notification` component abstract displays a single notification.
  * Subclasses should implement the `icon`, `href`, and `content` methods.
@@ -20,7 +22,7 @@ export interface INotificationAttrs extends ComponentAttrs {
 export default abstract class Notification<CustomAttrs extends INotificationAttrs = INotificationAttrs> extends Component<CustomAttrs> {
   view(vnode: Mithril.Vnode<CustomAttrs, this>) {
     const notification = this.attrs.notification;
-    const href = this.href();
+    const href = this.href?.() ?? '';
 
     const fromUser = notification.fromUser();
 
@@ -32,9 +34,9 @@ export default abstract class Notification<CustomAttrs extends INotificationAttr
         onclick={this.markAsRead.bind(this)}
       >
         {avatar(fromUser || null)}
-        {icon(this.icon(), { className: 'Notification-icon' })}
+        {icon(this.icon?.(), { className: 'Notification-icon' })}
         <span className="Notification-title">
-          <span className="Notification-content">{this.content()}</span>
+          <span className="Notification-content">{this.content?.()}</span>
           <span className="Notification-title-spring" />
           {humanTime(notification.createdAt())}
         </span>
@@ -51,7 +53,7 @@ export default abstract class Notification<CustomAttrs extends INotificationAttr
             }}
           />
         )}
-        <div className="Notification-excerpt">{this.excerpt()}</div>
+        <div className="Notification-excerpt">{this.excerpt?.()}</div>
       </Link>
     );
   }


### PR DESCRIPTION


<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes live QA issue**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- only call Notification methods if they are defined, falling back to `undefined` if not through the use of the optional chaining operator.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

N/A


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
