### PR TITLE
feat: use `position: sticky` for discussion side nav

### DIFF
--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -3,7 +3,6 @@
   padding-top: var(--header-height);
   padding-bottom: 50px;
   min-height: 100vh;
-  max-width: 100vw;
 
   @media @phone {
     padding-top: var(--header-height-phone);

--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -2,8 +2,8 @@
   position: relative !important;
   padding-top: var(--header-height);
   padding-bottom: 50px;
-  overflow-x: hidden;
   min-height: 100vh;
+  max-width: 100vw;
 
   @media @phone {
     padding-top: var(--header-height-phone);

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -13,6 +13,7 @@ body {
   font-size: 13px;
   line-height: 1.5;
   overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -25,15 +25,15 @@
 @media @tablet-up {
   .DiscussionPage-nav {
     float: right;
+    position: sticky;
+    top: var(--header-height);
+    padding-top: 32px;
 
     &, > ul {
       width: 150px;
     }
+    
     > ul {
-      position: fixed;
-      margin-top: 30px;
-      z-index: 1;
-
       > li {
         margin-bottom: 10px;
       }

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -14,6 +14,11 @@
     top: 5px;
     opacity: 0.5;
   }
+
+  // Needed for sidebar `position: sticky` due to its `float`
+  &::after {
+    display: table-cell;
+  }
 }
 
 .Post-header {

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -8,16 +8,10 @@
   position: relative;
   top: 0;
   border-radius: var(--border-radius);
-  .clearfix();
 
   &.editing {
     top: 5px;
     opacity: 0.5;
-  }
-
-  // Needed for sidebar `position: sticky` due to its `float`
-  &::after {
-    display: table-cell;
   }
 }
 


### PR DESCRIPTION
**Fixes #3541**

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Swaps `position: fixed` for `position: sticky` for the Discussion sidebar. This helps to increase the amount of screen real estate for extension to add controls to the sidebar, when a large discussion hero is used.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

Removal of the `overflow-x: hidden` is needed for sticky to work correctly. This shouldn't pose any issues for us, but bad extensions could cause x overflow to occur now.

> We _could_ keep it, but set to `visible` when the selector is `.App.App-discussion` instead.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->




https://user-images.githubusercontent.com/7406822/179372878-d3c889d2-c1f4-478a-81aa-74885f5114a5.mp4

https://user-images.githubusercontent.com/7406822/179372873-b98ce48a-9381-49c6-959e-370e239cfd62.mp4




**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
