### PR TITLE
fix: nickname regex validation not working

### DIFF
--- a/extensions/nicknames/src/AddNicknameValidation.php
+++ b/extensions/nicknames/src/AddNicknameValidation.php
@@ -40,7 +40,7 @@ class AddNicknameValidation
             function ($attribute, $value, $fail) {
                 $regex = $this->settings->get('flarum-nicknames.regex');
                 if ($regex && ! preg_match_all("/$regex/", $value)) {
-                    $this->translator->trans('flarum-nicknames.api.invalid_nickname_message');
+                    $fail($this->translator->trans('flarum-nicknames.api.invalid_nickname_message'));
                 }
             },
             'min:'.$this->settings->get('flarum-nicknames.min'),

--- a/extensions/nicknames/tests/integration/api/RegisterTest.php
+++ b/extensions/nicknames/tests/integration/api/RegisterTest.php
@@ -74,4 +74,26 @@ class RegisterTest extends TestCase
 
         $this->assertEquals(403, $response->getStatusCode());
     }
+
+    /**
+     * @test
+     */
+    public function cant_register_with_nickname_if_invalid_regex()
+    {
+        $this->setting('flarum-nicknames.set_on_registration', true);
+        $this->setting('flarum-nicknames.regex', '^[A-z]+$');
+
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'nickname' => '007',
+                    'username' => 'test',
+                    'password' => 'too-obscure',
+                    'email' => 'test@machine.local',
+                ]
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+    }
 }

--- a/extensions/nicknames/tests/integration/api/RegisterTest.php
+++ b/extensions/nicknames/tests/integration/api/RegisterTest.php
@@ -96,4 +96,26 @@ class RegisterTest extends TestCase
 
         $this->assertEquals(422, $response->getStatusCode());
     }
+
+    /**
+     * @test
+     */
+    public function can_register_with_nickname_if_valid_regex()
+    {
+        $this->setting('flarum-nicknames.set_on_registration', true);
+        $this->setting('flarum-nicknames.regex', '^[A-z]+$');
+
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'nickname' => 'Acme',
+                    'username' => 'test',
+                    'password' => 'too-obscure',
+                    'email' => 'test@machine.local',
+                ]
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
**Fixes #3416**

**Changes proposed in this pull request:**
The validator doesn't call the failure callback which allows rejecting non-conforming inputs.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
