### PR TITLE
fix: empty suspension message uses email template expecting one

### DIFF
--- a/extensions/suspend/locale/en.yml
+++ b/extensions/suspend/locale/en.yml
@@ -49,6 +49,7 @@ flarum-suspend:
 
   # Translations in this namespace are used by suspension email notifications
   email:
+    no_reason_given: No reason was given for this suspension.
     suspended:
       subject: Your account has been suspended
       body: |

--- a/extensions/suspend/views/emails/suspended.blade.php
+++ b/extensions/suspend/views/emails/suspended.blade.php
@@ -1,4 +1,4 @@
 {!! $translator->trans('flarum-suspend.email.suspended.body', [
 '{recipient_display_name}' => $user->display_name,
-'{suspension_message}' => $blueprint->user->suspend_message,
+'{suspension_message}' => $blueprint->user->suspend_message ?? $translator->trans('flarum-suspend.email.no_reason_given'),
 ]) !!}


### PR DESCRIPTION
**Fixes #3417**

**Changes proposed in this pull request:**
Adds a fallback message when the suspension message is empty.

**Reviewers should focus on:**
Do we want to do this or to introduce a new email template that simply does not expect a suspension message?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
