### PR TITLE
docs: ItemList set methods throw errors when keys are not present

### DIFF
--- a/framework/core/js/src/common/utils/ItemList.ts
+++ b/framework/core/js/src/common/utils/ItemList.ts
@@ -127,7 +127,7 @@ export default class ItemList<T> {
   /**
    * Replaces an item's content, if the provided item key exists.
    *
-   * If the provided `key` is not present, nothing will happen.
+   * If the provided `key` is not present, an error will be thrown.
    *
    * @param key The key of the item in the list
    * @param content The item's new content
@@ -154,7 +154,7 @@ export default class ItemList<T> {
   /**
    * Replaces an item's priority, if the provided item key exists.
    *
-   * If the provided `key` is not present, nothing will happen.
+   * If the provided `key` is not present, an error will be thrown.
    *
    * @param key The key of the item in the list
    * @param priority The item's new priority
@@ -181,6 +181,8 @@ export default class ItemList<T> {
 
   /**
    * Remove an item from the list.
+   *
+   * If the provided `key` is not present, nothing will happen.
    */
   remove(key: string): this {
     delete this._items[key];


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Corrects errors in TSDoc annotations of ItemList

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

