### PR TITLE
fix: intellisense imports defaulting to absolute path from `src` folder

### DIFF
--- a/extensions/akismet/js/tsconfig.json
+++ b/extensions/akismet/js/tsconfig.json
@@ -8,7 +8,6 @@
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
-    "baseUrl": ".",
     "paths": {
       "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"],
       "flarum/flags/*": ["../vendor/flarum/flags/js/dist-typings/*"]

--- a/extensions/flags/js/tsconfig.json
+++ b/extensions/flags/js/tsconfig.json
@@ -8,7 +8,6 @@
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
-    "baseUrl": ".",
     "paths": {
       "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"],
       "@flarum/core/*": ["../vendor/flarum/core/js/dist-typings/*"]

--- a/extensions/package-manager/js/tsconfig.json
+++ b/extensions/package-manager/js/tsconfig.json
@@ -8,7 +8,6 @@
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
-    "baseUrl": ".",
     "paths": {
       "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"]
     }

--- a/extensions/pusher/js/tsconfig.json
+++ b/extensions/pusher/js/tsconfig.json
@@ -8,7 +8,6 @@
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
-    "baseUrl": ".",
     "paths": {
       "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"],
       "flarum/tags/*": ["../vendor/flarum/tags/js/dist-typings/*"]

--- a/extensions/statistics/js/tsconfig.json
+++ b/extensions/statistics/js/tsconfig.json
@@ -8,7 +8,6 @@
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
-    "baseUrl": ".",
     "paths": {
       "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"]
     }

--- a/extensions/tags/js/tsconfig.json
+++ b/extensions/tags/js/tsconfig.json
@@ -8,7 +8,6 @@
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
-    "baseUrl": ".",
     "paths": {
       "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"],
       // TODO: remove after export registry system implemented

--- a/js-packages/tsconfig/README.md
+++ b/js-packages/tsconfig/README.md
@@ -26,7 +26,6 @@ A baseline `tsconfig.json` is provided below that you can modify as needed. This
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
-    "baseUrl": ".",
     "paths": {
       "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"]
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://github.com/flarum/flarum-tsconfig/issues/4**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- removes baseUrl recommendation

This fixes intellisense from defaulting imports to `src/...` rather than relative (`./` or `../`) imports.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?
