### PR TITLE
fix(a11y): add accessible labels to notification grid options

### DIFF
--- a/framework/core/js/src/forum/components/NotificationGrid.js
+++ b/framework/core/js/src/forum/components/NotificationGrid.js
@@ -70,7 +70,14 @@ export default class NotificationGrid extends Component {
                       loading={this.loading[key]}
                       disabled={!(key in preferences)}
                       onchange={this.toggle.bind(this, [key])}
-                    />
+                    >
+                      <span class="sr-only">
+                        {app.translator.trans('core.forum.settings.notification_checkbox_a11y_label_template', {
+                          description: type.label,
+                          method: method.label,
+                        })}
+                      </span>
+                    </Checkbox>
                   </td>
                 );
               })}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -448,6 +448,7 @@ core:
       account_heading: Account
       change_email_button: => core.ref.change_email
       change_password_button: => core.ref.change_password
+      notification_checkbox_a11y_label_template: 'Receive "{description}" notifications via {method}'
       notifications_heading: => core.ref.notifications
       notify_by_email_heading: => core.ref.email
       notify_by_web_heading: Web


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3369**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- adds a11y labels to the notification grid

![image](https://user-images.githubusercontent.com/7406822/178219117-0d66c630-be16-45f3-958c-ee0305a3a42d.png)


**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

Is there a better way this label could be written?

Screenreaders will announce, for example, `checkbox. receive "someone renames a discussion i started" notifications via web. ticked.`

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
