### PR TITLE
feat(translator): add locale getter

### DIFF
--- a/framework/core/js/src/common/Translator.tsx
+++ b/framework/core/js/src/common/Translator.tsx
@@ -18,8 +18,18 @@ export default class Translator {
    */
   protected formatter = new RichMessageFormatter(null, this.formatterTypeHandlers(), mithrilRichHandler);
 
+  /**
+   * Sets the formatter's locale to the provided value.
+   */
   setLocale(locale: string) {
     this.formatter.locale = locale;
+  }
+
+  /**
+   * Returns the formatter's current locale.
+   */
+  getLocale() {
+    return this.formatter.locale;
   }
 
   addTranslations(translations: Translations) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
`app.translator.formatter` is protected and considered internal API, so shouldn't be accessed directly. We should expose a public API method to get the formatter's current locale, just like we support setting the locale.

This is useful for extensions which specifically need to integrate multi-lingual support within their frontend code.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

Should we expose any other things, too?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
