### PR TITLE
fix(a11y): set `aria-busy` when editing a post stream item

### DIFF
--- a/framework/core/js/src/forum/components/CommentPost.js
+++ b/framework/core/js/src/forum/components/CommentPost.js
@@ -107,6 +107,8 @@ export default class CommentPost extends Post {
         editing: this.isEditing(),
       });
 
+    if (this.isEditing()) attrs['aria-busy'] = 'true';
+
     return attrs;
   }
 

--- a/framework/core/js/src/forum/components/ReplyPlaceholder.js
+++ b/framework/core/js/src/forum/components/ReplyPlaceholder.js
@@ -18,7 +18,7 @@ export default class ReplyPlaceholder extends Component {
   view() {
     if (app.composer.composingReplyTo(this.attrs.discussion)) {
       return (
-        <article className="Post CommentPost editing">
+        <article className="Post CommentPost editing" aria-busy="true">
           <header className="Post-header">
             <div className="PostUser">
               <h3>


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3366**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
As per title

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
