### PR TITLE
chore: add `.gitattributes` to extensions to export-ignore files.

### DIFF
--- a/extensions/akismet/.gitattributes
+++ b/extensions/akismet/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/approval/.gitattributes
+++ b/extensions/approval/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/bbcode/.gitattributes
+++ b/extensions/bbcode/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/embed/.gitattributes
+++ b/extensions/embed/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/emoji/.gitattributes
+++ b/extensions/emoji/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/flags/.gitattributes
+++ b/extensions/flags/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/lang-english/.gitattributes
+++ b/extensions/lang-english/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/likes/.gitattributes
+++ b/extensions/likes/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/lock/.gitattributes
+++ b/extensions/lock/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/markdown/.gitattributes
+++ b/extensions/markdown/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/mentions/.gitattributes
+++ b/extensions/mentions/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/nicknames/.gitattributes
+++ b/extensions/nicknames/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/package-manager/.gitattributes
+++ b/extensions/package-manager/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/pusher/.gitattributes
+++ b/extensions/pusher/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/statistics/.gitattributes
+++ b/extensions/statistics/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/sticky/.gitattributes
+++ b/extensions/sticky/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/subscriptions/.gitattributes
+++ b/extensions/subscriptions/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/suspend/.gitattributes
+++ b/extensions/suspend/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf

--- a/extensions/tags/.gitattributes
+++ b/extensions/tags/.gitattributes
@@ -1,0 +1,20 @@
+**/.gitattributes export-ignore
+**/.gitignore export-ignore
+**/.gitmodules export-ignore
+**/.github export-ignore
+**/.travis export-ignore
+**/.travis.yml export-ignore
+**/.editorconfig export-ignore
+**/.styleci.yml export-ignore
+
+**/phpunit.xml export-ignore
+**/tests export-ignore
+
+**/js/dist/**/* -diff
+**/js/dist/**/* linguist-generated
+**/js/dist-typings/**/* -diff
+**/js/dist-typings/**/* linguist-generated
+**/js/yarn.lock -diff
+**/js/package-lock.json -diff
+
+* text=auto eol=lf


### PR DESCRIPTION
**Changes proposed in this pull request:**
Recovers `.gitattributes` file in extensions to avoid exporting non-essential files in production and reduce final packages size.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
