### PR TITLE
fix: Set the translator locale to user preference for email notifications

### DIFF
--- a/framework/core/src/Notification/NotificationMailer.php
+++ b/framework/core/src/Notification/NotificationMailer.php
@@ -52,7 +52,7 @@ class NotificationMailer
     {
         // Ensure that notifications are delivered to the user in their default language, if they've selected one.
         // If the selected locale is no longer available, the forum default will be used instead.
-		$this->translator->setLocale($user->getPreference('locale') ?? $this->settings->get('default_locale'));
+        $this->translator->setLocale($user->getPreference('locale') ?? $this->settings->get('default_locale'));
 
         $this->mailer->send(
             $blueprint->getEmailView(),

--- a/framework/core/src/Notification/NotificationMailer.php
+++ b/framework/core/src/Notification/NotificationMailer.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Notification;
 
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Mail\Message;
@@ -27,13 +28,20 @@ class NotificationMailer
     protected $translator;
 
     /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
      * @param Mailer $mailer
      * @param TranslatorInterface $translator
+     * @param SettingsRepositoryInterface $settings
      */
-    public function __construct(Mailer $mailer, TranslatorInterface $translator)
+    public function __construct(Mailer $mailer, TranslatorInterface $translator, SettingsRepositoryInterface $settings)
     {
         $this->mailer = $mailer;
         $this->translator = $translator;
+        $this->settings = $settings;
     }
 
     /**
@@ -42,6 +50,10 @@ class NotificationMailer
      */
     public function send(MailableInterface $blueprint, User $user)
     {
+        // Ensure that notifications are delivered to the user in their default language, if they've selected one.
+        // If the selected locale is no longer available, the forum default will be used instead.
+		$this->translator->setLocale($user->getPreference('locale') ?? $this->settings->get('default_locale'));
+
         $this->mailer->send(
             $blueprint->getEmailView(),
             compact('blueprint', 'user'),


### PR DESCRIPTION
**Changes proposed in this pull request:**
Currently, on multi-lingual Flarum installations, all email notifications are sent to users based on the Forum's default language.

This PR proposes to set the `translator` to the recipient users' prefferred locale ahead of building the notification, therefore the resulting notification email is in their chosen language.

If the locale returned from the user preferences is no longer available (language pack disabled, removed, etc), the forum default will be used as currently. Also uses forum default if the user has not set a preference.

**Screenshot**
```
[2022-07-12 10:39:10] flarum.INFO: Message-ID: <a320ae619ecd39df702af93a11b44649@dev.morland.it>
Date: Tue, 12 Jul 2022 10:39:10 +0000
Subject: IanM hat dich in test =?utf-8?Q?erw=C3=A4hnt?=
From: IanM Flarum Dev <flarum@email.morland.dev>
To: im <ian@XXXXXX>
MIME-Version: 1.0
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: quoted-printable

Hallo im!

IanM hat dich in der Diskussion test erwähnt.

https://dev.morland.it/d/416/7

---

@"ian_slack"#17 @"im"#3 

  
[2022-07-12 10:39:10] flarum.INFO: Message-ID: <52ae7a670d2eab61542ad4bc78726d3d@dev.morland.it>
Date: Tue, 12 Jul 2022 10:39:10 +0000
Subject: IanM mentioned you in test
From: IanM Flarum Dev <flarum@email.morland.dev>
To: ian_slack <ian@bXXXXXX>
MIME-Version: 1.0
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: quoted-printable

Hey ian_slack!

IanM mentioned you in a post in test.

https://dev.morland.it/d/416/7

---

@"ian_slack"#17 @"im"#3 

 ```


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
