### PR TITLE
fix: html entities shown raw in page title

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -414,7 +414,12 @@ export default class Application {
       onHomepage || !this.title
         ? extractText(app.translator.trans('core.lib.meta_titles.without_page_title', params))
         : extractText(app.translator.trans('core.lib.meta_titles.with_page_title', params));
-    document.title = count + title;
+
+    const tempEl = document.createElement('div');
+    tempEl.innerHTML = title;
+    const decodedTitle = tempEl.innerText;
+
+    document.title = count + decodedTitle;
   }
 
   protected transformRequestOptions<ResponseType>(flarumOptions: FlarumRequestOptions<ResponseType>): InternalFlarumRequestOptions<ResponseType> {

--- a/framework/core/views/frontend/app.blade.php
+++ b/framework/core/views/frontend/app.blade.php
@@ -3,7 +3,7 @@
       @if ($language) lang="{{ $language }}" @endif>
     <head>
         <meta charset="utf-8">
-        <title>{{ $title }}</title>
+        <title>{!! $title !!}</title>
 
         {!! $head !!}
     </head>


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3514**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- echoes the forum title directly into the page blade template
- on frontend, title is passed through an `innerHtml` -> `innerText` conversion in order to decode any HTML entities returned by the translator params insertion

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/179503109-13f574d5-fc91-4996-a3ab-a7d4725ab4d1.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

