### PR TITLE
docs: Fix incorrect links to docs

### DIFF
--- a/framework/core/views/install/install.php
+++ b/framework/core/views/install/install.php
@@ -1,6 +1,6 @@
 <h2>Install Flarum</h2>
 
-<p>Set up your forum by filling out your details below. If you have any trouble, get help on the <a href="https://flarum.org/docs/install.html" target="_blank">Flarum website</a>.</p>
+<p>Set up your forum by filling out your details below. If you have any trouble, get help on the <a href="https://docs.flarum.org/install" target="_blank">Flarum website</a>.</p>
 
 <form method="post">
   <div id="error" style="display:none"></div>

--- a/framework/core/views/install/problems.php
+++ b/framework/core/views/install/problems.php
@@ -1,6 +1,6 @@
 <h2>Hold Up!</h2>
 
-<p>These problems must be resolved before you can continue the installation. If you're having trouble, get help on the <a href="https://flarum.org/docs/install.html" target="_blank">Flarum website</a>.</p>
+<p>These problems must be resolved before you can continue the installation. If you're having trouble, get help on the <a href="https://docs.flarum.org/install" target="_blank">Flarum website</a>.</p>
 
 <div class="Problems">
   <?php foreach ($problems as $problem) { ?>

--- a/framework/core/views/install/update.php
+++ b/framework/core/views/install/update.php
@@ -1,6 +1,6 @@
 <h2>Update Flarum</h2>
 
-<p>Enter your database password to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="http://flarum.org/docs/update.html" target="_blank">Flarum website</a>.</p>
+<p>Enter your database password to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
 
 <form method="post">
   <div id="error" style="display:none"></div>


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Fix incorrect links to docs

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
