### PR TITLE
fix(suspend): suspension modal shows after suspension is over

### DIFF
--- a/extensions/suspend/js/src/forum/checkForSuspension.js
+++ b/extensions/suspend/js/src/forum/checkForSuspension.js
@@ -7,11 +7,12 @@ export default function () {
     if (app.session.user) {
       const message = app.session.user.suspendMessage();
       const until = app.session.user.suspendedUntil();
+      const isSuspended = message && until && new Date() < until;
       const alreadyDisplayed = localStorage.getItem(localStorageKey()) === until?.getTime().toString();
 
-      if (message && !alreadyDisplayed) {
+      if (isSuspended && !alreadyDisplayed) {
         app.modal.show(SuspensionInfoModal, { message, until });
-      } else if (!until && localStorage.getItem(localStorageKey())) {
+      } else if (localStorage.getItem(localStorageKey())) {
         localStorage.removeItem(localStorageKey());
       }
     }


### PR DESCRIPTION
**Fixes #3441**

**Changes proposed in this pull request:**
Checks on the frontend that `suspendedUntil` time has passed before showing the modal to the user.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.