### PR TITLE
chore: split FA imports into separate Less file for easy overriding

### DIFF
--- a/framework/core/less/common/Iconography.less
+++ b/framework/core/less/common/Iconography.less
@@ -1,0 +1,5 @@
+@import "fontawesome";
+@import "brands";
+@import "regular";
+@import "solid";
+@fa-font-path: "./fonts";

--- a/framework/core/less/common/common.less
+++ b/framework/core/less/common/common.less
@@ -1,8 +1,4 @@
-@import "fontawesome";
-@import "brands";
-@import "regular";
-@import "solid";
-@fa-font-path: "./fonts";
+@import "Iconography";
 
 @import "normalize";
 @import "print";


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

After a good while exploring core, I've not been able to find a way to rip out FontAwesome's imports in our Less. I assume this is because of the weird way it's added as a global import directory within core.

As a result, I've chosen to split out all the FA imports into a new `Iconography.less` file, which can be overridden using the Less import override extender.

The reason I'm trying to do this is to replace FA5 Free entirely with FA6 Free or FA6 Pro. While importing both does work, it's a huge waste of bundle size. In the meantime, I'll have to override the whole `common.less` file where FA is imported.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
