### PR TITLE
Get class to class keyword

### DIFF
--- a/framework/core/src/Bus/Dispatcher.php
+++ b/framework/core/src/Bus/Dispatcher.php
@@ -15,7 +15,7 @@ class Dispatcher extends BaseDispatcher
 {
     public function getCommandHandler($command)
     {
-        $handler = get_class($command).'Handler';
+        $handler = $command::class.'Handler';
 
         if (class_exists($handler)) {
             return $this->container->make($handler);

--- a/framework/core/src/Extension/Exception/ExtensionBootError.php
+++ b/framework/core/src/Extension/Exception/ExtensionBootError.php
@@ -23,7 +23,7 @@ class ExtensionBootError extends Exception
         $this->extension = $extension;
         $this->extender = $extender;
 
-        $extenderClass = get_class($extender);
+        $extenderClass = $extender::class;
 
         parent::__construct("Experienced an error while booting extension: {$extension->getTitle()}.\n\nError occurred while applying an extender of type: $extenderClass.", null, $previous);
     }

--- a/framework/core/src/Foundation/Application.php
+++ b/framework/core/src/Foundation/Application.php
@@ -210,7 +210,7 @@ class Application
      */
     public function getProvider($provider)
     {
-        $name = is_string($provider) ? $provider : get_class($provider);
+        $name = is_string($provider) ? $provider : $provider::class;
 
         return Arr::first($this->serviceProviders, function ($key, $value) use ($name) {
             return $value instanceof $name;
@@ -236,7 +236,7 @@ class Application
      */
     protected function markAsRegistered($provider)
     {
-        $this->container['events']->dispatch($class = get_class($provider), [$provider]);
+        $this->container['events']->dispatch($class = $provider::class, [$provider]);
 
         $this->serviceProviders[] = $provider;
 

--- a/framework/core/src/Foundation/ErrorHandling/Registry.php
+++ b/framework/core/src/Foundation/ErrorHandling/Registry.php
@@ -58,7 +58,7 @@ class Registry
         if ($error instanceof KnownError) {
             $errorType = $error->getType();
         } else {
-            $errorClass = get_class($error);
+            $errorClass = $error::class;
             if (isset($this->classMap[$errorClass])) {
                 $errorType = $this->classMap[$errorClass];
             }
@@ -77,7 +77,7 @@ class Registry
 
     private function handleCustomTypes(Throwable $error): ?HandledError
     {
-        $errorClass = get_class($error);
+        $errorClass = $error::class;
 
         if (isset($this->handlerMap[$errorClass])) {
             $handler = new $this->handlerMap[$errorClass];

--- a/framework/core/src/Http/Server.php
+++ b/framework/core/src/Http/Server.php
@@ -86,7 +86,7 @@ class Server
             $message = $error->getMessage();
             $file = $error->getFile();
             $line = $error->getLine();
-            $type = get_class($error);
+            $type = $error::class;
 
             echo <<<ERROR
             Flarum encountered a boot error ($type)<br />

--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -179,7 +179,7 @@ class Notification extends AbstractModel
      */
     public function scopeWhereSubject(Builder $query, $model)
     {
-        return $query->whereSubjectModel(get_class($model))
+        return $query->whereSubjectModel($model::class)
             ->where('subject_id', $model->id);
     }
 

--- a/framework/core/src/Search/GambitManager.php
+++ b/framework/core/src/Search/GambitManager.php
@@ -87,7 +87,7 @@ class GambitManager
             foreach ($this->gambits as $gambit) {
                 if (! $gambit instanceof GambitInterface) {
                     throw new LogicException(
-                        'Gambit '.get_class($gambit).' does not implement '.GambitInterface::class
+                        'Gambit '.$gambit::class.' does not implement '.GambitInterface::class
                     );
                 }
 

--- a/framework/core/src/User/Access/Gate.php
+++ b/framework/core/src/User/Access/Gate.php
@@ -65,7 +65,7 @@ class Gate
         $appliedPolicies = [];
 
         if ($model) {
-            $modelClasses = is_string($model) ? [$model] : array_merge(class_parents(($model)), [get_class($model)]);
+            $modelClasses = is_string($model) ? [$model] : array_merge(class_parents(($model)), [$model::class]);
 
             foreach ($modelClasses as $class) {
                 $appliedPolicies = array_merge($appliedPolicies, $this->getPolicies($class));


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
