### PR TITLE
feat(likes): Add likes tab to user profile

### DIFF
--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -15,8 +15,10 @@ use Flarum\Likes\Event\PostWasLiked;
 use Flarum\Likes\Event\PostWasUnliked;
 use Flarum\Likes\Listener;
 use Flarum\Likes\Notification\PostLikedBlueprint;
+use Flarum\Likes\Query\LikedFilter;
 use Flarum\Post\Event\Deleted;
 use Flarum\Post\Event\Saving;
+use Flarum\Post\Filter\PostFilterer;
 use Flarum\Post\Post;
 use Flarum\User\User;
 
@@ -59,4 +61,7 @@ return [
         ->listen(PostWasUnliked::class, Listener\SendNotificationWhenPostIsUnliked::class)
         ->listen(Deleted::class, [Listener\SaveLikesToDatabase::class, 'whenPostIsDeleted'])
         ->listen(Saving::class, [Listener\SaveLikesToDatabase::class, 'whenPostIsSaving']),
+
+    (new Extend\Filter(PostFilterer::class))
+        ->addFilter(LikedFilter::class),
 ];

--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -15,7 +15,7 @@ use Flarum\Likes\Event\PostWasLiked;
 use Flarum\Likes\Event\PostWasUnliked;
 use Flarum\Likes\Listener;
 use Flarum\Likes\Notification\PostLikedBlueprint;
-use Flarum\Likes\Query\LikedFilter;
+use Flarum\Likes\Query\LikedByFilter;
 use Flarum\Post\Event\Deleted;
 use Flarum\Post\Event\Saving;
 use Flarum\Post\Filter\PostFilterer;
@@ -63,5 +63,5 @@ return [
         ->listen(Saving::class, [Listener\SaveLikesToDatabase::class, 'whenPostIsSaving']),
 
     (new Extend\Filter(PostFilterer::class))
-        ->addFilter(LikedFilter::class),
+        ->addFilter(LikedByFilter::class),
 ];

--- a/extensions/likes/js/src/forum/addLikesTabToUserProfile.tsx
+++ b/extensions/likes/js/src/forum/addLikesTabToUserProfile.tsx
@@ -1,0 +1,21 @@
+import { extend } from 'flarum/common/extend';
+import app from 'flarum/forum/app';
+import UserPage from 'flarum/forum/components/UserPage';
+import LinkButton from 'flarum/common/components/LinkButton';
+import LikesUserPage from './components/LikesUserPage';
+import ItemList from 'flarum/common/utils/ItemList';
+import type Mithril from 'mithril';
+
+export default function addLikesTabToUserProfile() {
+  app.routes['user.likes'] = { path: '/u/:username/likes', component: LikesUserPage };
+  extend(UserPage.prototype, 'navItems', function (items: ItemList<Mithril.Children>) {
+    const user = this.user;
+    items.add(
+      'likes',
+      <LinkButton href={app.route('user.likes', { username: user.slug() })} name="likes" icon="far fa-thumbs-up">
+        {app.translator.trans('flarum-likes.forum.user.likes_link')}
+      </LinkButton>,
+      88
+    );
+  });
+}

--- a/extensions/likes/js/src/forum/addLikesTabToUserProfile.tsx
+++ b/extensions/likes/js/src/forum/addLikesTabToUserProfile.tsx
@@ -12,7 +12,7 @@ export default function addLikesTabToUserProfile() {
     const user = this.user;
     items.add(
       'likes',
-      <LinkButton href={app.route('user.likes', { username: user.slug() })} name="likes" icon="far fa-thumbs-up">
+      <LinkButton href={app.route('user.likes', { username: user.slug() })} icon="far fa-thumbs-up">
         {app.translator.trans('flarum-likes.forum.user.likes_link')}
       </LinkButton>,
       88

--- a/extensions/likes/js/src/forum/components/LikesUserPage.tsx
+++ b/extensions/likes/js/src/forum/components/LikesUserPage.tsx
@@ -15,7 +15,7 @@ export default class LikesUserPage extends PostsUserPage {
     return app.store.find('posts', {
       filter: {
         type: 'comment',
-        liked: this.user.id(),
+        likedBy: this.user.id(),
       },
       page: { offset, limit: this.loadLimit },
       sort: '-createdAt',

--- a/extensions/likes/js/src/forum/components/LikesUserPage.tsx
+++ b/extensions/likes/js/src/forum/components/LikesUserPage.tsx
@@ -1,0 +1,24 @@
+import app from 'flarum/forum/app';
+import PostsUserPage from 'flarum/forum/components/PostsUserPage';
+
+/**
+ * The `LikesUserPage` component shows posts which user the user liked.
+ */
+export default class LikesUserPage extends PostsUserPage {
+  /**
+   * Load a new page of the user's activity feed.
+   *
+   * @param offset The position to start getting results from.
+   * @protected
+   */
+  loadResults(offset: number) {
+    return app.store.find('posts', {
+      filter: {
+        type: 'comment',
+        liked: this.user.id(),
+      },
+      page: { offset, limit: this.loadLimit },
+      sort: '-createdAt',
+    });
+  }
+}

--- a/extensions/likes/js/src/forum/index.js
+++ b/extensions/likes/js/src/forum/index.js
@@ -7,6 +7,7 @@ import NotificationGrid from 'flarum/forum/components/NotificationGrid';
 import addLikeAction from './addLikeAction';
 import addLikesList from './addLikesList';
 import PostLikedNotification from './components/PostLikedNotification';
+import addLikesTabToUserProfile from './addLikesTabToUserProfile';
 
 app.initializers.add('flarum-likes', () => {
   app.notificationComponents.postLiked = PostLikedNotification;
@@ -16,6 +17,7 @@ app.initializers.add('flarum-likes', () => {
 
   addLikeAction();
   addLikesList();
+  addLikesTabToUserProfile();
 
   extend(NotificationGrid.prototype, 'notificationTypes', function (items) {
     items.add('postLiked', {

--- a/extensions/likes/locale/en.yml
+++ b/extensions/likes/locale/en.yml
@@ -35,3 +35,7 @@ flarum-likes:
     # These translations are used in the Settings page.
     settings:
       notify_post_liked_label: Someone likes one of my posts
+
+    # These translations are used in the User profile page.
+    user:
+      likes_link: Likes

--- a/extensions/likes/src/Query/LikedByFilter.php
+++ b/extensions/likes/src/Query/LikedByFilter.php
@@ -12,11 +12,11 @@ namespace Flarum\Likes\Query;
 use Flarum\Filter\FilterInterface;
 use Flarum\Filter\FilterState;
 
-class LikedFilter implements FilterInterface
+class LikedByFilter implements FilterInterface
 {
     public function getFilterKey(): string
     {
-        return 'liked';
+        return 'likedBy';
     }
 
     public function filter(FilterState $filterState, string $filterValue, bool $negate)

--- a/extensions/likes/src/Query/LikedFilter.php
+++ b/extensions/likes/src/Query/LikedFilter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Likes\Query;
+
+use Flarum\Filter\FilterInterface;
+use Flarum\Filter\FilterState;
+
+class LikedFilter implements FilterInterface
+{
+    public function getFilterKey(): string
+    {
+        return 'liked';
+    }
+
+    public function filter(FilterState $filterState, string $filterValue, bool $negate)
+    {
+        $likedId = trim($filterValue, '"');
+
+        $filterState
+            ->getQuery()
+            ->whereIn('id', function ($query) use ($likedId, $negate) {
+                $query->select('post_id')
+                    ->from('post_likes')
+                    ->where('user_id', $negate ? '!=' : '=', $likedId);
+            });
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
Similar to `flarum/mentions`, this proposes to add a `Likes` tab to the user profile. Displays posts liked by the current user, for easy referencing back to previous posts.

**Screenshot**
![image](https://user-images.githubusercontent.com/16573496/178853489-92fa1f5a-a38e-49cd-a156-9c6846ac1e67.png)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
