### PR TITLE
fix: settings extender working only with first instances

### DIFF
--- a/framework/core/src/Extend/Settings.php
+++ b/framework/core/src/Extend/Settings.php
@@ -95,6 +95,8 @@ class Settings implements ExtenderInterface
 
                     $defaults->put($key, $value);
                 }
+
+                return $defaults;
             });
         }
 

--- a/framework/core/tests/integration/extenders/SettingsTest.php
+++ b/framework/core/tests/integration/extenders/SettingsTest.php
@@ -173,14 +173,16 @@ class SettingsTest extends TestCase
             (new Extend\Settings())
                 ->serializeToForum('customPrefix.unavailableCustomSetting3', 'custom-prefix.unavailable_custom_setting3')
                 ->default('custom-prefix.unavailable_custom_setting3', 'extenderDefault')
+                ->default('custom-prefix.unavailable_custom_setting100', 'extenderDefault100'),
+            (new Extend\Settings())
+                ->default('custom-prefix.unavailable_custom_setting200', 'extenderDefault200')
         );
 
-        $value = $this->app()
-            ->getContainer()
-            ->make('flarum.settings')
-            ->get('custom-prefix.unavailable_custom_setting3', 'defaultParameterValue');
+        $settings = $this->app()->getContainer()->make('flarum.settings');
 
-        $this->assertEquals('extenderDefault', $value);
+        $this->assertEquals('extenderDefault', $settings->get('custom-prefix.unavailable_custom_setting3'));
+        $this->assertEquals('extenderDefault100', $settings->get('custom-prefix.unavailable_custom_setting100'));
+        $this->assertEquals('extenderDefault200', $settings->get('custom-prefix.unavailable_custom_setting200'));
     }
 
     /**


### PR DESCRIPTION
**Fixes #3438**

**Changes proposed in this pull request:**
This was an oversight, after extending the container binding it wasn't returned.
The extender still worked, but only partially, it didn't register all defaults. I'm not entirely sure yet how that even worked before.
I have tweaked the tests to catch this.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
