### PR TITLE
fix(ext typings): remove some accessibility modifiers from Component

### DIFF
--- a/framework/core/js/src/common/Component.ts
+++ b/framework/core/js/src/common/Component.ts
@@ -33,14 +33,14 @@ export default abstract class Component<Attrs extends ComponentAttrs = Component
   /**
    * The root DOM element for the component.
    */
-  protected element!: Element;
+  element!: Element;
 
   /**
    * The attributes passed into the component.
    *
    * @see https://mithril.js.org/components.html#passing-data-to-components
    */
-  protected attrs!: Attrs;
+  attrs!: Attrs;
 
   /**
    * Class component state that is persisted between redraws.
@@ -53,7 +53,7 @@ export default abstract class Component<Attrs extends ComponentAttrs = Component
    *
    * This is `undefined` by default.
    */
-  protected state!: State;
+  state!: State;
 
   /**
    * @inheritdoc
@@ -109,7 +109,7 @@ export default abstract class Component<Attrs extends ComponentAttrs = Component
    * @returns the jQuery object for the DOM node
    * @final
    */
-  protected $(selector?: string): JQuery {
+  $(selector?: string): JQuery {
     const $element = $(this.element) as JQuery<HTMLElement>;
 
     return selector ? $element.find(selector) : $element;
@@ -156,5 +156,5 @@ export default abstract class Component<Attrs extends ComponentAttrs = Component
    *
    * This can be used to assign default values for missing, optional attrs.
    */
-  protected static initAttrs<T>(attrs: T): void {}
+  static initAttrs<T>(attrs: T): void {}
 }

--- a/framework/core/js/src/forum/components/Search.tsx
+++ b/framework/core/js/src/forum/components/Search.tsx
@@ -71,11 +71,11 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
    */
   // TODO: [Flarum 2.0] Remove this.
   // @ts-expect-error This is a get accessor, while superclass defines this as a property. This is needed to prevent breaking changes, however.
-  protected get state() {
+  get state() {
     fireDeprecationWarning('`state` property of the Search component is deprecated', '3212');
     return this.searchState;
   }
-  protected set state(state: SearchState) {
+  set state(state: SearchState) {
     // Workaround to prevent triggering deprecation warnings due to Mithril
     // setting state to undefined when creating components
     state !== undefined && fireDeprecationWarning('`state` property of the Search component is deprecated', '3212');
@@ -107,7 +107,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
 
   protected navigator!: KeyboardNavigatable;
 
-  protected searchTimeout?: NodeJS.Timeout;
+  protected searchTimeout?: number;
 
   private updateMaxHeightHandler?: () => void;
 
@@ -240,7 +240,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
         if (!query) return;
 
         if (search.searchTimeout) clearTimeout(search.searchTimeout);
-        search.searchTimeout = setTimeout(() => {
+        search.searchTimeout = window.setTimeout(() => {
           if (state.isCached(query)) return;
 
           if (query.length >= (search.constructor as typeof Search).MIN_SEARCH_LEN) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
At the moment, our `Component` class has various protected attributes and methods. Sometimes, we need to override/extend these methods (`initAttrs`) or to use these attributes (`this.$`/`this.attrs`) within the body of `extend` or `override`.

This presents an issue, as our typings pretend these don't exist outside of the class and its subclasses, so show up as errors in TS.

![image](https://user-images.githubusercontent.com/7406822/169622600-9fbffcfa-b7ca-43be-85ba-118c5ae41481.png)

This PR removes those accessibility modifiers to prevent these TS errors.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

I don't see this as an issue since these are regularly used outside of the classes anyway in JS-based extends/overrides.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
