### PR TITLE
feat(modals): support stacking modals, remove bootstrap modals dependency

### DIFF
--- a/framework/core/js/package.json
+++ b/framework/core/js/package.json
@@ -6,6 +6,7 @@
     "dependencies": {
         "@askvortsov/rich-icu-message-formatter": "^0.2.4",
         "@ultraq/icu-message-formatter": "^0.12.0",
+        "body-scroll-lock": "^4.0.0-beta.0",
         "bootstrap": "^3.4.1",
         "clsx": "^1.1.1",
         "color-thief-browser": "^2.0.2",
@@ -21,6 +22,7 @@
     },
     "devDependencies": {
         "@flarum/prettier-config": "^1.0.0",
+        "@types/body-scroll-lock": "^3.1.0",
         "@types/jquery": "^3.5.10",
         "@types/mithril": "^2.0.8",
         "@types/punycode": "^2.1.0",

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -319,8 +319,8 @@ export default class Application {
 
   protected mount(basePath: string = '') {
     // An object with a callable view property is used in order to pass arguments to the component; see https://mithril.js.org/mount.html
-    m.mount(document.getElementById('modal')!, { view: () => ModalManager.component({ state: this.modal }) });
-    m.mount(document.getElementById('alerts')!, { view: () => AlertManager.component({ state: this.alerts }) });
+    m.mount(document.getElementById('modal')!, { view: () => <ModalManager state={this.modal} /> });
+    m.mount(document.getElementById('alerts')!, { view: () => <AlertManager state={this.alerts} /> });
 
     this.drawer = new Drawer();
 

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -64,7 +64,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
             onclick={this.handlePossibleBackdropClick.bind(this)}
             ontransitionend={this.onBackdropTransitionEnd.bind(this)}
             data-showing={!!this.attrs.state.modalList.length}
-            style={{'--modal-count': this.attrs.state.modalList.length}}
+            style={{ '--modal-count': this.attrs.state.modalList.length }}
           />
         )}
       </>

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -196,7 +196,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
     }
   }
 
-  protected handlePossibleBackdropClick(e: MouseEvent | TouchEvent): void {
+  protected handlePossibleBackdropClick(e: MouseEvent): void {
     if (!this.attrs.state.modal || !this.attrs.state.modal.componentClass.dismissibleOptions.viaBackdropClick) return;
 
     this.animateHide();

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -71,7 +71,15 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
 
     requestAnimationFrame(() => {
       try {
-        if (!this.attrs.state.isModalOpen()) return;
+        // Main content should gain or lose `aria-hidden` when modals are shown/removed
+        // See: http://web-accessibility.carnegiemuseums.org/code/dialogs/
+
+        if (!this.attrs.state.isModalOpen()) {
+          document.getElementById('app')?.setAttribute('aria-hidden', 'false');
+          return;
+        }
+
+        document.getElementById('app')?.setAttribute('aria-hidden', 'true');
 
         // Get current dialog key
         const dialogKey = this.attrs.state.modal!.key;

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -2,6 +2,8 @@ import Component from '../Component';
 
 import { createFocusTrap, FocusTrap } from '../utils/focusTrap';
 
+import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
+
 import type ModalManagerState from '../states/ModalManagerState';
 import type Mithril from 'mithril';
 
@@ -77,6 +79,9 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
 
         if (!this.attrs.state.isModalOpen()) {
           document.getElementById('app')?.setAttribute('aria-hidden', 'false');
+          this.focusTrap!.deactivate?.();
+          clearAllBodyScrollLocks();
+
           return;
         }
 
@@ -88,13 +93,16 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
         // Deactivate focus trap if there's a new dialog/closed
         if (this.focusTrap && this.lastSetFocusTrap !== dialogKey) {
           this.focusTrap!.deactivate?.();
+
+          clearAllBodyScrollLocks();
         }
 
         // Activate focus trap if there's a new dialog which is not trapped yet
         if (this.activeDialogElement && this.lastSetFocusTrap !== dialogKey) {
           this.focusTrap = createFocusTrap(this.activeDialogElement as HTMLElement, { allowOutsideClick: true });
-
           this.focusTrap!.activate?.();
+
+          disableBodyScroll(this.activeDialogElement, { reserveScrollBarGap: true });
         }
 
         // Update key of current opened modal

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -26,6 +26,8 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
   // Keep track if there's an modal closing
   protected modalClosing: boolean = false;
 
+  protected keyUpListener: null | ((e: KeyboardEvent) => void) = null;
+
   view(vnode: Mithril.VnodeDOM<IModalManagerAttrs, this>): Mithril.Children {
     return this.attrs.state.modalList.map((modal, i) => {
       const Tag = modal?.componentClass;
@@ -62,12 +64,15 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
   oncreate(vnode: Mithril.VnodeDOM<IModalManagerAttrs, this>): void {
     super.oncreate(vnode);
 
-    // Register keyup
-    document.body.addEventListener('keyup', this.handleEscPress.bind(this));
+    this.keyUpListener = this.handleEscPress.bind(this);
+    document.body.addEventListener('keyup', this.keyUpListener);
   }
 
   onbeforeremove(vnode: Mithril.VnodeDOM<IModalManagerAttrs, this>): void {
-    document.body.removeEventListener('keyup', this.handleEscPress);
+    super.onbeforeremove(vnode);
+
+    this.keyUpListener && document.body.removeEventListener('keyup', this.keyUpListener);
+    this.keyUpListener = null;
   }
 
   onupdate(vnode: Mithril.VnodeDOM<IModalManagerAttrs, this>): void {

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -30,7 +30,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
 
       return (
         <div
-          className="ModalManager modal"
+          class="ModalManager modal"
           data-modal-key={modal.key}
           role="dialog"
           style={{ '--modal-number': i }}
@@ -46,7 +46,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
             />
           )}
 
-          <div className="backdrop" key={`backdrop-${modal.key}`} onclick={this.handleBackdropClick.bind(this)} />
+          <div class="backdrop" key={`backdrop-${modal.key}`} onclick={this.handleBackdropClick.bind(this)} />
         </div>
       );
     });

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -64,6 +64,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
             onclick={this.handlePossibleBackdropClick.bind(this)}
             ontransitionend={this.onBackdropTransitionEnd.bind(this)}
             data-showing={!!this.attrs.state.modalList.length}
+            style={{'--modal-count': this.attrs.state.modalList.length}}
           />
         )}
       </>

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -123,21 +123,14 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
    * Get current active dialog
    */
   private get activeDialogElement(): HTMLElement {
-    return document.body.querySelector(`.ModalManager[data-modal-key="${this?.attrs?.state?.modal?.key}"] .Modal`) as HTMLElement;
+    return document.body.querySelector(`.ModalManager[data-modal-key="${this.attrs.state.modal?.key}"] .Modal`) as HTMLElement;
   }
 
   /**
    * Get current active dialog
    */
   private get activeDialogManagerElement(): HTMLElement {
-    return document.body.querySelector(`.ModalManager[data-modal-key="${this?.attrs?.state?.modal?.key}"]`) as HTMLElement;
-  }
-
-  /**
-   * Get backdrop element of active dialog
-   */
-  private get activeBackdropElement(): HTMLElement {
-    return document.body.querySelector(`.ModalManager[data-modal-key="${this?.attrs?.state?.modal?.key}"] .backdrop`) as HTMLElement;
+    return document.body.querySelector(`.ModalManager[data-modal-key="${this.attrs.state.modal?.key}"]`) as HTMLElement;
   }
 
   animateShow(readyCallback: () => void = () => {}): void {

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -45,15 +45,20 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
               style={{ '--modal-number': i }}
               aria-hidden={this.attrs.state.modal !== modal && 'true'}
             >
-              {!!Tag && (
+              {!!Tag && [
                 <Tag
                   key={modal.key}
                   {...modal.attrs}
                   animateShow={this.animateShow.bind(this)}
                   animateHide={this.animateHide.bind(this)}
                   state={this.attrs.state}
-                />
-              )}
+                />,
+                /* This backdrop is invisible and used for outside clicks to close the modal. */
+                <div
+                  key={modal.key}
+                  className="ModalManager-invisibleBackdrop"
+                  onclick={this.handlePossibleBackdropClick.bind(this)} />
+              ]}
             </div>
           );
         })}
@@ -61,7 +66,6 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
         {this.attrs.state.backdropShown && (
           <div
             class="Modal-backdrop backdrop"
-            onclick={this.handlePossibleBackdropClick.bind(this)}
             ontransitionend={this.onBackdropTransitionEnd.bind(this)}
             data-showing={!!this.attrs.state.modalList.length}
             style={{ '--modal-count': this.attrs.state.modalList.length }}
@@ -192,7 +196,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
     }
   }
 
-  protected handlePossibleBackdropClick(e: MouseEvent): void {
+  protected handlePossibleBackdropClick(e: MouseEvent | TouchEvent): void {
     if (!this.attrs.state.modal || !this.attrs.state.modal.componentClass.dismissibleOptions.viaBackdropClick) return;
 
     this.animateHide();

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -35,6 +35,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
           data-modal-key={modal.key}
           data-modal-number={i}
           role="dialog"
+          aria-modal="true"
           style={{ '--modal-number': i }}
           data-visibility-state={modal.animationState}
           aria-hidden={this.attrs.state.modal !== modal && 'true'}

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -30,6 +30,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
 
       return (
         <div
+          key={modal.key}
           class="ModalManager modal"
           data-modal-key={modal.key}
           role="dialog"
@@ -38,7 +39,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
         >
           {!!Tag && (
             <Tag
-              key={modal?.key}
+              key={modal.key}
               {...modal.attrs}
               animateShow={this.animateShow.bind(this)}
               animateHide={this.animateHide.bind(this)}

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -25,7 +25,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
   protected modalClosing: boolean = false;
 
   view(vnode: Mithril.VnodeDOM<IModalManagerAttrs, this>): Mithril.Children {
-    return this.attrs.state.modalList.map((modal: any) => {
+    return this.attrs.state.modalList.map((modal, i) => {
       const Tag = modal?.componentClass;
 
       return (
@@ -33,7 +33,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
           className="ModalManager modal"
           data-modal-key={modal.key}
           role="dialog"
-          style={{ '--modal-number': modal.key }}
+          style={{ '--modal-number': i }}
           aria-hidden={this.attrs.state.modal !== modal && 'true'}
         >
           {!!Tag && (

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -177,7 +177,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
     this.activeDialogElement.classList.add('out');
   }
 
-  protected handleEscPress(e: KeyboardEvent): any {
+  protected handleEscPress(e: KeyboardEvent): void {
     if (!this.attrs.state.modal) return;
 
     const dismissibleState = this.attrs.state.modal.componentClass.dismissibleOptions;
@@ -191,7 +191,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
     }
   }
 
-  protected handlePossibleBackdropClick(e: MouseEvent): any {
+  protected handlePossibleBackdropClick(e: MouseEvent): void {
     if (!this.attrs.state.modal || !this.attrs.state.modal.componentClass.dismissibleOptions.viaBackdropClick) return;
 
     // If click wasn't on backdrop, exit early

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -71,8 +71,10 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
 
     requestAnimationFrame(() => {
       try {
+        if (!this.attrs.state.isModalOpen()) return;
+
         // Get current dialog key
-        const dialogKey = this?.attrs?.state?.modal?.key;
+        const dialogKey = this.attrs.state.modal!.key;
 
         // Deactivate focus trap if there's a new dialog/closed
         if (this.focusTrap && this.lastSetFocusTrap !== dialogKey) {

--- a/framework/core/js/src/common/index.ts
+++ b/framework/core/js/src/common/index.ts
@@ -5,7 +5,6 @@ import 'expose-loader?exposes=dayjs!dayjs';
 
 import 'bootstrap/js/affix';
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/modal';
 import 'bootstrap/js/tooltip';
 import 'bootstrap/js/transition';
 import 'jquery.hotkeys/jquery.hotkeys';

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -81,31 +81,23 @@ export default class ModalManagerState {
   }
 
   /**
-   * Closes the currently open dialog, if one is open.
+   * Closes the topmost currently open dialog, if one is open.
    */
   close(): void {
     if (!this.modal) return;
 
     // If there are two modals, remove the most recent one
-    if (this.modalList.length >= 2) {
-      const currentModalPosition = this.modalList.indexOf(this.modal);
-
+    if (this.modalList.length > 1) {
       // Remove last modal from list
-      this.modalList.splice(currentModalPosition, 1);
+      this.modalList.pop();
 
       // Open last modal from list
       this.modal = this.modalList[this.modalList.length - 1];
-
-      m.redraw();
-
-      return;
+    } else {
+      // Reset state
+      this.modal = null;
+      this.modalList = [];
     }
-
-    // Reset current modal
-    this.modal = null;
-
-    // Empty modal list
-    this.modalList = [];
 
     m.redraw();
   }

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -14,6 +14,7 @@ type ModalItem = {
   componentClass: UnsafeModalClass;
   attrs?: Record<string, unknown>;
   key: number;
+  animationState: 'entering' | 'entered' | 'entered-underneath' | 'exiting';
 };
 
 /**
@@ -64,12 +65,12 @@ export default class ModalManagerState {
     }
 
     // Set current modal
-    this.modal = { componentClass, attrs, key: this.key++ };
+    this.modal = { componentClass, attrs, key: this.key++, animationState: 'entering' };
 
     // We want to stack this modal
     if (stackModal) {
-      // Remember previously opened modal and
-      // add new modal to the modal list
+      // Remember previously opened modal and add new modal to the modal list
+      this.modalList.forEach((m) => (m.animationState = 'entered-underneath'));
       this.modalList.push(this.modal);
     } else {
       // Override last modals

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -10,7 +10,7 @@ import Modal, { IDismissibleOptions } from '../components/Modal';
  */
 type UnsafeModalClass = ComponentClass<any, Modal> & { get dismissibleOptions(): IDismissibleOptions; component: typeof Component.component };
 
-type ModalItem = null | {
+type ModalItem = {
   componentClass: UnsafeModalClass;
   attrs?: Record<string, unknown>;
   key: number;
@@ -25,12 +25,12 @@ export default class ModalManagerState {
   /**
    * @internal
    */
-  modal: ModalItem = null;
+  modal: ModalItem | null = null;
 
   /**
    * @internal
    */
-  modalList: Array<ModalItem> = [];
+  modalList: ModalItem[] = [];
 
   /**
    * Used to force re-initialization of modals if a modal

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -42,24 +42,6 @@ export default class ModalManagerState {
   /**
    * Shows a modal dialog.
    *
-   * @deprecated **From Flarum 2.0, stacking will be enabled by default, and values
-   * for `attrs` and `stackModal` will be required.**
-   *
-   * Opening a new modal will close any others currently being shown for backwards
-   * compatibility reasons, until Flarum 2.0.
-   *
-   * @example <caption>Show a modal</caption>
-   * app.modal.show(MyCoolModal, { attr: 'value' });
-   *
-   * @example <caption>Show a modal from a lifecycle method (`oncreate`, `view`, etc.)</caption>
-   * // This "hack" is needed due to quirks with nested redraws in Mithril.
-   * setTimeout(() => app.modal.show(MyCoolModal, { attr: 'value' }), 0);
-   */
-  show(componentClass: UnsafeModalClass, attrs?: Record<string, unknown>): void;
-
-  /**
-   * Shows a modal dialog.
-   *
    * If `stackModal` is `true`, the modal will be shown on top of the current modal.
    *
    * If a value for `stackModal` is not provided, opening a new modal will close
@@ -75,8 +57,6 @@ export default class ModalManagerState {
    * @example <caption>Stacking modals</caption>
    * app.modal.show(MyCoolStackedModal, { attr: 'value' }, true);
    */
-  show(componentClass: UnsafeModalClass, attrs: Record<string, unknown> | undefined, stackModal: boolean): void;
-
   show(componentClass: UnsafeModalClass, attrs: Record<string, unknown> = {}, stackModal: boolean = false): void {
     if (!(componentClass.prototype instanceof Modal)) {
       // This is duplicated so that if the error is caught, an error message still shows up in the debug console.

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -72,8 +72,8 @@ export default class ModalManagerState {
     this.backdropShown = true;
     m.redraw.sync();
 
-    // Me use RAF here, since we need to wait for the backdrop to be added to the DOM before
-    // actually adding the modal to the modal list.
+    // We use requestAnimationFrame here, since we need to wait for the backdrop to be added
+    // to the DOM before actually adding the modal to the modal list.
     //
     // This is because we use RAF inside the ModalManager onupdate lifecycle hook, and if we
     // skip this RAF call, the hook will attempt to add a focus trap as well as lock scroll

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -55,7 +55,7 @@ export default class ModalManagerState {
    * @example <caption>Stacking modals</caption>
    * app.modal.show(MyCoolStackedModal, { attr: 'value' }, true);
    */
-  show(componentClass: UnsafeModalClass, attrs: Record<string, unknown> = {}, stackModal: Boolean = false): void {
+  show(componentClass: UnsafeModalClass, attrs: Record<string, unknown> = {}, stackModal: boolean = false): void {
     if (!(componentClass.prototype instanceof Modal)) {
       // This is duplicated so that if the error is caught, an error message still shows up in the debug console.
       const invalidModalWarning = 'The ModalManager can only show Modals.';

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -42,9 +42,28 @@ export default class ModalManagerState {
   /**
    * Shows a modal dialog.
    *
-   * If a modal is already open, the existing one will close and the new modal will replace it.
+   * @deprecated **From Flarum 2.0, stacking will be enabled by default, and values
+   * for `attrs` and `stackModal` will be required.**
    *
-   * Stacking modals is supported, the previous modal will stay behind the new modal.
+   * Opening a new modal will close any others currently being shown for backwards
+   * compatibility reasons, until Flarum 2.0.
+   *
+   * @example <caption>Show a modal</caption>
+   * app.modal.show(MyCoolModal, { attr: 'value' });
+   *
+   * @example <caption>Show a modal from a lifecycle method (`oncreate`, `view`, etc.)</caption>
+   * // This "hack" is needed due to quirks with nested redraws in Mithril.
+   * setTimeout(() => app.modal.show(MyCoolModal, { attr: 'value' }), 0);
+   */
+  show(componentClass: UnsafeModalClass, attrs?: Record<string, unknown>): void;
+
+  /**
+   * Shows a modal dialog.
+   *
+   * If `stackModal` is `true`, the modal will be shown on top of the current modal.
+   *
+   * If a value for `stackModal` is not provided, opening a new modal will close
+   * any others currently being shown for backwards compatibility.
    *
    * @example <caption>Show a modal</caption>
    * app.modal.show(MyCoolModal, { attr: 'value' });
@@ -56,6 +75,8 @@ export default class ModalManagerState {
    * @example <caption>Stacking modals</caption>
    * app.modal.show(MyCoolStackedModal, { attr: 'value' }, true);
    */
+  show(componentClass: UnsafeModalClass, attrs: Record<string, unknown> | undefined, stackModal: boolean): void;
+
   show(componentClass: UnsafeModalClass, attrs: Record<string, unknown> = {}, stackModal: boolean = false): void {
     if (!(componentClass.prototype instanceof Modal)) {
       // This is duplicated so that if the error is caught, an error message still shows up in the debug console.

--- a/framework/core/js/src/forum/components/LogInModal.tsx
+++ b/framework/core/js/src/forum/components/LogInModal.tsx
@@ -146,7 +146,7 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
     const email = this.identification();
     const attrs = email.includes('@') ? { email } : undefined;
 
-    app.modal.show(ForgotPasswordModal, attrs);
+    app.modal.show(ForgotPasswordModal, attrs, true);
   }
 
   /**

--- a/framework/core/js/src/forum/components/LogInModal.tsx
+++ b/framework/core/js/src/forum/components/LogInModal.tsx
@@ -146,7 +146,7 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
     const email = this.identification();
     const attrs = email.includes('@') ? { email } : undefined;
 
-    app.modal.show(ForgotPasswordModal, attrs, true);
+    app.modal.show(ForgotPasswordModal, attrs);
   }
 
   /**

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -6,27 +6,7 @@
   overflow: hidden;
 }
 
-// Modal background
-.modal-backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: var(--zindex-modal-background);
-  background-color: var(--overlay-bg);
-  opacity: 0;
-  transition: opacity 0.2s;
-
-  &.in {
-    opacity: 1;
-  }
-}
-
-// Container that the modal scrolls within
 .ModalManager {
-  display: none;
-  overflow: hidden;
   position: fixed;
   top: 0;
   right: 0;
@@ -34,27 +14,45 @@
   left: 0;
   z-index: var(--zindex-modal);
   -webkit-overflow-scrolling: touch;
-
-  // When fading in the modal, animate it to slide down
-  .Modal {
-    transform: scale(0.9);
-    transition: transform 0.2s ease-out;
-  }
-  &.in .Modal {
-    transform: scale(1);
-  }
-}
-.modal-open .ModalManager {
   overflow-x: hidden;
   overflow-y: auto;
 }
 
-// Shell div to position the modal with bottom padding
 .Modal {
+  padding: 0;
+  border-radius: @border-radius;
+
+  transform: scale(0.9);
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out, top 0.2s ease-out;
+  z-index: 2;
   position: relative;
+
   width: auto;
   margin: 10px;
   max-width: 600px;
+
+  + .backdrop {
+    background: var(--overlay-bg);
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    transition: opacity 0.2s ease-out;
+    z-index: 1;
+    transition-delay: 0.2s;
+  }
+
+  &.in {
+    transform: scale(1);
+    transition-delay: 0.2s;
+
+    + .backdrop {
+      opacity: 1;
+      transition-delay: 0s;
+    }
+  }
 }
 
 // Actual modal
@@ -129,9 +127,6 @@
 }
 
 @media @phone {
-  .ModalManager.fade {
-    opacity: 1;
-  }
   .ModalManager {
     position: fixed;
     left: 0;
@@ -139,17 +134,12 @@
     bottom: 0;
     top: 0;
     overflow: auto;
-    transition: transform 0.2s ease-out;
-    transform: translate(0, 100vh);
 
-    &.in {
-      -webkit-transform: none !important;
-              transform: none !important;
-    }
     &:before {
       content: " ";
       .header-background();
       position: absolute;
+      z-index: 2;
     }
   }
   .Modal {
@@ -157,6 +147,15 @@
     margin: 0;
     -webkit-transform: none !important;
             transform: none !important;
+    top: 100vh;
+
+    &.fade {
+      opacity: 1;
+    }
+
+    &.in {
+      top: 0;
+    }
   }
   .Modal-content {
     border-radius: 0;
@@ -174,19 +173,20 @@
 
 @media @tablet-up {
   .Modal {
+    border-radius: var(--border-radius);
+    box-shadow: 0 7px 15px var(--shadow-color);
+    width: 100%;
+    max-width: 600px;
     margin: 120px auto;
   }
   .Modal-close {
     position: absolute;
     right: 10px;
     top: 10px;
-    z-index: 1;
+    z-index: 2;
   }
   .Modal-content {
-
-    border: 0;
     border-radius: var(--border-radius);
-    box-shadow: 0 7px 15px var(--shadow-color);
   }
   .Modal--small {
     max-width: 375px;

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -14,25 +14,27 @@
   margin: 10px;
   max-width: 600px;
 
-  + .backdrop {
-    background: var(--overlay-bg);
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    opacity: 0;
-    transition: opacity 0.2s ease-out;
-    z-index: 1;
-    pointer-events: none;
-  }
+  pointer-events: auto;
 
   &.in {
     transform: scale(1);
+  }
+}
 
-    + .backdrop {
-      opacity: 1;
-    }
+.Modal-backdrop {
+  background: var(--overlay-bg);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  opacity: 0;
+  transition: opacity 0.2s ease-out;
+  z-index: 1;
+  z-index: ~"calc(var(--zindex-modal) - 1)";
+
+  &[data-showing] {
+    opacity: 1;
   }
 }
 
@@ -46,41 +48,7 @@
   -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   overflow-y: auto;
-
-  // This mess of data attribute selectors ensures that the backdrop correctly
-  // transitions when modals are stacked.
-  //
-  // When a modal is stacked on top of another, the original backdrop is
-  // immediately hidden, and the new backdrop is immediately shown. Same with
-  // removing a stacked modal: the topmost backdrop is immediately hidden,
-  // and the next backdrop is shown.
-  //
-  // This prevents flashes of backdrops being shown/hidden as multiple
-  // transitions occur simultaneously.
-  &[data-visibility-state="entered-underneath"] {
-    .backdrop {
-      opacity: 0;
-      transition: none;
-    }
-
-    + .ModalManager[data-visibility-state="entering"] {
-      .backdrop {
-        transition: none;
-      }
-    }
-  }
-
-  &[data-visibility-state="entered"] {
-    .backdrop {
-      transition: none;
-    }
-
-    + .ModalManager[data-visibility-state="exiting"] {
-      .backdrop {
-        transition: none;
-      }
-    }
-  }
+  pointer-events: none;
 }
 
 // Actual modal

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -12,7 +12,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: ~"calc(9999 + var(--modal-number))";
+  z-index: ~"calc(var(--zindex-modal) + var(--modal-number))";
   -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   overflow-y: auto;

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -14,8 +14,6 @@
   margin: 10px;
   max-width: 600px;
 
-  pointer-events: auto;
-
   &.in {
     transform: scale(1);
   }
@@ -30,7 +28,7 @@
   bottom: 0;
   opacity: 0;
   transition: opacity 0.2s ease-out;
-  z-index: ~"calc(var(--zindex-modal) + var(--modal-count)) - 2";
+  z-index: ~"calc(var(--zindex-modal) + var(--modal-count) - 2)";
 
   &[data-showing] {
     opacity: 1;
@@ -47,7 +45,14 @@
   -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   overflow-y: auto;
-  pointer-events: none;
+
+  &-invisibleBackdrop {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 }
 
 // Actual modal

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -30,8 +30,7 @@
   bottom: 0;
   opacity: 0;
   transition: opacity 0.2s ease-out;
-  z-index: 1;
-  z-index: ~"calc(var(--zindex-modal) - 1)";
+  z-index: ~"calc(var(--zindex-modal) + var(--modal-count)) - 2";
 
   &[data-showing] {
     opacity: 1;

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -1,11 +1,6 @@
 // ------------------------------------
 // Modals
 
-// Kill the scroll on the body
-.modal-open {
-  overflow: hidden;
-}
-
 .Modal {
   padding: 0;
   border-radius: @border-radius;

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -24,6 +24,7 @@
     opacity: 0;
     transition: opacity 0.2s ease-out;
     z-index: 1;
+    pointer-events: none;
   }
 
   &.in {

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -12,7 +12,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: var(--zindex-modal);
+  z-index: ~"calc(9999 + var(--modal-number))";
   -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   overflow-y: auto;
@@ -146,7 +146,7 @@
     max-width: 100%;
     margin: 0;
     -webkit-transform: none !important;
-            transform: none !important;
+    transform: none !important;
     top: 100vh;
 
     &.fade {

--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -6,18 +6,6 @@
   overflow: hidden;
 }
 
-.ModalManager {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: ~"calc(var(--zindex-modal) + var(--modal-number))";
-  -webkit-overflow-scrolling: touch;
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-
 .Modal {
   padding: 0;
   border-radius: @border-radius;
@@ -41,16 +29,60 @@
     opacity: 0;
     transition: opacity 0.2s ease-out;
     z-index: 1;
-    transition-delay: 0.2s;
   }
 
   &.in {
     transform: scale(1);
-    transition-delay: 0.2s;
 
     + .backdrop {
       opacity: 1;
-      transition-delay: 0s;
+    }
+  }
+}
+
+.ModalManager {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: ~"calc(var(--zindex-modal) + var(--modal-number))";
+  -webkit-overflow-scrolling: touch;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  // This mess of data attribute selectors ensures that the backdrop correctly
+  // transitions when modals are stacked.
+  //
+  // When a modal is stacked on top of another, the original backdrop is
+  // immediately hidden, and the new backdrop is immediately shown. Same with
+  // removing a stacked modal: the topmost backdrop is immediately hidden,
+  // and the next backdrop is shown.
+  //
+  // This prevents flashes of backdrops being shown/hidden as multiple
+  // transitions occur simultaneously.
+  &[data-visibility-state="entered-underneath"] {
+    .backdrop {
+      opacity: 0;
+      transition: none;
+    }
+
+    + .ModalManager[data-visibility-state="entering"] {
+      .backdrop {
+        transition: none;
+      }
+    }
+  }
+
+  &[data-visibility-state="entered"] {
+    .backdrop {
+      transition: none;
+    }
+
+    + .ModalManager[data-visibility-state="exiting"] {
+      .backdrop {
+        transition: none;
+      }
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,6 +1112,11 @@
     prop-types "^15.7.2"
     react-is "^16.6.3"
 
+"@types/body-scroll-lock@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-3.1.0.tgz#435f6abf682bf58640e1c2ee5978320b891970e7"
+  integrity sha512-3owAC4iJub5WPqRhxd8INarF2bWeQq1yQHBgYhN0XLBJMpd5ED10RrJ3aKiAwlTyL5wK7RkBD4SZUQz2AAAMdA==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
@@ -1487,6 +1492,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+body-scroll-lock@^4.0.0-beta.0:
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
+  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
 
 bootstrap@^3.4.1:
   version "3.4.1"


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

Fixes #3516

**Changes proposed in this pull request:**
In this PR I've worked on making it possible to have multiple dialogs opened at the same time and make them stackable. I have partly used code of #3246 and altered it. It also removed the bootstrap modal dependency.

However, I did not proceed using the native HTML Dialog element for this PR due to lack of animations (for example, the backdrop is not animatable) and responsiveness with the interface.

A third parameter has been added to the `app.modal.show` function which is a boolean and defaults to `false`. This means that all already existing modals will keep their intended behaviour.

I also copied the new 'dismissable' options from the other PR, such as an option to hide the dialog on escape key, clicking on the backdrop or using the close button and managing them seperately per modal. This means there is a deprecation too which was mentioned in the code.

**Reviewers should focus on:**
- Current modals are opening and closing as intended
- Stacking multiple modals works
- Responsiveness is still good

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

