### PR TITLE
fix(tags): tag selection modal shown when no tags can be selected

### DIFF
--- a/extensions/tags/js/src/forum/addTagComposer.js
+++ b/extensions/tags/js/src/forum/addTagComposer.js
@@ -65,10 +65,15 @@ export default function () {
     const chosenSecondaryTags = chosenTags.filter((tag) => tag.position() === null);
     const selectableTags = getSelectableTags();
 
+    const minPrimaryTags = parseInt(app.forum.attribute('minPrimaryTags'));
+    const minSecondaryTags = parseInt(app.forum.attribute('minSecondaryTags'));
+    const maxPrimaryTags = parseInt(app.forum.attribute('maxPrimaryTags'));
+    const maxSecondaryTags = parseInt(app.forum.attribute('maxSecondaryTags'));
+
     if (
-      (!chosenTags.length ||
-        chosenPrimaryTags.length < app.forum.attribute('minPrimaryTags') ||
-        chosenSecondaryTags.length < app.forum.attribute('minSecondaryTags')) &&
+      ((!chosenTags.length && maxPrimaryTags !== 0 && maxSecondaryTags !== 0) ||
+        chosenPrimaryTags.length < minPrimaryTags ||
+        chosenSecondaryTags.length < minSecondaryTags) &&
       selectableTags.length
     ) {
       app.modal.show(TagDiscussionModal, {


### PR DESCRIPTION
**Fixes #3444**

**Changes proposed in this pull request:**
Checks that `maxPrimaryTags` and `maxSecondaryTags` are not nil before showing tag selection modal.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
