### PR TITLE
chore: Point Font Awesome icons link to v5

### DIFF
--- a/framework/core/js/src/admin/components/EditGroupModal.js
+++ b/framework/core/js/src/admin/components/EditGroupModal.js
@@ -78,7 +78,7 @@ export default class EditGroupModal extends Modal {
       <div className="Form-group">
         <label>{app.translator.trans('core.admin.edit_group.icon_label')}</label>
         <div className="helpText">
-          {app.translator.trans('core.admin.edit_group.icon_text', { a: <a href="https://fontawesome.com/icons?m=free" tabindex="-1" /> })}
+          {app.translator.trans('core.admin.edit_group.icon_text', { a: <a href="https://fontawesome.com/v5/search?m=free" tabindex="-1" /> })}
         </div>
         <input className="FormControl" placeholder="fas fa-bolt" bidi={this.icon} />
       </div>,


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Update Font Awesome link to represent the currently used major version in order to avoid confusion when choosing icons while editing or creating groups

**Screenshot**
![grafik](https://user-images.githubusercontent.com/4963183/171595983-f0ba629a-5588-4f04-b301-62ae4c07d925.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] ~Frontend changes: tested on a local Flarum installation.~
- [ ] ~Backend changes: tests are green (run `composer test`).~
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

