### PR TITLE
Combine consecutive issets

### DIFF
--- a/framework/core/src/Forum/Content/Discussion.php
+++ b/framework/core/src/Forum/Content/Discussion.php
@@ -88,7 +88,7 @@ class Discussion
         $posts = [];
 
         foreach ($apiDocument->included as $resource) {
-            if ($resource->type === 'posts' && isset($resource->relationships->discussion) && isset($resource->attributes->contentHtml)) {
+            if ($resource->type === 'posts' && isset($resource->relationships->discussion, $resource->attributes->contentHtml)  ) {
                 $posts[] = $resource;
             }
         }

--- a/framework/core/src/Group/Command/EditGroupHandler.php
+++ b/framework/core/src/Group/Command/EditGroupHandler.php
@@ -60,7 +60,7 @@ class EditGroupHandler
 
         $attributes = Arr::get($data, 'attributes', []);
 
-        if (isset($attributes['nameSingular']) && isset($attributes['namePlural'])) {
+        if (isset($attributes['nameSingular'], $attributes['namePlural'])  ) {
             $group->rename($attributes['nameSingular'], $attributes['namePlural']);
         }
 


### PR DESCRIPTION
Using isset($var) && multiple times should be done in one call.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
