### PR TITLE
Make unread notifications method public

### DIFF
--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -447,7 +447,7 @@ class User extends AbstractModel
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function getUnreadNotifications()
+    public function getUnreadNotifications()
     {
         static $cached = null;
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Makes the notifications method public in `framework/core/src/User/User.php`