### PR TITLE
Bug fix - Select the correct users to notify for subscribed posts

### DIFF
--- a/extensions/subscriptions/src/Job/SendReplyNotification.php
+++ b/extensions/subscriptions/src/Job/SendReplyNotification.php
@@ -49,7 +49,7 @@ class SendReplyNotification implements ShouldQueue
         $notify = $discussion->readers()
             ->where('users.id', '!=', $post->user_id)
             ->where('discussion_user.subscription', 'follow')
-            ->where('discussion_user.last_read_post_number', $this->lastPostNumber)
+            ->where('discussion_user.last_read_post_number', '<', $this->lastPostNumber)
             ->get();
 
         $notifications->sync(


### PR DESCRIPTION
Sorry, I don't have time to do a full tested and reviewed PR feedback form to due our project deadlines.

However this has been requested via: https://discuss.flarum.org/d/30928-subscription-notifications-not-firing

The issue was that the notification would only get dispatched to users who's last read number was the same as the latest post.

However we need to send the notification to all users who have a read number LESS than the current post to make sure they are notified.

This PR hopes to solve that.