### PR TITLE
fix: forum/discussion titles in notifications overflow

### DIFF
--- a/framework/core/less/forum/NotificationList.less
+++ b/framework/core/less/forum/NotificationList.less
@@ -68,14 +68,17 @@
     color: var(--heading-color) !important;
     padding: 8px 16px;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
     display: flex;
     align-items: center;
 
     // Prevent outline overflowing parent
     .add-keyboard-focus-ring-offset(-1px);
+
+    &, span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   &-badges {


### PR DESCRIPTION
**Fixes #3408**

**Changes proposed in this pull request:**
- Apply overflow & ellipsis to `span` as well as parent element
    - The span appears when the title is a discussion title, as it separates discussion badges vs titles in the DOM

**Reviewers should focus on:**
Do we just want to wrap the forum title in a span?

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/177045222-09de15d9-1b58-4fb5-9219-d5b62a19fedc.png)


**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
- [X] Core developer confirmed locally this works as intended.
- ~~Tests have been added, or are not appropriate here.~~