### PR TITLE
fix: `assertAdmin` sending wrong ability name to gate

### DIFF
--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -650,7 +650,7 @@ class User extends AbstractModel
      */
     public function assertAdmin()
     {
-        $this->assertCan($this, 'administrate');
+        $this->assertCan('administrate');
     }
 
     /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Currently, the full user record serialized as JSON is being sent to the gate when checking for admin privilege, while the intended ability name `administrate` is sent as the gate parameter as string. This works because the gate will always return `true` for admins, but this means extensions can't customize the `administrate` ability since it's never actually passed.

I have not tested the change locally, but I wanted to start with the PR right away since it's easier to explain this way instead of creating a whole issue about it.

This is the output from my [gate logger](https://github.com/clarkwinkelmann/flarum-ext-gate-logger) extension prior to the fix, it's supposed to say `Gate Logger administrate(Actor: Admin, [GLOBAL])`

```
[2022-07-03 21:24:12] flarum.DEBUG: Gate Logger {"id":1,"username":"Admin","email":"admin@http418.ch","is_email_confirmed":1,"password":"$2y$10$lLDDVBiags5q80XY8imjQuc\/Bk6EBGd.CkEvfoKZI.oxPMyCtsfFy","avatar_url":"http:\/\/1.3.flarum.localhost\/assets\/avatars\/predefinedAvatar:RFjlw9i7awEUwtzz.png","preferences":{"notify_discussionRenamed_alert":true,"notify_selectBestAnswer_alert":true,"notify_selectBestAnswer_email":true,"notify_awardedBestAnswer_alert":true,"notify_awardedBestAnswer_email":false,"notify_bestAnswerInDiscussion_alert":false,"notify_bestAnswerInDiscussion_email":false,"notify_postMentioned_alert":true,"notify_postMentioned_email":false,"notify_userMentioned_alert":true,"notify_userMentioned_email":false,"notify_discussionLocked_alert":true,"notify_postLiked_alert":true,"discloseOnline":true,"indexProfile":true,"locale":null},"joined_at":"2022-05-17T17:49:12.000000Z","last_seen_at":"2022-07-03T21:24:12.000000Z","marked_all_as_read_at":null,"read_notifications_at":null,"discussion_count":6,"comment_count":9,"read_flags_at":null,"suspended_until":null,"suspend_reason":null,"suspend_message":null,"best_answer_count":0,"social_buttons":"[{\"title\":\"Test\",\"url\":\"https:\/\/extiverse.com\/\",\"icon\":\"favicon\",\"favicon\":\"data:image\/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxzY3JpcHQ+YWxlcnQoJ1hTUycpPC9zY3JpcHQ+PC9zdmc+Cg==\"}]"}(Actor: Admin, administrate::class)
Decision: ALLOW (Admin role)  
```

Maybe this is worth an integration test? I'm not sure which feature could be tested for `administrate` extensibility though.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
