### PR TITLE
fix: composer title positioning incorrect with custom header height

### DIFF
--- a/framework/core/less/forum/Composer.less
+++ b/framework/core/less/forum/Composer.less
@@ -190,6 +190,7 @@
       }
 
       .normal &:first-child {
+        height: var(--header-height-phone);
         margin: calc(~"0px - var(--header-height-phone)") 50px 0;
         text-align: center;
         position: relative;
@@ -198,6 +199,9 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        display: flex;
+        align-items: center;
+        justify-content: center;
 
         h3 {
           color: var(--header-control-color);


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

With a custom header height specified, the mobile composer slips up, with some elements appearing behind the header as if it isn't bigger, and the title isn't centred correctly.

This PR fixes both of these issues, as seen in the screenshots below.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Before and after screenshots:
![image](https://user-images.githubusercontent.com/7406822/177143560-fe227820-190f-4619-bb9c-06e011638815.png)
![image](https://user-images.githubusercontent.com/7406822/177143580-84511eeb-429c-43f4-99d2-ba9f16947ec3.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
