### PR TITLE
docs: link logo at the top with the official website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<p align="center"><img src="https://flarum.org/assets/img/logo.png"></p>
+<p align="center">
+<a href="https://flarum.org/"><img src="https://flarum.org/assets/img/logo.png"></a>
+</p>
 
 <p align="center">
 <a href="https://github.com/flarum/core/actions?query=workflow%3ATests"><img src="https://github.com/flarum/core/workflows/Tests/badge.svg" alt="PHP Tests"></a>


### PR DESCRIPTION
Fixes [N/A]

**Changes proposed in this pull request:**
When I was reading README.md, I clicked the logo and I expected it to go to the official website https://flarum.org/
but it didn't. So, the image is being linked to the official website in this commit.

**Reviewers should focus on:**
N/A

**Screenshot**
N/A

**Necessity**

- [x] N/A

**Confirmed**

- [x] N/A

**Required changes:**

- [x] N/A
