### PR TITLE
fix(mentions): post mentions with deleted author not rendering

### DIFF
--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -125,10 +125,13 @@ class ConfigureMentions
     {
         $post = CommentPost::find($tag->getAttribute('id'));
 
-        if ($post && $post->user) {
+        if ($post) {
             $tag->setAttribute('discussionid', (int) $post->discussion_id);
             $tag->setAttribute('number', (int) $post->number);
-            $tag->setAttribute('displayname', $post->user->display_name);
+
+            if ($post->user) {
+                $tag->setAttribute('displayname', $post->user->display_name);
+            }
 
             return true;
         }


### PR DESCRIPTION
**Fixes #3427**

**Changes proposed in this pull request:**
The issue details the problem and solution very well.
Remember to clear the cache when testing locally.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
