### PR TITLE
fix: unread notifications are globally cached between users.

### DIFF
--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -449,10 +449,10 @@ class User extends AbstractModel
      */
     protected function getUnreadNotifications()
     {
-        static $cached = null;
+        static $cached = [];
 
-        if (is_null($cached)) {
-            $cached = $this->notifications()
+        if (! isset($cached[$this->id])) {
+            $cached[$this->id] = $this->notifications()
                 ->whereIn('type', $this->getAlertableNotificationTypes())
                 ->whereNull('read_at')
                 ->where('is_deleted', false)
@@ -460,7 +460,7 @@ class User extends AbstractModel
                 ->get();
         }
 
-        return $cached;
+        return $cached[$this->id];
     }
 
     /**


### PR DESCRIPTION
**Changes proposed in this pull request:**
This static caching can cause problems like the crazy bell notification count on realtime extension. For now we should be caching per user id.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
