### PR TITLE
fix: potential static caching memory exhaustion

### DIFF
--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -439,7 +439,7 @@ class User extends AbstractModel
      */
     public function getUnreadNotificationCount()
     {
-        return $this->queryUnreadNotifications()->count();
+        return $this->unreadNotifications()->count();
     }
 
     /**
@@ -447,7 +447,7 @@ class User extends AbstractModel
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    protected function queryUnreadNotifications()
+    protected function unreadNotifications()
     {
         return $this->notifications()
             ->whereIn('type', $this->getAlertableNotificationTypes())
@@ -463,7 +463,7 @@ class User extends AbstractModel
      */
     protected function getUnreadNotifications()
     {
-        return $this->queryUnreadNotifications()->get();
+        return $this->unreadNotifications()->get();
     }
 
     /**
@@ -473,7 +473,7 @@ class User extends AbstractModel
      */
     public function getNewNotificationCount()
     {
-        return $this->queryUnreadNotifications()
+        return $this->unreadNotifications()
             ->where('created_at', '>', $this->read_notifications_at)
             ->count();
     }

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -439,7 +439,21 @@ class User extends AbstractModel
      */
     public function getUnreadNotificationCount()
     {
-        return $this->getUnreadNotifications()->count();
+        return $this->queryUnreadNotifications()->count();
+    }
+
+    /**
+     * Return query builder for all notifications that have not been read yet.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    protected function queryUnreadNotifications()
+    {
+        return $this->notifications()
+            ->whereIn('type', $this->getAlertableNotificationTypes())
+            ->whereNull('read_at')
+            ->where('is_deleted', false)
+            ->whereSubjectVisibleTo($this);
     }
 
     /**
@@ -449,18 +463,7 @@ class User extends AbstractModel
      */
     protected function getUnreadNotifications()
     {
-        static $cached = [];
-
-        if (! isset($cached[$this->id])) {
-            $cached[$this->id] = $this->notifications()
-                ->whereIn('type', $this->getAlertableNotificationTypes())
-                ->whereNull('read_at')
-                ->where('is_deleted', false)
-                ->whereSubjectVisibleTo($this)
-                ->get();
-        }
-
-        return $cached[$this->id];
+        return $this->queryUnreadNotifications()->get();
     }
 
     /**
@@ -470,9 +473,9 @@ class User extends AbstractModel
      */
     public function getNewNotificationCount()
     {
-        return $this->getUnreadNotifications()->filter(function ($notification) {
-            return $notification->created_at > $this->read_notifications_at ?: 0;
-        })->count();
+        return $this->queryUnreadNotifications()
+            ->where('created_at', '>', $this->read_notifications_at)
+            ->count();
     }
 
     /**

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -474,7 +474,7 @@ class User extends AbstractModel
     public function getNewNotificationCount()
     {
         return $this->unreadNotifications()
-            ->where('created_at', '>', $this->read_notifications_at)
+            ->where('created_at', '>', $this->read_notifications_at ?? 0)
             ->count();
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Removes static caching and model filtering in favour of adding extra where clauses to a relation.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Why was the static caching utilised in the first place?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
