### PR TITLE
fix: dropdown show results search button hidden while loading results

### DIFF
--- a/framework/core/js/src/forum/components/Search.tsx
+++ b/framework/core/js/src/forum/components/Search.tsx
@@ -130,7 +130,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
     const searchLabel = extractText(app.translator.trans('core.forum.header.search_placeholder'));
 
     const isActive = !!currentSearch;
-    const shouldShowResults = !!(!this.loadingSources && this.searchState.getValue() && this.hasFocus);
+    const shouldShowResults = !!(this.searchState.getValue() && this.hasFocus);
     const shouldShowClearButton = !!(!this.loadingSources && this.searchState.getValue());
 
     return (


### PR DESCRIPTION
**Fixes #3400**

**Changes proposed in this pull request:**
The link to more results resides in the `DiscussionSearchSource` component. Search source components are currently only rendered when all of them have finished loading results, hence why the relevant link disappears. That is unnecessary and we can directly render them, I believe this used to be the previous behavior as well.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
