### PR TITLE
feat: add tag selector custom setting component for `buildSettingComponent`

### DIFF
--- a/extensions/tags/js/src/admin/addCustomSettingComponent.tsx
+++ b/extensions/tags/js/src/admin/addCustomSettingComponent.tsx
@@ -1,0 +1,13 @@
+import AdminPage, { CommonSettingsItemOptions } from 'flarum/admin/components/AdminPage';
+import { extend } from 'flarum/common/extend';
+import TagSelectorComponent, { ITagSelectorAttrsSpecial } from './components/TagSelector';
+
+export default function addCustomSettingComponent() {
+  extend(AdminPage.prototype, 'customSettingComponents', function (items) {
+    items.add('flarum-tags.tag-selector', (attrs: ITagSelectorAttrsSpecial & CommonSettingsItemOptions) => {
+      const { setting } = attrs;
+
+      return <TagSelectorComponent<true> {...attrs} __fromBuildComponent={true} adminPage={this} settingsKey={setting} />;
+    });
+  });
+}

--- a/extensions/tags/js/src/admin/compat.js
+++ b/extensions/tags/js/src/admin/compat.js
@@ -6,12 +6,14 @@ import TagsPage from './components/TagsPage';
 import EditTagModal from './components/EditTagModal';
 import addTagPermission from './addTagPermission';
 import addTagsPermissionScope from './addTagsPermissionScope';
+import TagSelectorComponent from './components/TagSelector';
 
 export default Object.assign(compat, {
   'tags/addTagsHomePageOption': addTagsHomePageOption,
   'tags/addTagChangePermission': addTagChangePermission,
   'tags/components/TagsPage': TagsPage,
   'tags/components/EditTagModal': EditTagModal,
+  'tags/components/TagSelector': TagSelectorComponent,
   'tags/addTagPermission': addTagPermission,
   'tags/addTagsPermissionScope': addTagsPermissionScope,
 });

--- a/extensions/tags/js/src/admin/components/TagSelector.tsx
+++ b/extensions/tags/js/src/admin/components/TagSelector.tsx
@@ -1,0 +1,366 @@
+import app from 'flarum/admin/app';
+import Component from 'flarum/common/Component';
+import Dropdown from 'flarum/common/components/Dropdown';
+import Button from 'flarum/common/components/Button';
+import { IPageAttrs } from 'flarum/common/components/Page';
+import classList from 'flarum/common/utils/classList';
+
+import Tag from '../../common/models/Tag';
+import sortTags from '../../common/utils/sortTags';
+import tagLabel from '../../common/helpers/tagLabel';
+import tagsLabel from '../../common/helpers/tagsLabel';
+
+import type Mithril from 'mithril';
+import type AdminPage from 'flarum/admin/components/AdminPage';
+
+/**
+ * Defines how the `TagSelector` will save its state to the database.
+ */
+export interface ITagSelectorSaveFormat {
+  separation: 'json' | 'csv';
+  values: 'id' | 'slug';
+}
+
+/**
+ * Attributes for general usage of the `TagSelector`.
+ */
+export interface ITagSelectorAttrs {
+  label: Mithril.Children;
+  help?: Mithril.Children;
+  class?: string;
+  className?: string;
+
+  /**
+   * Whether multiple tags can be selected in the component.
+   */
+  multiselect?: boolean;
+  /**
+   * Event handler triggered when the user finishes tag selection.
+   */
+  onChange?: (tags: Tag[]) => void;
+  /**
+   * An array of tags that are selected.
+   */
+  value?: Tag[];
+  /**
+   * Filter function which the full list of tags are passed through which
+   * can be used to hide certain tags.
+   */
+  tagFilter?: (tag: Tag) => boolean;
+}
+
+/**
+ * Attributes for usage of the `TagSelector` within `AdminPage`'s
+ * `buildSettingComponent` method.
+ */
+export interface ITagSelectorAttrsSpecial extends ITagSelectorAttrs {
+  /**
+   * How the selected tags should be stored and retrieved from the database.
+   *
+   * `separation` refers to the format itself, with JSON forming a valid
+   * JSON string representing an array, and CSV simply separating items
+   * with commas.
+   *
+   * `values` refers to the format of the values in the array. This can
+   * either be `id` or `slug`.
+   *
+   * **Note that IDs are stored as strings, not numbers.**
+   *
+   * @example
+   * { separation: "json", values: "id" }
+   * // '["1", "2", "3"]'
+   * @example
+   * { separation: "csv", values: "slug" }
+   * // 'tag-1,tag-2,tag-3'
+   */
+  saveFormat?: ITagSelectorSaveFormat;
+}
+
+/**
+ * Attributes for `TagSelector` reserved for internal use.
+ */
+export interface ITagSelectorAttrsSpecialInternal extends ITagSelectorAttrsSpecial {
+  /**
+   * @internal
+   */
+  __fromBuildComponent: true;
+  adminPage: AdminPage<IPageAttrs>;
+  settingsKey: string;
+}
+
+/**
+ * A component used for selecting one or multiple tags from a dropdown
+ * list.
+ *
+ * Can be used within an `AdminPage` via `buildSettingComponent` or
+ * can be implemented on its own.
+ *
+ * @example
+ * ```tsx
+ * {this.buildSettingComponent({
+ *   type: 'flarum-tags.tag-selector',
+ *   label: 'Pick a tag',
+ *   help: 'Tags are cool!',
+ *   setting: 'abcdefg.1',
+ *   saveFormat: {
+ *     separation: 'json',
+ *     values: 'id',
+ *   },
+ * })}
+ *
+ * {this.buildSettingComponent({
+ *   type: 'flarum-tags.tag-selector',
+ *   label: 'Pick multiple tags',
+ *   help: 'Tags are cool!',
+ *   multiselect: true,
+ *   setting: 'abcdefg.2',
+ *   saveFormat: {
+ *     separation: 'json',
+ *     values: 'id',
+ *   },
+ * })}
+ *
+ * {this.buildSettingComponent({
+ *   type: 'flarum-tags.tag-selector',
+ *   label: 'Pick loads of tags!',
+ *   help: 'Tags are cool!',
+ *   multiselect: true,
+ *   setting: 'abcdefg.3',
+ *   saveFormat: {
+ *     separation: 'json',
+ *     values: 'id',
+ *   },
+ * })}
+ *
+ * {this.buildSettingComponent({
+ *   type: 'flarum-tags.tag-selector',
+ *   label: 'Pick only secondary tags',
+ *   help: 'Tags are cool!',
+ *   multiselect: true,
+ *   setting: 'abcdefg.4',
+ *   tagFilter: (t) => t.position() === null,
+ *   saveFormat: {
+ *     separation: 'json',
+ *     values: 'id',
+ *   },
+ * })}
+ * ```
+ */
+export default class TagSelector<InternalUsage extends boolean = false> extends Component<
+  InternalUsage extends true ? ITagSelectorAttrsSpecialInternal : ITagSelectorAttrs
+> {
+  availableTags: Tag[] | null = null;
+  selectedIds: string[] = [];
+  loadingState: 'loaded' | 'error' | 'loading' = 'loading';
+  saveFormat!: ITagSelectorSaveFormat;
+  /**
+   * When the number of selected tags exceeds this number, the label
+   * switches to text-only.
+   */
+  textLabelCutoff = 3;
+
+  oninit(vnode: Mithril.Vnode<InternalUsage extends true ? ITagSelectorAttrsSpecialInternal : ITagSelectorAttrs, this>) {
+    super.oninit(vnode);
+
+    // ensure formatting options are set
+    if ('__fromBuildComponent' in this.attrs) {
+      this.saveFormat = this.attrs.saveFormat || {
+        separation: 'csv',
+        values: 'id',
+      };
+
+      this.saveFormat.separation ||= 'csv';
+      this.saveFormat.values ||= 'id';
+    }
+
+    if (this.attrs.value && !('__fromBuildComponent' in this.attrs)) {
+      this.selectedIds = this.attrs.value.map((tag) => tag.id()!);
+    }
+
+    this.loadTags();
+  }
+
+  view(vnode: Mithril.Vnode<InternalUsage extends true ? ITagSelectorAttrsSpecialInternal : ITagSelectorAttrs, this>): Mithril.Children {
+    if (this.loadingState !== 'loaded') {
+      return (
+        <div class={classList('TagSelector Form-group', this.attrs.class, this.attrs.className)}>
+          {this.attrs.label && <label>{this.attrs.label}</label>}
+          {this.attrs.help && <p class="helpText">{this.attrs.help}</p>}
+
+          <Button class="Button Dropdown-toggle" disabled>
+            {app.translator.trans(`flarum-tags.admin.tag_selector.${this.loadingState}_label`)}
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div class={classList('TagSelector Form-group', this.attrs.class, this.attrs.className)}>
+        {this.attrs.label && <label>{this.attrs.label}</label>}
+        {this.attrs.help && <p class="helpText">{this.attrs.help}</p>}
+
+        <Dropdown
+          className="TagSelector-Dropdown"
+          buttonClassName="Button"
+          accessibleToggleLabel={app.translator.trans('flarum-tags.admin.tag_selector.open_dropdown_a11y_label')}
+          label={this.dropdownLabel()}
+          onhide={this.onhide.bind(this)}
+        >
+          {this.availableTags?.map((tag) => {
+            return (
+              <Button
+                key={tag.id()}
+                icon={this.selectedIds.includes(tag.id()!) ? 'fas fa-check' : 'none'}
+                class="Button"
+                onclick={this.handleTagSelectToggle(tag.id()!)}
+              >
+                {this.tagLabel(tag)}
+              </Button>
+            );
+          })}
+        </Dropdown>
+      </div>
+    );
+  }
+
+  get settingValue(): string {
+    if (!('__fromBuildComponent' in this.attrs)) return '';
+
+    return this.attrs.adminPage.setting(this.attrs.settingsKey)();
+  }
+
+  /**
+   * Fetches all tags from the API and loads them into the store, as well as
+   * setting the default state of the selector if using the selector within
+   * the settings component builder.
+   */
+  async loadTags() {
+    this.loadingState = 'loading';
+    m.redraw();
+
+    let tags: Tag[] = await app.store.find<Tag[]>('tags');
+
+    if ('__fromBuildComponent' in this.attrs) {
+      // preload value from settings
+      const settingData = this.settingValue;
+      let decodedSetting: null | string[] = null;
+
+      switch (this.saveFormat.separation) {
+        default:
+        case 'csv':
+          // splitting an empty string results in an array element
+          // with an empty string, so we need to filter that out
+          decodedSetting = settingData ? settingData.split(',') : [];
+          break;
+
+        case 'json':
+          try {
+            decodedSetting = JSON.parse(settingData || '[]');
+          } catch {
+            app.alerts.show({ type: 'error' }, app.translator.trans('flarum-tags.admin.tag_selector.failed_parse'));
+            decodedSetting = [];
+          }
+          break;
+      }
+
+      switch (this.saveFormat.values) {
+        default:
+        case 'id':
+          this.selectedIds = decodedSetting!;
+          break;
+
+        case 'slug':
+          this.selectedIds = decodedSetting!.map(
+            // Use -1 as fallback for a deleted tag
+            (slug) => app.store.getBy<Tag>('tags', 'slug', slug)?.id() || '-1'
+          );
+          break;
+      }
+    }
+
+    if (typeof this.attrs.tagFilter === 'function') {
+      tags = tags.filter(this.attrs.tagFilter);
+    }
+
+    this.availableTags = sortTags(tags);
+    this.loadingState = 'loaded';
+    m.redraw();
+  }
+
+  onhide() {
+    if ('__fromBuildComponent' in this.attrs) {
+      // this is being used on the admin page, so we need to save the setting
+      const convertedArr = this.selectedIds
+        .map((id) => {
+          switch (this.saveFormat.values) {
+            default:
+            case 'id':
+              return id;
+
+            case 'slug':
+              return app.store.getById<Tag>('tags', id)?.slug();
+          }
+        })
+        .filter((t) => !!t) as string[];
+
+      let stringVal = '';
+
+      switch (this.saveFormat.separation) {
+        default:
+        case 'csv':
+          stringVal = convertedArr.join(',');
+          break;
+
+        case 'json':
+          stringVal = JSON.stringify(convertedArr);
+          break;
+      }
+
+      this.attrs.adminPage.setting(this.attrs.settingsKey)(stringVal);
+    }
+  }
+
+  handleTagSelectToggle(tagId: string) {
+    return (e: MouseEvent) => {
+      // Keep dropdown open in multiselect mode
+      if (this.attrs.multiselect) {
+        e.stopPropagation();
+
+        const index = this.selectedIds.indexOf(tagId);
+
+        if (index !== -1) {
+          // Remove from list
+          this.selectedIds.splice(index, 1);
+        } else {
+          // Add to list
+          this.selectedIds.push(tagId);
+        }
+      } else {
+        // Single select -- just replace the array
+        this.selectedIds = [tagId];
+      }
+    };
+  }
+
+  tagLabel(tag: Tag | undefined): Mithril.Children {
+    if (tag?.parent()) {
+      // Show parental hierarchy
+      return tagsLabel([tag.parent(), tag]);
+    } else {
+      return tagLabel(tag);
+    }
+  }
+
+  dropdownLabel(): Mithril.Children {
+    if (this.selectedIds.length > this.textLabelCutoff) {
+      // X selected
+      return app.translator.trans(`flarum-tags.admin.tag_selector.tags_selected_label`, { count: this.selectedIds.length });
+    } else if (this.selectedIds.length > 0) {
+      // Show tag label itself
+      return this.selectedIds.map((id) => this.tagLabel(app.store.getById('tags', id)));
+    }
+
+    // Choose tags...
+    return app.translator.trans(`flarum-tags.admin.tag_selector.choose_tags_label`);
+  }
+}

--- a/extensions/tags/js/src/admin/index.ts
+++ b/extensions/tags/js/src/admin/index.ts
@@ -4,6 +4,7 @@ import addTagsPermissionScope from './addTagsPermissionScope';
 import addTagPermission from './addTagPermission';
 import addTagsHomePageOption from './addTagsHomePageOption';
 import addTagChangePermission from './addTagChangePermission';
+import addCustomSettingComponent from './addCustomSettingComponent';
 import TagsPage from './components/TagsPage';
 
 app.initializers.add('flarum-tags', (app) => {
@@ -15,6 +16,7 @@ app.initializers.add('flarum-tags', (app) => {
   addTagPermission();
   addTagsHomePageOption();
   addTagChangePermission();
+  addCustomSettingComponent();
 });
 
 // Expose compat API

--- a/extensions/tags/js/src/common/components/SelectTagsModal.tsx
+++ b/extensions/tags/js/src/common/components/SelectTagsModal.tsx
@@ -1,0 +1,273 @@
+import app from 'flarum/forum/app';
+import type Mithril from 'mithril';
+import Modal, { IInternalModalAttrs } from 'flarum/common/components/Modal';
+import DiscussionPage from 'flarum/forum/components/DiscussionPage';
+import Button from 'flarum/common/components/Button';
+import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
+import highlight from 'flarum/common/helpers/highlight';
+import classList from 'flarum/common/utils/classList';
+import extractText from 'flarum/common/utils/extractText';
+import KeyboardNavigatable from 'flarum/forum/utils/KeyboardNavigatable';
+import Stream from 'flarum/common/utils/Stream';
+import Discussion from 'flarum/common/models/Discussion';
+
+import tagLabel from '../helpers/tagLabel';
+import tagIcon from '../helpers/tagIcon';
+import sortTags from '../utils/sortTags';
+
+import Tag from '../models/Tag';
+import AdminPage from 'flarum/admin/components/AdminPage';
+import { IPageAttrs } from 'flarum/common/components/Page';
+
+/**
+ * Defines how the `SelectTagsModal` will save its state to the database.
+ */
+export interface ITagSelectorSaveFormat {
+  separation: 'json' | 'csv';
+  values: 'id' | 'slug';
+}
+
+export interface ISelectTagModalAttrs extends IInternalModalAttrs {
+  /**
+   * Event handler triggered when the user finishes tag selection.
+   */
+  onsubmit?: (tags: Tag[]) => {};
+  /**
+   * Whether multiple tags can be selected in the component.
+   */
+  multiselect?: boolean;
+  /**
+   * An array of tags that are selected.
+   */
+  value?: Tag[];
+  /**
+   * Filter function which the full list of tags are passed through which
+   * can be used to hide certain tags.
+   */
+  tagFiler?: (tag: Tag) => boolean;
+}
+
+interface ISelectTagModalInternalAttrs extends ISelectTagModalAttrs {
+  __fromBuildSettingsComponent: true;
+  adminPage: AdminPage<IPageAttrs>;
+  settingsKey: string;
+  /**
+   * `false` to disable automatically saving tags to the database.
+   *
+   * Otherwise, provide a valid object matching the `ITagSelectorSaveFormat` interface.
+   */
+  saveFormat: ITagSelectorSaveFormat;
+}
+
+export default class SelectTagsModal<InternalUsage extends boolean = false> extends Modal<
+  InternalUsage extends true ? ISelectTagModalInternalAttrs : ISelectTagModalAttrs
+> {
+  availableTags: Tag[] | null = null;
+  selectedIds: string[] = [];
+  loadingState: 'loaded' | 'error' | 'loading' = 'loading';
+  saveFormat!: ITagSelectorSaveFormat;
+  /**
+   * When the number of selected tags exceeds this number, the label
+   * switches to text-only.
+   */
+  textLabelCutoff = 3;
+
+  navigator = new KeyboardNavigatable();
+
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    // Ensure save formatting options are set
+    if ('__fromBuildSettingsComponent' in this.attrs) {
+      this.saveFormat = this.attrs.saveFormat || {
+        separation: 'csv',
+        values: 'id',
+      };
+
+      this.saveFormat.separation ||= 'csv';
+      this.saveFormat.values ||= 'id';
+    }
+
+    if (this.attrs.value && !('__fromBuildComponent' in this.attrs)) {
+      this.selectedIds = this.attrs.value.map((tag) => tag.id()!);
+    }
+
+    this.loadTags();
+
+    // this.navigator
+    //   .onUp(() => this.setIndex(this.getCurrentNumericIndex() - 1, true))
+    //   .onDown(() => this.setIndex(this.getCurrentNumericIndex() + 1, true))
+    //   .onSelect(this.select.bind(this))
+    //   .onRemove(() => this.selected.splice(this.selected.length - 1, 1));
+
+    app.tagList.load(['parent']).then(() => {
+      this.tagsLoading = false;
+
+      const tags = sortTags(getSelectableTags(this.attrs.discussion));
+      this.tags = tags;
+
+      const discussionTags = this.attrs.discussion?.tags();
+      if (this.attrs.selectedTags) {
+        this.attrs.selectedTags.map(this.addTag.bind(this));
+      } else if (discussionTags) {
+        discussionTags.forEach((tag) => tag && this.addTag(tag));
+      }
+
+      this.selectedTag = tags[0];
+
+      m.redraw();
+    });
+  }
+
+  /**
+   * Fetches all tags from the API and loads them into the store, as well as
+   * setting the default state of the selector if using the selector within
+   * the settings component builder.
+   */
+  async loadTags() {
+    this.loadingState = 'loading';
+    m.redraw();
+
+    let tags: Tag[] = await app.store.find<Tag[]>('tags');
+
+    if ('__fromBuildComponent' in this.attrs) {
+      // preload value from settings
+      const settingData = this.settingValue;
+      let decodedSetting: null | string[] = null;
+
+      switch (this.saveFormat.separation) {
+        default:
+        case 'csv':
+          // splitting an empty string results in an array element
+          // with an empty string, so we need to filter that out
+          decodedSetting = settingData ? settingData.split(',') : [];
+          break;
+
+        case 'json':
+          try {
+            decodedSetting = JSON.parse(settingData || '[]');
+          } catch {
+            app.alerts.show({ type: 'error' }, app.translator.trans('flarum-tags.admin.tag_selector.failed_parse'));
+            decodedSetting = [];
+          }
+          break;
+      }
+
+      switch (this.saveFormat.values) {
+        default:
+        case 'id':
+          this.selectedIds = decodedSetting!;
+          break;
+
+        case 'slug':
+          this.selectedIds = decodedSetting!.map(
+            // Use -1 as fallback for a deleted tag
+            (slug) => app.store.getBy<Tag>('tags', 'slug', slug)?.id() || '-1'
+          );
+          break;
+      }
+    }
+
+    if (typeof this.attrs.tagFilter === 'function') {
+      tags = tags.filter(this.attrs.tagFilter);
+    }
+
+    this.availableTags = sortTags(tags);
+    this.loadingState = 'loaded';
+    m.redraw();
+  }
+
+  primaryCount() {
+    return this.selected.filter((tag) => tag.isPrimary()).length;
+  }
+
+  secondaryCount() {
+    return this.selected.filter((tag) => !tag.isPrimary()).length;
+  }
+
+  /**
+   * Add the given tag to the list of selected tags.
+   */
+  addTag(tag: Tag) {
+    if (!tag.canStartDiscussion()) return;
+
+    // If this tag has a parent, we'll also need to add the parent tag to the
+    // selected list if it's not already in there.
+    const parent = tag.parent();
+    if (parent && !this.selected.includes(parent)) {
+      this.selected.push(parent);
+    }
+
+    if (!this.selected.includes(tag)) {
+      this.selected.push(tag);
+    }
+  }
+
+  /**
+   * Remove the given tag from the list of selected tags.
+   */
+  removeTag(tag: Tag) {
+    const index = this.selected.indexOf(tag);
+    if (index !== -1) {
+      this.selected.splice(index, 1);
+
+      // Look through the list of selected tags for any tags which have the tag
+      // we just removed as their parent. We'll need to remove them too.
+      this.selected.filter((selected) => selected.parent() === tag).forEach(this.removeTag.bind(this));
+    }
+  }
+
+  className() {
+    return 'ChooseTagsModal';
+  }
+
+  title() {
+    // return this.attrs.discussion
+    //   ? app.translator.trans('flarum-tags.forum.choose_tags.edit_title', { title: <em>{this.attrs.discussion.title()}</em> })
+    //   : app.translator.trans('flarum-tags.forum.choose_tags.title');
+  }
+
+  // getInstruction(primaryCount: number, secondaryCount: number) {
+  //   if (this.bypassReqs) {
+  //     return '';
+  //   }
+
+  //   if (primaryCount < this.minPrimary) {
+  //     const remaining = this.minPrimary - primaryCount;
+  //     return app.translator.trans('flarum-tags.forum.choose_tags.choose_primary_placeholder', { count: remaining });
+  //   } else if (secondaryCount < this.minSecondary) {
+  //     const remaining = this.minSecondary - secondaryCount;
+  //     return app.translator.trans('flarum-tags.forum.choose_tags.choose_secondary_placeholder', { count: remaining });
+  //   }
+
+  //   return '';
+  // }
+
+  content() {
+    if (this.tagsLoading || !this.tags) {
+      return <LoadingIndicator />;
+    }
+
+    return <div className="Modal-body"></div>;
+  }
+
+  onsubmit(e: SubmitEvent) {
+    e.preventDefault();
+
+    const discussion = this.attrs.discussion;
+    const tags = this.selected;
+
+    if (discussion) {
+      discussion.save({ relationships: { tags } }).then(() => {
+        if (app.current.matches(DiscussionPage)) {
+          app.current.get('stream').update();
+        }
+        m.redraw();
+      });
+    }
+
+    if (this.attrs.onsubmit) this.attrs.onsubmit(tags);
+
+    this.hide();
+  }
+}

--- a/extensions/tags/js/src/forum/utils/getSelectableTags.js
+++ b/extensions/tags/js/src/forum/utils/getSelectableTags.js
@@ -1,3 +1,5 @@
+import app from "flarum/common/app";
+
 export default function getSelectableTags(discussion) {
   let tags = app.store.all('tags');
 

--- a/extensions/tags/less/admin.less
+++ b/extensions/tags/less/admin.less
@@ -2,6 +2,7 @@
 
 @import "admin/TagsPage";
 @import "admin/EditTagModal";
+@import "admin/TagsSelector";
 
 .Dropdown--restrictByTag .Dropdown-menu {
   max-height: 400px;

--- a/extensions/tags/less/admin/TagsSelector.less
+++ b/extensions/tags/less/admin/TagsSelector.less
@@ -1,0 +1,10 @@
+.TagSelector-Dropdown {
+  .Dropdown-toggle .Button-label {
+    > .TagLabel,
+    > .TagsLabel {
+      &:not(:first-child) {
+        margin-left: 4px;
+      }
+    }
+  }
+}

--- a/extensions/tags/locale/en.yml
+++ b/extensions/tags/locale/en.yml
@@ -38,6 +38,15 @@ flarum-tags:
       restrict_by_tag_heading: Restrict by Tag
       tag_discussions_label: Tag discussions
 
+    # These translations are used in the tag selector dropdown component.
+    tag_selector:
+      choose_tags_label: Choose tags...
+      error_label: Failed to load tags!
+      failed_parse: "Failed to parse tags selection settings value! (key: {settingKey})"
+      loading_label: Loading tags...
+      open_dropdown_a11y_label: Open tag selection dropdown
+      tags_selected_label: "{count} selected"
+
     # These translations are used in the Tag Settings modal dialog.
     tag_settings:
       range_separator_text: " to "


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Creates a new `TagSelector` component, designed for use within `buildSettingComponent` in conjuction with core PR #3494.

This allows extensions to more easily select tag model instances within their settings pages.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

Checks may fail until #3494 is merged.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

https://user-images.githubusercontent.com/7406822/174515268-493ee6e2-19ee-4a27-a7a6-7ce54ab8b4cb.mp4

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [x] Related core PR: #3494
- [ ] Related core PR: #3456
