### PR TITLE
Final public method for abstract class

### DIFF
--- a/framework/core/src/Api/Controller/AbstractCreateController.php
+++ b/framework/core/src/Api/Controller/AbstractCreateController.php
@@ -17,7 +17,7 @@ abstract class AbstractCreateController extends AbstractShowController
     /**
      * {@inheritdoc}
      */
-    public function handle(ServerRequestInterface $request): ResponseInterface
+    final public function handle(ServerRequestInterface $request): ResponseInterface
     {
         return parent::handle($request)->withStatus(201);
     }

--- a/framework/core/src/Api/Controller/AbstractDeleteController.php
+++ b/framework/core/src/Api/Controller/AbstractDeleteController.php
@@ -19,7 +19,7 @@ abstract class AbstractDeleteController implements RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(ServerRequestInterface $request): ResponseInterface
+    final public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $this->delete($request);
 

--- a/framework/core/src/Api/Controller/AbstractSerializeController.php
+++ b/framework/core/src/Api/Controller/AbstractSerializeController.php
@@ -100,7 +100,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(ServerRequestInterface $request): ResponseInterface
+    final public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $document = new Document;
 
@@ -324,7 +324,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param string $serializer
      */
-    public function setSerializer(string $serializer)
+    final public function setSerializer(string $serializer)
     {
         $this->serializer = $serializer;
     }
@@ -334,7 +334,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param string|array $name
      */
-    public function addInclude($name)
+    final public function addInclude($name)
     {
         $this->include = array_merge($this->include, (array) $name);
     }
@@ -344,7 +344,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param string|array $name
      */
-    public function removeInclude($name)
+    final public function removeInclude($name)
     {
         $this->include = array_diff($this->include, (array) $name);
     }
@@ -354,7 +354,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param string|array $name
      */
-    public function addOptionalInclude($name)
+    final public function addOptionalInclude($name)
     {
         $this->optionalInclude = array_merge($this->optionalInclude, (array) $name);
     }
@@ -364,7 +364,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param string|array $name
      */
-    public function removeOptionalInclude($name)
+    final public function removeOptionalInclude($name)
     {
         $this->optionalInclude = array_diff($this->optionalInclude, (array) $name);
     }
@@ -374,7 +374,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param int $limit
      */
-    public function setLimit(int $limit)
+    final public function setLimit(int $limit)
     {
         $this->limit = $limit;
     }
@@ -384,7 +384,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param int $max
      */
-    public function setMaxLimit(int $max)
+    final public function setMaxLimit(int $max)
     {
         $this->maxLimit = $max;
     }
@@ -394,7 +394,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param string|array $field
      */
-    public function addSortField($field)
+    final public function addSortField($field)
     {
         $this->sortFields = array_merge($this->sortFields, (array) $field);
     }
@@ -404,7 +404,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param string|array $field
      */
-    public function removeSortField($field)
+    final public function removeSortField($field)
     {
         $this->sortFields = array_diff($this->sortFields, (array) $field);
     }
@@ -414,7 +414,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @param array $sort
      */
-    public function setSort(array $sort)
+    final public function setSort(array $sort)
     {
         $this->sort = $sort;
     }
@@ -422,7 +422,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     /**
      * @return Container
      */
-    public static function getContainer()
+    final public static function getContainer()
     {
         return static::$container;
     }
@@ -432,7 +432,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @internal
      */
-    public static function setContainer(Container $container)
+    final public static function setContainer(Container $container)
     {
         static::$container = $container;
     }
@@ -443,7 +443,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @internal
      */
-    public static function addDataPreparationCallback(string $controllerClass, callable $callback)
+    final public static function addDataPreparationCallback(string $controllerClass, callable $callback)
     {
         if (! isset(static::$beforeDataCallbacks[$controllerClass])) {
             static::$beforeDataCallbacks[$controllerClass] = [];
@@ -458,7 +458,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @internal
      */
-    public static function addSerializationPreparationCallback(string $controllerClass, callable $callback)
+    final public static function addSerializationPreparationCallback(string $controllerClass, callable $callback)
     {
         if (! isset(static::$beforeSerializationCallbacks[$controllerClass])) {
             static::$beforeSerializationCallbacks[$controllerClass] = [];
@@ -470,7 +470,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     /**
      * @internal
      */
-    public static function setLoadRelations(string $controllerClass, array $relations)
+    final public static function setLoadRelations(string $controllerClass, array $relations)
     {
         if (! isset(static::$loadRelations[$controllerClass])) {
             static::$loadRelations[$controllerClass] = [];
@@ -482,7 +482,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     /**
      * @internal
      */
-    public static function setLoadRelationCallables(string $controllerClass, array $relations)
+    final public static function setLoadRelationCallables(string $controllerClass, array $relations)
     {
         if (! isset(static::$loadRelationCallables[$controllerClass])) {
             static::$loadRelationCallables[$controllerClass] = [];

--- a/framework/core/src/Api/Controller/UploadImageController.php
+++ b/framework/core/src/Api/Controller/UploadImageController.php
@@ -60,7 +60,7 @@ abstract class UploadImageController extends ShowForumController
     /**
      * {@inheritdoc}
      */
-    public function data(ServerRequestInterface $request, Document $document)
+    final public function data(ServerRequestInterface $request, Document $document)
     {
         RequestUtil::getActor($request)->assertAdmin();
 

--- a/framework/core/src/Api/Serializer/AbstractSerializer.php
+++ b/framework/core/src/Api/Serializer/AbstractSerializer.php
@@ -54,7 +54,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     /**
      * @return Request
      */
-    public function getRequest()
+    final public function getRequest()
     {
         return $this->request;
     }
@@ -62,7 +62,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     /**
      * @param Request $request
      */
-    public function setRequest(Request $request)
+    final public function setRequest(Request $request)
     {
         $this->request = $request;
         $this->actor = RequestUtil::getActor($request);
@@ -71,7 +71,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     /**
      * @return User
      */
-    public function getActor()
+    final public function getActor()
     {
         return $this->actor;
     }
@@ -79,7 +79,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     /**
      * {@inheritdoc}
      */
-    public function getAttributes($model, array $fields = null)
+    final public function getAttributes($model, array $fields = null)
     {
         if (! is_object($model) && ! is_array($model)) {
             return [];
@@ -113,7 +113,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
      * @param DateTime|null $date
      * @return string|null
      */
-    public function formatDate(DateTime $date = null)
+    final public function formatDate(DateTime $date = null)
     {
         if ($date) {
             return $date->format(DateTime::RFC3339);
@@ -123,7 +123,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     /**
      * {@inheritdoc}
      */
-    public function getRelationship($model, $name)
+    final public function getRelationship($model, $name)
     {
         if ($relationship = $this->getCustomRelationship($model, $name)) {
             return $relationship;
@@ -166,7 +166,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
      * @param string|Closure|null $relation
      * @return Relationship
      */
-    public function hasOne($model, $serializer, $relation = null)
+    final public function hasOne($model, $serializer, $relation = null)
     {
         return $this->buildRelationship($model, $serializer, $relation);
     }
@@ -179,7 +179,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
      * @param string|null $relation
      * @return Relationship
      */
-    public function hasMany($model, $serializer, $relation = null)
+    final public function hasMany($model, $serializer, $relation = null)
     {
         return $this->buildRelationship($model, $serializer, $relation, true);
     }
@@ -267,7 +267,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     /**
      * @return Container
      */
-    public static function getContainer()
+    final public static function getContainer()
     {
         return static::$container;
     }
@@ -277,7 +277,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
      *
      * @internal
      */
-    public static function setContainer(Container $container)
+    final public static function setContainer(Container $container)
     {
         static::$container = $container;
     }
@@ -288,7 +288,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
      *
      * @internal
      */
-    public static function addAttributeMutator(string $serializerClass, callable $callback): void
+    final public static function addAttributeMutator(string $serializerClass, callable $callback): void
     {
         if (! isset(static::$attributeMutators[$serializerClass])) {
             static::$attributeMutators[$serializerClass] = [];
@@ -304,7 +304,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
      *
      * @internal
      */
-    public static function setRelationship(string $serializerClass, string $relation, callable $callback): void
+    final public static function setRelationship(string $serializerClass, string $relation, callable $callback): void
     {
         static::$customRelations[$serializerClass][$relation] = $callback;
     }

--- a/framework/core/src/Database/AbstractModel.php
+++ b/framework/core/src/Database/AbstractModel.php
@@ -62,7 +62,7 @@ abstract class AbstractModel extends Eloquent
     /**
      * {@inheritdoc}
      */
-    public static function boot()
+    final public static function boot()
     {
         parent::boot();
 
@@ -102,7 +102,7 @@ abstract class AbstractModel extends Eloquent
      *
      * @return array
      */
-    public function getDates()
+    final public function getDates()
     {
         $dates = $this->dates;
 
@@ -120,7 +120,7 @@ abstract class AbstractModel extends Eloquent
      * @param string $key
      * @return mixed
      */
-    public function getAttribute($key)
+    final public function getAttribute($key)
     {
         if (! is_null($value = parent::getAttribute($key))) {
             return $value;
@@ -162,7 +162,7 @@ abstract class AbstractModel extends Eloquent
      * @param callable $callback
      * @return void
      */
-    public function afterSave($callback)
+    final public function afterSave($callback)
     {
         $this->afterSaveCallbacks[] = $callback;
     }
@@ -173,7 +173,7 @@ abstract class AbstractModel extends Eloquent
      * @param callable $callback
      * @return void
      */
-    public function afterDelete($callback)
+    final public function afterDelete($callback)
     {
         $this->afterDeleteCallbacks[] = $callback;
     }
@@ -181,7 +181,7 @@ abstract class AbstractModel extends Eloquent
     /**
      * @return callable[]
      */
-    public function releaseAfterSaveCallbacks()
+    final public function releaseAfterSaveCallbacks()
     {
         $callbacks = $this->afterSaveCallbacks;
 
@@ -193,7 +193,7 @@ abstract class AbstractModel extends Eloquent
     /**
      * @return callable[]
      */
-    public function releaseAfterDeleteCallbacks()
+    final public function releaseAfterDeleteCallbacks()
     {
         $callbacks = $this->afterDeleteCallbacks;
 

--- a/framework/core/src/Database/Migration.php
+++ b/framework/core/src/Database/Migration.php
@@ -24,7 +24,7 @@ abstract class Migration
     /**
      * Create a table.
      */
-    public static function createTable($name, callable $definition)
+    final public static function createTable($name, callable $definition)
     {
         return [
             'up' => function (Builder $schema) use ($name, $definition) {
@@ -41,7 +41,7 @@ abstract class Migration
     /**
      * Rename a table.
      */
-    public static function renameTable($from, $to)
+    final public static function renameTable($from, $to)
     {
         return [
             'up' => function (Builder $schema) use ($from, $to) {
@@ -56,7 +56,7 @@ abstract class Migration
     /**
      * Add columns to a table.
      */
-    public static function addColumns($tableName, array $columnDefinitions)
+    final public static function addColumns($tableName, array $columnDefinitions)
     {
         return [
             'up' => function (Builder $schema) use ($tableName, $columnDefinitions) {
@@ -78,7 +78,7 @@ abstract class Migration
     /**
      * Drop columns from a table.
      */
-    public static function dropColumns($tableName, array $columnDefinitions)
+    final public static function dropColumns($tableName, array $columnDefinitions)
     {
         $inverse = static::addColumns($tableName, $columnDefinitions);
 
@@ -91,7 +91,7 @@ abstract class Migration
     /**
      * Rename a column.
      */
-    public static function renameColumn($tableName, $from, $to)
+    final public static function renameColumn($tableName, $from, $to)
     {
         return static::renameColumns($tableName, [$from => $to]);
     }
@@ -99,7 +99,7 @@ abstract class Migration
     /**
      * Rename multiple columns.
      */
-    public static function renameColumns($tableName, array $columnNames)
+    final public static function renameColumns($tableName, array $columnNames)
     {
         return [
             'up' => function (Builder $schema) use ($tableName, $columnNames) {
@@ -125,7 +125,7 @@ abstract class Migration
      * @deprecated Use the Settings extender's `default` method instead to register settings.
      * @see Settings::default()
      */
-    public static function addSettings(array $defaults)
+    final public static function addSettings(array $defaults)
     {
         return [
             'up' => function (Builder $schema) use ($defaults) {
@@ -152,7 +152,7 @@ abstract class Migration
     /**
      * Add default permissions.
      */
-    public static function addPermissions(array $permissions)
+    final public static function addPermissions(array $permissions)
     {
         $rows = [];
 

--- a/framework/core/src/Filter/AbstractFilterer.php
+++ b/framework/core/src/Filter/AbstractFilterer.php
@@ -45,7 +45,7 @@ abstract class AbstractFilterer
      * @return QueryResults
      * @throws InvalidArgumentException
      */
-    public function filter(QueryCriteria $criteria, int $limit = null, int $offset = 0): QueryResults
+    final public function filter(QueryCriteria $criteria, int $limit = null, int $offset = 0): QueryResults
     {
         $actor = $criteria->actor;
 

--- a/framework/core/src/Foundation/AbstractServiceProvider.php
+++ b/framework/core/src/Foundation/AbstractServiceProvider.php
@@ -37,7 +37,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     /**
      * {@inheritdoc}
      */
-    public function register()
+    final public function register()
     {
     }
 }

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -21,7 +21,7 @@ abstract class AbstractValidator
      */
     protected $configuration = [];
 
-    public function addConfiguration($callable)
+    final public function addConfiguration($callable)
     {
         $this->configuration[] = $callable;
     }
@@ -56,7 +56,7 @@ abstract class AbstractValidator
      *
      * @param array $attributes
      */
-    public function assertValid(array $attributes)
+    final public function assertValid(array $attributes)
     {
         $validator = $this->makeValidator($attributes);
 

--- a/framework/core/src/Http/Controller/AbstractHtmlController.php
+++ b/framework/core/src/Http/Controller/AbstractHtmlController.php
@@ -21,7 +21,7 @@ abstract class AbstractHtmlController implements RequestHandlerInterface
      * @param Request $request
      * @return HtmlResponse
      */
-    public function handle(Request $request): ResponseInterface
+    final public function handle(Request $request): ResponseInterface
     {
         $view = $this->render($request);
 

--- a/framework/core/src/Post/AbstractEventPost.php
+++ b/framework/core/src/Post/AbstractEventPost.php
@@ -20,7 +20,7 @@ abstract class AbstractEventPost extends Post
      * @param string $value
      * @return array
      */
-    public function getContentAttribute($value)
+    final public function getContentAttribute($value)
     {
         return json_decode($value, true);
     }
@@ -30,7 +30,7 @@ abstract class AbstractEventPost extends Post
      *
      * @param string $value
      */
-    public function setContentAttribute($value)
+    final public function setContentAttribute($value)
     {
         $this->attributes['content'] = json_encode($value);
     }

--- a/framework/core/src/Query/AbstractQueryState.php
+++ b/framework/core/src/Query/AbstractQueryState.php
@@ -45,7 +45,7 @@ abstract class AbstractQueryState
      *
      * @return Builder
      */
-    public function getQuery()
+    final public function getQuery()
     {
         return $this->query;
     }
@@ -55,7 +55,7 @@ abstract class AbstractQueryState
      *
      * @return User
      */
-    public function getActor()
+    final public function getActor()
     {
         return $this->actor;
     }
@@ -65,7 +65,7 @@ abstract class AbstractQueryState
      *
      * @return array
      */
-    public function getDefaultSort()
+    final public function getDefaultSort()
     {
         return $this->defaultSort;
     }
@@ -80,7 +80,7 @@ abstract class AbstractQueryState
      *     Alternatively, a callable may be used.
      * @return mixed
      */
-    public function setDefaultSort($defaultSort)
+    final public function setDefaultSort($defaultSort)
     {
         $this->defaultSort = $defaultSort;
     }

--- a/framework/core/src/Search/AbstractRegexGambit.php
+++ b/framework/core/src/Search/AbstractRegexGambit.php
@@ -19,7 +19,7 @@ abstract class AbstractRegexGambit implements GambitInterface
     /**
      * {@inheritdoc}
      */
-    public function apply(SearchState $search, $bit)
+    final public function apply(SearchState $search, $bit)
     {
         if ($matches = $this->match($bit)) {
             list($negate) = array_splice($matches, 1, 1);

--- a/framework/core/src/Search/AbstractSearcher.php
+++ b/framework/core/src/Search/AbstractSearcher.php
@@ -45,7 +45,7 @@ abstract class AbstractSearcher
      * @return QueryResults
      * @throws InvalidArgumentException
      */
-    public function search(QueryCriteria $criteria, $limit = null, $offset = 0): QueryResults
+    final public function search(QueryCriteria $criteria, $limit = null, $offset = 0): QueryResults
     {
         $actor = $criteria->actor;
 

--- a/framework/core/src/User/Access/AbstractPolicy.php
+++ b/framework/core/src/User/Access/AbstractPolicy.php
@@ -45,7 +45,7 @@ abstract class AbstractPolicy
      * @param $instance
      * @return string|void
      */
-    public function checkAbility(User $actor, string $ability, $instance)
+    final public function checkAbility(User $actor, string $ability, $instance)
     { // If a specific method for this ability is defined,
         // call that and return any non-null results
         if (method_exists($this, $ability)) {
@@ -75,7 +75,7 @@ abstract class AbstractPolicy
      * @param mixed $result
      * @return string|void
      */
-    public function sanitizeResult($result)
+    final public function sanitizeResult($result)
     {
         if ($result === true) {
             return $this->allow();


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
