### PR TITLE
fix: Move guzzle requirement to core

### DIFF
--- a/extensions/akismet/composer.json
+++ b/extensions/akismet/composer.json
@@ -20,8 +20,7 @@
     ],
     "require": {
         "flarum/core": "^1.4",
-        "flarum/approval": "^1.2",
-        "guzzlehttp/guzzle": "^7.4"
+        "flarum/approval": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -42,6 +42,7 @@
         "doctrine/dbal": "^2.7",
         "dragonmantank/cron-expression": "^3.1.0",
         "franzl/whoops-middleware": "^2.0.0",
+        "guzzlehttp/guzzle": "^7.4",
         "illuminate/bus": "^8.0",
         "illuminate/cache": "^8.0",
         "illuminate/config": "^8.0",


### PR DESCRIPTION
I just had an issue which caused 500 errors when sending mail, only using the mailgun driver. Turns out, we've always had a dependency on GuzzleHttp\Client, but not required it in composer.json

https://github.com/flarum/framework/blob/29179e27c6e8217f49a51c7e1b5d1de4dbcd458a/framework/core/src/Mail/MailgunDriver.php#L13

**Changes proposed in this pull request:**
Remove `GuzzleHttp/Guzzle` from flarum/askimet, and onto core itself.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
