### PR TITLE
fix: titles positioned wrongly with custom header height

### DIFF
--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -82,6 +82,7 @@
       }
     }
   }
+
   .App-titleControl {
     width: 200px;
     left: 50%;
@@ -89,7 +90,8 @@
     text-align: center;
     color: var(--header-color) !important;
 
-    &, > .Button {
+    &,
+    > .Button {
       font-size: 16px;
     }
     > .Button {
@@ -98,14 +100,21 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+
+    &--text {
+      line-height: var(--header-height);
+
+      @media @phone {
+        line-height: var(--header-height-phone);
+      }
+
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-weight: normal;
+    }
   }
-  .App-titleControl--text {
-    line-height: 46px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-weight: normal;
-  }
+
   .App-backControl {
     left: 0;
 

--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -102,12 +102,7 @@
     }
 
     &--text {
-      line-height: var(--header-height);
-
-      @media @phone {
-        line-height: var(--header-height-phone);
-      }
-
+      line-height: var(--header-height-phone);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
For text app titles, such as those in modals on mobile devices, ensure we use the height of the header as the line height instead of an arbitrary number. This ensures the text is vertically centred as expected with a custom header height.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

### Before

![image](https://user-images.githubusercontent.com/7406822/179974024-ec46cf90-2982-4a31-95cf-a20a22d25c0b.png)


### After 

![image](https://user-images.githubusercontent.com/7406822/179973974-fc788ea2-6222-422f-8bd0-ab4768ccf61a.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
