### PR TITLE
feat: split frontend asset generation into separate steps for more extensibility

### DIFF
--- a/framework/core/src/Frontend/Content/Assets.php
+++ b/framework/core/src/Frontend/Content/Assets.php
@@ -46,7 +46,7 @@ class Assets
      * @return $this
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function forFrontend(string $name): static
+    public function forFrontend(string $name): Assets
     {
         $this->assets = $this->container->make('flarum.assets.'.$name);
 

--- a/framework/core/src/Frontend/Content/Assets.php
+++ b/framework/core/src/Frontend/Content/Assets.php
@@ -18,7 +18,14 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class Assets
 {
+    /**
+     * @var Container
+     */
     protected $container;
+
+    /**
+     * @var Config
+     */
     protected $config;
 
     /**
@@ -32,26 +39,56 @@ class Assets
         $this->config = $config;
     }
 
-    public function forFrontend(string $name)
+    /**
+     * Sets the frontend to generate assets for.
+     *
+     * @param string $name frontend name
+     * @return $this
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function forFrontend(string $name): static
     {
         $this->assets = $this->container->make('flarum.assets.'.$name);
 
         return $this;
     }
 
-    public function __invoke(Document $document, Request $request)
+    public function __invoke(Document $document, Request $request): void
     {
         $locale = $request->getAttribute('locale');
 
-        $compilers = [
-            'js' => [$this->assets->makeJs(), $this->assets->makeLocaleJs($locale)],
-            'css' => [$this->assets->makeCss(), $this->assets->makeLocaleCss($locale)]
-        ];
+        $compilers = $this->assembleCompilers($locale);
 
         if ($this->config->inDebugMode()) {
             $this->forceCommit(Arr::flatten($compilers));
         }
 
+        $this->addAssetsToDocument($document, $compilers);
+    }
+
+    /**
+     * Assembles JS and CSS compilers to be used to generate frontend assets.
+     *
+     * @param string|null $locale
+     * @return array[]
+     */
+    protected function assembleCompilers(?string $locale): array
+    {
+        return [
+            'js' => [$this->assets->makeJs(), $this->assets->makeLocaleJs($locale)],
+            'css' => [$this->assets->makeCss(), $this->assets->makeLocaleCss($locale)]
+        ];
+    }
+
+    /**
+     * Adds URLs of frontend JS and CSS to the {@link Document} class.
+     *
+     * @param Document $document
+     * @param array $compilers
+     * @return void
+     */
+    protected function addAssetsToDocument(Document $document, array $compilers): void
+    {
         $document->js = array_merge($document->js, $this->getUrls($compilers['js']));
         $document->css = array_merge($document->css, $this->getUrls($compilers['css']));
     }
@@ -61,7 +98,7 @@ class Assets
      *
      * @param array $compilers
      */
-    private function forceCommit(array $compilers)
+    protected function forceCommit(array $compilers): void
     {
         /** @var CompilerInterface $compiler */
         foreach ($compilers as $compiler) {
@@ -70,10 +107,12 @@ class Assets
     }
 
     /**
+     * Maps provided {@link CompilerInterface}s to their URLs.
+     *
      * @param CompilerInterface[] $compilers
      * @return string[]
      */
-    private function getUrls(array $compilers)
+    protected function getUrls(array $compilers): array
     {
         return array_filter(array_map(function (CompilerInterface $compiler) {
             return $compiler->getUrl();


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR splits out the logic within frontend asset generation into separate protected methods on the class to allow for more simple extending of asset generation.

For example, this is particularly useful for FoF Nightmode. Instead of completely duplicating logic found in this class, it can now override methods in order to add its own CSS compiler, and will no longer need to manually force commit assets.

It also means that future changes to core are less likely to impact extensions hooking into this class (which caused https://github.com/FriendsOfFlarum/nightmode/pull/60, for example).

You can see the impact this has in this diff: https://github.com/FriendsOfFlarum/nightmode/compare/72a75dec1ed85be8a3ec0c0442a87a6688157e84..dw/flarum-1.4-rewrite

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

I'm not totally familiar with this area of core, so am unsure if this will have additional unforeseen (by me) impacts. Local testing with the Nightmode branch above does not raise any issues for me.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

