### PR TITLE
feat: support custom reusable setting components for `buildSettingComponent`

### DIFF
--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -11,6 +11,7 @@ import saveSettings from '../utils/saveSettings';
 import AdminHeader from './AdminHeader';
 import generateElementId from '../utils/generateElementId';
 import ColorPreviewInput from '../../common/components/ColorPreviewInput';
+import ItemList from '../../common/utils/ItemList';
 
 export interface AdminHeaderOptions {
   title: Mithril.Children;
@@ -120,7 +121,9 @@ export type SettingsComponentOptions =
   | SwitchSettingComponentOptions
   | SelectSettingComponentOptions
   | TextareaSettingComponentOptions
-  | ColorPreviewSettingComponentOptions;
+  | ColorPreviewSettingComponentOptions
+  // For custom settings component options
+  | string;
 
 /**
  * Valid attrs that can be returned by the `headerInfo` function
@@ -186,6 +189,41 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
   }
 
   /**
+   * A list of extension-defined custom setting components to be available through
+   * {@link AdminPage.buildSettingComponent}.
+   *
+   * The ItemList key represents the value for `type` to be provided when calling
+   * {@link AdminPage.buildSettingComponent}. Other attributes passed are provided
+   * as arguments to the function added to the ItemList.
+   *
+   * ItemList priority has no effect here.
+   *
+   * @example
+   * ```tsx
+   * extend(AdminPage.prototype, 'customSettingComponents', function (items) {
+   *   // You can access the AdminPage instance with `this` to access its `settings` property.
+   *
+   *   // Prefixing the key with your extension ID is recommended to avoid collisions.
+   *   items.add('my-ext.setting-component', (attrs) => {
+   *     return (
+   *       <div className={attrs.className}>
+   *         <label>{attrs.label}</label>
+   *         {attrs.help && <p class="helpText">{attrs.help}</p>}
+   *
+   *         My setting component!
+   *       </div>
+   *     );
+   *   })
+   * })
+   * ```
+   */
+  customSettingComponents(): ItemList<(attributes: CommonSettingsItemOptions) => Mithril.Children> {
+    const items = new ItemList<(attributes: CommonSettingsItemOptions) => Mithril.Children>();
+
+    return items;
+  }
+
+  /**
    * `buildSettingComponent` takes a settings object and turns it into a component.
    * Depending on the type of input, you can set the type to 'bool', 'select', or
    * any standard <input> type. Any values inside the 'extra' object will be added
@@ -228,6 +266,8 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
       return entry.call(this);
     }
 
+    const customSettingComponents = this.customSettingComponents();
+
     const { setting, help, type, label, ...componentAttrs } = entry;
 
     const value = this.setting(setting)();
@@ -262,8 +302,10 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
           {...otherAttrs}
         />
       );
+    } else if (customSettingComponents.has(type)) {
+      return customSettingComponents.get(type)({ setting, help, label, ...componentAttrs });
     } else {
-      componentAttrs.className = classList(['FormControl', componentAttrs.className]);
+      componentAttrs.className = classList('FormControl', componentAttrs.className);
 
       if ((TextareaSettingTypes as readonly string[]).includes(type)) {
         settingElement = <textarea id={inputId} aria-describedby={helpTextId} bidi={this.setting(setting)} {...componentAttrs} />;

--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -57,7 +57,7 @@ export type HTMLInputTypes =
   | 'url'
   | 'week';
 
-interface CommonSettingsItemOptions extends Mithril.Attributes {
+export interface CommonSettingsItemOptions extends Mithril.Attributes {
   setting: string;
   label: Mithril.Children;
   help?: Mithril.Children;

--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -113,6 +113,11 @@ export interface ColorPreviewSettingComponentOptions extends CommonSettingsItemO
   type: typeof ColorPreviewSettingType;
 }
 
+export interface CustomSettingComponentOptions extends CommonSettingsItemOptions {
+  type: string;
+  [key: string]: unknown;
+}
+
 /**
  * All valid options for the setting component builder.
  */
@@ -122,8 +127,7 @@ export type SettingsComponentOptions =
   | SelectSettingComponentOptions
   | TextareaSettingComponentOptions
   | ColorPreviewSettingComponentOptions
-  // For custom settings component options
-  | string;
+  | CustomSettingComponentOptions;
 
 /**
  * Valid attrs that can be returned by the `headerInfo` function


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Adds the ability for extensions to declare custom setting components for use with `buildSettingComponent`.

This could be used to aid model selection, for example, such as providing an easy and reusable way to allow extensions to interact with each other through their settings pages.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related core extension PRs: #3495 
