### PR TITLE
feat(likes): Option to prevent users liking their own posts

### DIFF
--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -7,6 +7,8 @@
  * LICENSE file that was distributed with this source code.
  */
 
+namespace Flarum\Likes;
+
 use Flarum\Api\Controller;
 use Flarum\Api\Serializer\BasicUserSerializer;
 use Flarum\Api\Serializer\PostSerializer;
@@ -64,4 +66,10 @@ return [
 
     (new Extend\Filter(PostFilterer::class))
         ->addFilter(LikedByFilter::class),
+
+    (new Extend\Settings())
+        ->default('flarum-likes.like_own_post', true),
+
+    (new Extend\Policy())
+        ->modelPolicy(Post::class, Access\LikePostPolicy::class),
 ];

--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -15,7 +15,6 @@ use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Extend;
 use Flarum\Likes\Event\PostWasLiked;
 use Flarum\Likes\Event\PostWasUnliked;
-use Flarum\Likes\Listener;
 use Flarum\Likes\Notification\PostLikedBlueprint;
 use Flarum\Likes\Query\LikedByFilter;
 use Flarum\Post\Event\Deleted;

--- a/extensions/likes/js/src/admin/index.js
+++ b/extensions/likes/js/src/admin/index.js
@@ -1,12 +1,20 @@
 import app from 'flarum/admin/app';
 
 app.initializers.add('flarum-likes', () => {
-  app.extensionData.for('flarum-likes').registerPermission(
-    {
-      icon: 'far fa-thumbs-up',
-      label: app.translator.trans('flarum-likes.admin.permissions.like_posts_label'),
-      permission: 'discussion.likePosts',
-    },
-    'reply'
-  );
+  app.extensionData
+    .for('flarum-likes')
+    .registerPermission(
+      {
+        icon: 'far fa-thumbs-up',
+        label: app.translator.trans('flarum-likes.admin.permissions.like_posts_label'),
+        permission: 'discussion.likePosts',
+      },
+      'reply'
+    )
+    .registerSetting({
+      setting: 'flarum-likes.like_own_post',
+      type: 'bool',
+      label: app.translator.trans('flarum-likes.admin.settings.like_own_posts_label'),
+      help: app.translator.trans('flarum-likes.admin.settings.like_own_posts_help'),
+    });
 });

--- a/extensions/likes/locale/en.yml
+++ b/extensions/likes/locale/en.yml
@@ -11,6 +11,10 @@ flarum-likes:
     permissions:
       like_posts_label: Like posts
 
+    settings:
+      like_own_posts_help: When enabled, subject to permission, users may 'like' their own posts on the forum. To prevent users placing a 'like' on their own posts, disable this setting.
+      like_own_posts_label: Users may like their own posts
+
   # Translations in this namespace are used by the forum user interface.
   forum:
 

--- a/extensions/likes/src/Access/LikePostPolicy.php
+++ b/extensions/likes/src/Access/LikePostPolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Flarum\Likes\Access;
+
+use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\Access\AbstractPolicy;
+use Flarum\User\User;
+
+class LikePostPolicy extends AbstractPolicy
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+    
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function like(User $actor, Post $post)
+    {
+        if ($actor->id === $post->user_id && ! (bool) $this->settings->get('flarum-likes.like_own_post')) {
+            return $this->deny();
+        }
+    }
+}

--- a/extensions/likes/src/Access/LikePostPolicy.php
+++ b/extensions/likes/src/Access/LikePostPolicy.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Likes\Access;
 
 use Flarum\Post\Post;
@@ -13,7 +20,7 @@ class LikePostPolicy extends AbstractPolicy
      * @var SettingsRepositoryInterface
      */
     protected $settings;
-    
+
     public function __construct(SettingsRepositoryInterface $settings)
     {
         $this->settings = $settings;


### PR DESCRIPTION
**Changes proposed in this pull request:**

Introduces an option to prevent forum users liking their own posts. Default to `allow`, as per current behavior. 

I've literally lost track of how many times I've been asked to override this, so I believe it makes sense to include the option directly in the extension 🤔 

**Reviewers should focus on:**
I'm not 100% convinced on the translation copy. Does this wording make sense?

**Screenshot**
![image](https://user-images.githubusercontent.com/16573496/179085904-2c2493f5-9b9c-4048-b0c8-f685c3628c6b.png)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
