### PR TITLE
Send JSON payload within a <script> tag

### DIFF
--- a/framework/core/views/frontend/app.blade.php
+++ b/framework/core/views/frontend/app.blade.php
@@ -21,11 +21,14 @@
 
         {!! $js !!}
 
+        <script id="flarum-json-payload" type="application/json">@json($payload)</script>
+
         <script>
+            const data = JSON.parse(document.getElementById('flarum-json-payload').textContent);
             document.getElementById('flarum-loading').style.display = 'none';
 
             try {
-                flarum.core.app.load(@json($payload));
+                flarum.core.app.load(data);
                 flarum.core.app.bootExtensions(flarum.extensions);
                 flarum.core.app.boot();
             } catch (e) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Instead of dynamically changing this script every time with the JSON payload, send the JSON payload within a `<script>` tag. This will allow site admins to specify a hash for the 2 inline scripts in this file within their CSP, so they should be able to remove the need for `unsafe-inline`.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
I don't really have any concerns, at some point I would like to move the 2 inline scripts in `framework/core/views/frontend/app.blade.php` to their own dedicated files, how would the project prefer to deal with that?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
N/A

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
