### PR TITLE
feature: adds advanced link handling in core

### DIFF
--- a/framework/core/src/Extend/Link.php
+++ b/framework/core/src/Extend/Link.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;

--- a/framework/core/src/Extend/Link.php
+++ b/framework/core/src/Extend/Link.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Flarum\Foundation\Config;
+use Illuminate\Contracts\Container\Container;
+use Laminas\Diactoros\Uri;
+use s9e\TextFormatter\Renderer;
+use s9e\TextFormatter\Utils;
+
+class Link implements ExtenderInterface
+{
+    protected $setRel = null;
+    protected $setTarget = null;
+
+    public function setRel(callable $callable): static
+    {
+        $this->setRel = $callable;
+
+        return $this;
+    }
+
+    public function setTarget(callable $callable): static
+    {
+        $this->setTarget = $callable;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        $siteUrl = $container->make(Config::class)->url();
+
+        (new Formatter)->render(function (Renderer $renderer, $context, string $xml) use ($siteUrl) {
+            return Utils::replaceAttributes($xml, 'URL', function ($attributes) use ($siteUrl) {
+                $uri = isset($attributes['url'])
+                    ? new Uri($attributes['url'])
+                    : null;
+
+                $setRel = $this->setRel;
+                if ($setRel && $rel = $setRel($uri, $siteUrl, $attributes)) {
+                    $attributes['rel'] = $rel;
+                }
+
+                $setTarget = $this->setTarget;
+                if ($setTarget && $target = $setTarget($uri, $siteUrl, $attributes)) {
+                    $attributes['target'] = $target;
+                }
+
+                return $attributes;
+            });
+        })->extend($container);
+    }
+}

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -9,10 +9,14 @@
 
 namespace Flarum\Formatter;
 
+use DOMDocument;
+use DOMElement;
 use Illuminate\Contracts\Cache\Repository;
 use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Configurator;
+use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Unparser;
+use s9e\TextFormatter\Utils;
 
 class Formatter
 {
@@ -110,6 +114,8 @@ class Formatter
             $xml = $callback($renderer, $context, $xml, $request);
         }
 
+        $xml = $this->configureDefaultsOnLinks($renderer, $context, $xml, $request);
+
         return $renderer->render($xml);
     }
 
@@ -174,11 +180,13 @@ class Formatter
      */
     protected function configureExternalLinks(Configurator $configurator)
     {
+        /** @var DOMDocument $dom */
         $dom = $configurator->tags['URL']->template->asDOM();
 
+        /** @var DOMElement $a */
         foreach ($dom->getElementsByTagName('a') as $a) {
-            $rel = $a->getAttribute('rel');
-            $a->setAttribute('rel', "$rel nofollow ugc");
+            $a->prependXslCopyOf('@target');
+            $a->prependXslCopyOf('@rel');
         }
 
         $dom->saveChanges();
@@ -217,7 +225,7 @@ class Formatter
     /**
      * Get the renderer.
      *
-     * @return \s9e\TextFormatter\Renderer
+     * @return Renderer
      */
     protected function getRenderer()
     {
@@ -238,5 +246,18 @@ class Formatter
     public function getJs()
     {
         return $this->getComponent('js');
+    }
+
+    protected function configureDefaultsOnLinks(
+        Renderer $renderer,
+        mixed $context,
+        string $xml,
+        ?ServerRequestInterface $request
+    ): string {
+        return Utils::replaceAttributes($xml, 'URL', function ($attributes) {
+            $attributes['rel'] = $attributes['rel'] ?? 'ugc nofollow';
+
+            return $attributes;
+        });
     }
 }

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -102,7 +102,7 @@ class Formatter
      * Render parsed XML.
      *
      * @param string $xml
-     * @param mixed $context
+     * @param mixed|null $context
      * @param ServerRequestInterface|null $request
      * @return string
      */
@@ -250,9 +250,9 @@ class Formatter
 
     protected function configureDefaultsOnLinks(
         Renderer $renderer,
-        mixed $context,
+        mixed $context = null,
         string $xml,
-        ?ServerRequestInterface $request
+        ServerRequestInterface $request = null
     ): string {
         return Utils::replaceAttributes($xml, 'URL', function ($attributes) {
             $attributes['rel'] = $attributes['rel'] ?? 'ugc nofollow';

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -114,7 +114,7 @@ class Formatter
             $xml = $callback($renderer, $context, $xml, $request);
         }
 
-        $xml = $this->configureDefaultsOnLinks($renderer, $context, $xml, $request);
+        $xml = $this->configureDefaultsOnLinks($renderer, $xml, $context, $request);
 
         return $renderer->render($xml);
     }
@@ -250,8 +250,8 @@ class Formatter
 
     protected function configureDefaultsOnLinks(
         Renderer $renderer,
-        mixed $context = null,
         string $xml,
+        $context = null,
         ServerRequestInterface $request = null
     ): string {
         return Utils::replaceAttributes($xml, 'URL', function ($attributes) {


### PR DESCRIPTION
**Changes proposed in this pull request:**

This PR adds rel and target to textformatter so that these can be easily extended and rendered into the source.

Without using the Extender the default values `ngc nofollow` are provided as a backward compatible way.

The new extender allows conditional overrides, a proof of concept extension is available at https://github.com/luceos/flarum-ext-dofollow; I will probably migrate this into the Blomstra namespace soon.

**Reviewers should focus on:**

- is the extender okay like this
- does the fallback work like before

**Screenshot**

__Extension disabled__

<img width="561" alt="image" src="https://user-images.githubusercontent.com/504687/173109949-2c3768b5-cf6a-4981-840b-649b02d536e1.png">


__Extension enabled__

<img width="566" alt="image" src="https://user-images.githubusercontent.com/504687/173109867-548714f4-d816-4065-8615-3d838729f5e5.png">



**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
