### PR TITLE
fix: replace `.fa()` mixin usage with `.fas()`

### DIFF
--- a/extensions/mentions/less/forum.less
+++ b/extensions/mentions/less/forum.less
@@ -28,7 +28,7 @@
   }
 
   &:before {
-    .fa();
+    .fas();
     content: @fa-var-reply;
     margin-right: 5px;
   }

--- a/extensions/tags/less/forum/TagDiscussionModal.less
+++ b/extensions/tags/less/forum/TagDiscussionModal.less
@@ -125,7 +125,7 @@
 
     &.selected {
       .icon::before {
-        .fa();
+        .fas();
         content: @fa-var-check !important;
         color: @muted-color;
         font-size: 14px;

--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -59,7 +59,7 @@
   color: var(--muted-color);
 
   &:before {
-    .fa();
+    .fas();
     content: @fa-var-search;
     float: left;
     margin-right: -36px;

--- a/framework/core/less/forum/DiscussionListItem.less
+++ b/framework/core/less/forum/DiscussionListItem.less
@@ -265,11 +265,11 @@
       font-weight: bold;
 
       &:before {
-        .fa();
+        .fas();
         content: @fa-var-comment;
       }
       &:hover:before {
-        .fa();
+        .fas();
         content: @fa-var-check;
       }
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
These mixin calls should be `.fas()` for solid icons rather than a standard `.fa()`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
