### PR TITLE
fix: multiple createdAt columns in query causes conflicts

### DIFF
--- a/extensions/mentions/tests/integration/api/ListPostsTest.php
+++ b/extensions/mentions/tests/integration/api/ListPostsTest.php
@@ -105,6 +105,6 @@ class ListPostsTest extends TestCase
 
         // Order-independent comparison
         $ids = Arr::pluck($data, 'id');
-        $this->assertEqualsCanonicalizing(['2', '3'], $ids, 'IDs do not match');
+        $this->assertEqualsCanonicalizing(['3', '2'], $ids, 'IDs do not match');
     }
 }

--- a/extensions/mentions/tests/integration/api/ListPostsTest.php
+++ b/extensions/mentions/tests/integration/api/ListPostsTest.php
@@ -14,7 +14,7 @@ use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
 
-class ListTest extends TestCase
+class ListPostsTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
 
@@ -84,5 +84,27 @@ class ListTest extends TestCase
         // Order-independent comparison
         $ids = Arr::pluck($data, 'id');
         $this->assertEqualsCanonicalizing(['4'], $ids, 'IDs do not match');
+    }
+
+    /**
+     * @test
+     */
+    public function mentioned_filter_works_with_sort()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts')
+                ->withQueryParams([
+                    'filter' => ['mentioned' => 1],
+                    'sort' => '-createdAt'
+                ])
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Order-independent comparison
+        $ids = Arr::pluck($data, 'id');
+        $this->assertEqualsCanonicalizing(['2', '3'], $ids, 'IDs do not match');
     }
 }

--- a/framework/core/src/Api/Controller/ListPostsController.php
+++ b/framework/core/src/Api/Controller/ListPostsController.php
@@ -114,7 +114,7 @@ class ListPostsController extends AbstractListController
     }
 
     /**
-     * {@inheritdoc}
+     * @link https://github.com/flarum/framework/pull/3506
      */
     protected function extractSort(ServerRequestInterface $request)
     {

--- a/framework/core/src/Api/Controller/ListPostsController.php
+++ b/framework/core/src/Api/Controller/ListPostsController.php
@@ -116,6 +116,20 @@ class ListPostsController extends AbstractListController
     /**
      * {@inheritdoc}
      */
+    protected function extractSort(ServerRequestInterface $request)
+    {
+        $sort = [];
+
+        foreach ((parent::extractSort($request) ?: []) as $field => $direction) {
+            $sort["posts.$field"] = $direction;
+        }
+
+        return $sort;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function extractOffset(ServerRequestInterface $request)
     {
         $actor = RequestUtil::getActor($request);


### PR DESCRIPTION
**Fixes #3504**

**Changes proposed in this pull request:**
Temporary fix until a more major change is carried out for the longer term.
- Prepends table name t sort fields before the query is executed.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
