### PR TITLE
feat: extender to add custom less variables

### DIFF
--- a/framework/core/src/Extend/Theme.php
+++ b/framework/core/src/Extend/Theme.php
@@ -104,11 +104,8 @@ class Theme implements ExtenderInterface
     /**
      * Defines a new Less variable to be accessible in all Less files.
      *
-     * This can be useful for styling based on a backend setting, for example.
-     *
-     * Remember that Less is not recompiled when settings values change, so you
-     * may need to hook into a Saved event to recompile stylesheets when the
-     * value of one of your extension's settings changes in the database.
+     * If you want to expose a setting from your database to Less, you should use
+     * the `registerLessConfigVar` extender from `Extend\Settings` instead.
      *
      * Please note the value returned from the callable will be inserted directly
      * into the Less source. If it is unsafe in some way (e.g., contains a
@@ -120,9 +117,10 @@ class Theme implements ExtenderInterface
      *
      * ```php
      * (new Extend\Theme())
-     *   ->addCustomLessVariable('my-extension__show-thing', function () {
-     *     $settings = resolve(SettingsRepositoryInterface::class);
-     *     return boolval($settings->get('my-extension.show_thing', false));
+     *   ->addCustomLessVariable('my-extension__asset_path', function () {
+     *     $url = resolve(UrlGenerator::class);
+     *     $assetUrl = $url->to('forum')->base().'/assets/extensions/my-extension/my-asset.jpg';
+     *     return "\"$assetUrl\"";
      *   })
      * ```
      *

--- a/framework/core/src/Extend/Theme.php
+++ b/framework/core/src/Extend/Theme.php
@@ -95,7 +95,7 @@ class Theme implements ExtenderInterface
                 return new \Less_Tree_Dimension($return);
             }
 
-            throw new RuntimeException('Custom Less function `' . $functionName . '` must only return a string, number or boolean.');
+            throw new RuntimeException('Custom Less function `'.$functionName.'` must only return a string, number or boolean.');
         };
 
         return $this;
@@ -103,17 +103,17 @@ class Theme implements ExtenderInterface
 
     /**
      * Defines a new Less variable to be accessible in all Less files.
-     * 
+     *
      * This can be useful for styling based on a backend setting, for example.
-     * 
+     *
      * Please note the value returned from the callable will be inserted directly
      * into the Less source. If it is unsafe in some way (e.g., contains a
      * semi-colon), this will result in potential security issues with your
      * stylesheet.
-     * 
+     *
      * Likewise, if you need your variable to be a string, you should surround it
      * with quotes yourself.
-     * 
+     *
      * ```php
      * (new Extend\Theme())
      *   ->addCustomLessVariable('my-extension__show-thing', function () {

--- a/framework/core/src/Extend/Theme.php
+++ b/framework/core/src/Extend/Theme.php
@@ -106,6 +106,10 @@ class Theme implements ExtenderInterface
      *
      * This can be useful for styling based on a backend setting, for example.
      *
+     * Remember that Less is not recompiled when settings values change, so you
+     * may need to hook into a Saved event to recompile stylesheets when the
+     * value of one of your extension's settings changes in the database.
+     *
      * Please note the value returned from the callable will be inserted directly
      * into the Less source. If it is unsafe in some way (e.g., contains a
      * semi-colon), this will result in potential security issues with your

--- a/framework/core/tests/fixtures/less/custom_variable.less
+++ b/framework/core/tests/fixtures/less/custom_variable.less
@@ -1,0 +1,3 @@
+.dummy_var_test {
+  --x: @doesnt-exist;
+}

--- a/framework/core/tests/integration/extenders/ThemeTest.php
+++ b/framework/core/tests/integration/extenders/ThemeTest.php
@@ -34,7 +34,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Theme)
-                ->overrideLessImport('forum/Hero.less', __DIR__.'/../../fixtures/less/dummy.less')
+                ->overrideLessImport('forum/Hero.less', __DIR__ . '/../../fixtures/less/dummy.less')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -53,9 +53,9 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Frontend('forum'))
-                ->css(__DIR__.'/../../fixtures/less/forum.less'),
+                ->css(__DIR__ . '/../../fixtures/less/forum.less'),
             (new Extend\Theme)
-                ->overrideLessImport('Imported.less', __DIR__.'/../../fixtures/less/dummy.less', 'site-custom')
+                ->overrideLessImport('Imported.less', __DIR__ . '/../../fixtures/less/dummy.less', 'site-custom')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -77,7 +77,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Theme)
-                ->overrideFileSource('forum.less', __DIR__.'/../../fixtures/less/override_filesource.less')
+                ->overrideFileSource('forum.less', __DIR__ . '/../../fixtures/less/override_filesource.less')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -96,7 +96,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Theme)
-                ->overrideFileSource('mixins.less', __DIR__.'/../../fixtures/less/dummy.less')
+                ->overrideFileSource('mixins.less', __DIR__ . '/../../fixtures/less/dummy.less')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -112,7 +112,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Frontend('forum'))
-                ->css(__DIR__.'/../../fixtures/less/custom_function.less'),
+                ->css(__DIR__ . '/../../fixtures/less/custom_function.less'),
             (new Extend\Theme)
                 ->addCustomLessFunction('is-flarum', function ($text) {
                     return strtolower($text) === 'flarum' ? 'true' : 100;
@@ -131,5 +131,29 @@ class ThemeTest extends TestCase
 
         $this->assertStringContainsString('.dummy_func_test{color:green}', $contents);
         $this->assertStringContainsString('.dummy_func_test2{--x:1000;--y:false}', $contents);
+    }
+
+    /**
+     * @test
+     */
+    public function theme_extender_can_add_custom_variable()
+    {
+        $this->extend(
+            (new Extend\Frontend('forum'))
+                ->css(__DIR__ . '/../../fixtures/less/custom_variable.less'),
+            (new Extend\Theme)
+                ->addCustomLessVariable('doesnt-exist', function () {
+                    return "it does";
+                })
+        );
+
+        $response = $this->send($this->request('GET', '/'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $cssFilePath = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets')->path('forum.css');
+        $contents = file_get_contents($cssFilePath);
+
+        $this->assertStringContainsString('.dummy_var_test{--x:it does}', $contents);
     }
 }

--- a/framework/core/tests/integration/extenders/ThemeTest.php
+++ b/framework/core/tests/integration/extenders/ThemeTest.php
@@ -34,7 +34,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Theme)
-                ->overrideLessImport('forum/Hero.less', __DIR__ . '/../../fixtures/less/dummy.less')
+                ->overrideLessImport('forum/Hero.less', __DIR__.'/../../fixtures/less/dummy.less')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -53,9 +53,9 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Frontend('forum'))
-                ->css(__DIR__ . '/../../fixtures/less/forum.less'),
+                ->css(__DIR__.'/../../fixtures/less/forum.less'),
             (new Extend\Theme)
-                ->overrideLessImport('Imported.less', __DIR__ . '/../../fixtures/less/dummy.less', 'site-custom')
+                ->overrideLessImport('Imported.less', __DIR__.'/../../fixtures/less/dummy.less', 'site-custom')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -77,7 +77,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Theme)
-                ->overrideFileSource('forum.less', __DIR__ . '/../../fixtures/less/override_filesource.less')
+                ->overrideFileSource('forum.less', __DIR__.'/../../fixtures/less/override_filesource.less')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -96,7 +96,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Theme)
-                ->overrideFileSource('mixins.less', __DIR__ . '/../../fixtures/less/dummy.less')
+                ->overrideFileSource('mixins.less', __DIR__.'/../../fixtures/less/dummy.less')
         );
 
         $response = $this->send($this->request('GET', '/'));
@@ -112,7 +112,7 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Frontend('forum'))
-                ->css(__DIR__ . '/../../fixtures/less/custom_function.less'),
+                ->css(__DIR__.'/../../fixtures/less/custom_function.less'),
             (new Extend\Theme)
                 ->addCustomLessFunction('is-flarum', function ($text) {
                     return strtolower($text) === 'flarum' ? 'true' : 100;
@@ -140,10 +140,10 @@ class ThemeTest extends TestCase
     {
         $this->extend(
             (new Extend\Frontend('forum'))
-                ->css(__DIR__ . '/../../fixtures/less/custom_variable.less'),
+                ->css(__DIR__.'/../../fixtures/less/custom_variable.less'),
             (new Extend\Theme)
                 ->addCustomLessVariable('doesnt-exist', function () {
-                    return "it does";
+                    return 'it does';
                 })
         );
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Adds new theming extender which allows for the definition of custom Less variables. This is somewhat similar to the current extender which allows the adding of functions.

This can help with things such as determining if styling should be applied at asset-compile-time rather than in runtime with Javascript. This will help reduce extra styles being present in stylesheets, and extra JS being present in our dist scripts.

Variables and values defined here will be added immediately after core's own settings keys `@config-...` directly into the Less source files.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
