### PR TITLE
fix(a11y: DiscussionListItem): controls dropdown not visible when tabbed into

### DIFF
--- a/framework/core/less/forum/DiscussionListItem.less
+++ b/framework/core/less/forum/DiscussionListItem.less
@@ -207,6 +207,10 @@
     opacity: 0;
     transition: opacity 0.2s;
 
+    &:focus-within {
+      opacity: 1;
+    }
+
     .Dropdown-toggle {
       display: block;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
When tabbing through `DiscussionListItem`s, the controls dropdown gains focus but remains hidden with `opacity: 0`. This PR sets `opacity: 1` when focus is within the controls DOM to make this visible again.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
