### PR TITLE
fix: post mention notification errors with _no content_ subjects

### DIFF
--- a/extensions/mentions/js/src/forum/components/PostMentionedNotification.js
+++ b/extensions/mentions/js/src/forum/components/PostMentionedNotification.js
@@ -23,6 +23,8 @@ export default class PostMentionedNotification extends Notification {
   }
 
   excerpt() {
-    return truncate(this.attrs.notification.subject().contentPlain(), 200);
+    const contentPlain = this.attrs.notification.subject().contentPlain();
+
+    return contentPlain && truncate(contentPlain, 200);
   }
 }

--- a/extensions/mentions/js/src/forum/components/PostMentionedNotification.js
+++ b/extensions/mentions/js/src/forum/components/PostMentionedNotification.js
@@ -23,8 +23,6 @@ export default class PostMentionedNotification extends Notification {
   }
 
   excerpt() {
-    const contentPlain = this.attrs.notification.subject().contentPlain();
-
-    return contentPlain && truncate(contentPlain, 200);
+    return truncate(this.attrs.notification.subject().contentPlain() || '', 200);
   }
 }


### PR DESCRIPTION
**Fixes #3492**

**Changes proposed in this pull request:**
Just checks before using the `contentPlain` result.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
