### PR TITLE
feat: throttle email change, email confirmation, and password reset endpoints.

### DIFF
--- a/framework/core/src/Post/PostCreationThrottler.php
+++ b/framework/core/src/Post/PostCreationThrottler.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Post;
+
+use Carbon\Carbon;
+use Flarum\Http\RequestUtil;
+use Psr\Http\Message\ServerRequestInterface;
+
+class PostCreationThrottler
+{
+    public static $timeout = 10;
+
+    /**
+     * @return bool|void
+     */
+    public function __invoke(ServerRequestInterface $request)
+    {
+        if (! in_array($request->getAttribute('routeName'), ['discussions.create', 'posts.create'])) {
+            return;
+        }
+
+        $actor = RequestUtil::getActor($request);
+
+        if ($actor->can('postWithoutThrottle')) {
+            return false;
+        }
+
+        if (Post::where('user_id', $actor->id)->where('created_at', '>=', Carbon::now()->subSeconds(self::$timeout))->exists()) {
+            return true;
+        }
+    }
+}

--- a/framework/core/src/User/Throttler/EmailActivationThrottler.php
+++ b/framework/core/src/User/Throttler/EmailActivationThrottler.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\Throttler;
+
+use Carbon\Carbon;
+use Flarum\Http\RequestUtil;
+use Flarum\User\EmailToken;
+use Psr\Http\Message\ServerRequestInterface;
+
+class EmailActivationThrottler
+{
+    public static $timeout = 300;
+
+    /**
+     * @return bool|void
+     */
+    public function __invoke(ServerRequestInterface $request)
+    {
+        if ($request->getAttribute('routeName') !== 'users.confirmation.send') {
+            return;
+        }
+
+        $actor = RequestUtil::getActor($request);
+
+        if (EmailToken::query()
+            ->where('user_id', $actor->id)
+            ->where('email', $actor->email)
+            ->where('created_at', '>=', Carbon::now()->subSeconds(self::$timeout))
+            ->exists()) {
+            return true;
+        }
+    }
+}

--- a/framework/core/src/User/Throttler/EmailActivationThrottler.php
+++ b/framework/core/src/User/Throttler/EmailActivationThrottler.php
@@ -14,6 +14,10 @@ use Flarum\Http\RequestUtil;
 use Flarum\User\EmailToken;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Unactivated users can request a confirmation email,
+ * this throttler applies a timeout of 5 minutes between confirmation requests.
+ */
 class EmailActivationThrottler
 {
     public static $timeout = 300;

--- a/framework/core/src/User/Throttler/EmailChangeThrottler.php
+++ b/framework/core/src/User/Throttler/EmailChangeThrottler.php
@@ -15,6 +15,10 @@ use Flarum\User\EmailToken;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Users can request an email change,
+ * this throttler applies a timeout of 5 minutes between requests.
+ */
 class EmailChangeThrottler
 {
     public static $timeout = 300;

--- a/framework/core/src/User/Throttler/EmailChangeThrottler.php
+++ b/framework/core/src/User/Throttler/EmailChangeThrottler.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\Throttler;
+
+use Carbon\Carbon;
+use Flarum\Http\RequestUtil;
+use Flarum\User\EmailToken;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ServerRequestInterface;
+
+class EmailChangeThrottler
+{
+    public static $timeout = 300;
+
+    /**
+     * @return bool|void
+     */
+    public function __invoke(ServerRequestInterface $request)
+    {
+        if ($request->getAttribute('routeName') !== 'users.update') {
+            return;
+        }
+
+        if (! Arr::has($request->getParsedBody(), 'data.attributes.email')) {
+            return;
+        }
+
+        $actor = RequestUtil::getActor($request);
+
+        // Check that an email token was not already created recently (last 5 minutes).
+        if (EmailToken::query()->where('user_id', $actor->id)->where('created_at', '>=', Carbon::now()->subSeconds(self::$timeout))->exists()) {
+            return true;
+        }
+    }
+}

--- a/framework/core/src/User/Throttler/PasswordResetThrottler.php
+++ b/framework/core/src/User/Throttler/PasswordResetThrottler.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Flarum\User\Throttler;
+
+use Carbon\Carbon;
+use Flarum\Http\RequestUtil;
+use Flarum\User\PasswordToken;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ServerRequestInterface;
+
+class PasswordResetThrottler
+{
+    public static $timeout = 300;
+
+    /**
+     * @return bool|void
+     */
+    public function __invoke(ServerRequestInterface $request)
+    {
+        if ($request->getAttribute('routeName') !== 'forgot') {
+            return;
+        }
+
+        if (! Arr::has($request->getParsedBody(), 'email')) {
+            return;
+        }
+
+        $actor = RequestUtil::getActor($request);
+
+        if (PasswordToken::query()->where('user_id', $actor->id)->where('created_at', '>=', Carbon::now()->subSeconds(self::$timeout))->exists()) {
+            return true;
+        }
+    }
+}

--- a/framework/core/src/User/Throttler/PasswordResetThrottler.php
+++ b/framework/core/src/User/Throttler/PasswordResetThrottler.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\User\Throttler;
 
 use Carbon\Carbon;
@@ -8,6 +15,11 @@ use Flarum\User\PasswordToken;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Logged-in users can request password reset email,
+ * this throttler applies a timeout of 5 minutes between password resets.
+ * This does not apply to guests requesting password resets.
+ */
 class PasswordResetThrottler
 {
     public static $timeout = 300;

--- a/framework/core/src/User/UserServiceProvider.php
+++ b/framework/core/src/User/UserServiceProvider.php
@@ -24,6 +24,7 @@ use Flarum\User\DisplayName\UsernameDriver;
 use Flarum\User\Event\EmailChangeRequested;
 use Flarum\User\Event\Registered;
 use Flarum\User\Event\Saving;
+use Flarum\User\Throttler\EmailActivationThrottler;
 use Flarum\User\Throttler\EmailChangeThrottler;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -55,6 +56,7 @@ class UserServiceProvider extends AbstractServiceProvider
 
         $this->container->extend('flarum.api.throttlers', function (array $throttlers, Container $container) {
             $throttlers['emailChangeTimeout'] = $container->make(EmailChangeThrottler::class);
+            $throttlers['emailActivationTimeout'] = $container->make(EmailActivationThrottler::class);
 
             return $throttlers;
         });

--- a/framework/core/src/User/UserServiceProvider.php
+++ b/framework/core/src/User/UserServiceProvider.php
@@ -24,6 +24,7 @@ use Flarum\User\DisplayName\UsernameDriver;
 use Flarum\User\Event\EmailChangeRequested;
 use Flarum\User\Event\Registered;
 use Flarum\User\Event\Saving;
+use Flarum\User\Throttler\EmailChangeThrottler;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
@@ -50,6 +51,12 @@ class UserServiceProvider extends AbstractServiceProvider
                 Post::class => [PostPolicy::class],
                 User::class => [Access\UserPolicy::class],
             ];
+        });
+
+        $this->container->extend('flarum.api.throttlers', function (array $throttlers, Container $container) {
+            $throttlers['emailChangeTimeout'] = $container->make(EmailChangeThrottler::class);
+
+            return $throttlers;
         });
     }
 

--- a/framework/core/src/User/UserServiceProvider.php
+++ b/framework/core/src/User/UserServiceProvider.php
@@ -26,6 +26,7 @@ use Flarum\User\Event\Registered;
 use Flarum\User\Event\Saving;
 use Flarum\User\Throttler\EmailActivationThrottler;
 use Flarum\User\Throttler\EmailChangeThrottler;
+use Flarum\User\Throttler\PasswordResetThrottler;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
@@ -57,6 +58,7 @@ class UserServiceProvider extends AbstractServiceProvider
         $this->container->extend('flarum.api.throttlers', function (array $throttlers, Container $container) {
             $throttlers['emailChangeTimeout'] = $container->make(EmailChangeThrottler::class);
             $throttlers['emailActivationTimeout'] = $container->make(EmailActivationThrottler::class);
+            $throttlers['passwordResetTimeout'] = $container->make(PasswordResetThrottler::class);
 
             return $throttlers;
         });

--- a/framework/core/tests/integration/api/users/SendActivationEmailTest.php
+++ b/framework/core/tests/integration/api/users/SendActivationEmailTest.php
@@ -36,7 +36,7 @@ class SendActivationEmailTest extends TestCase
     /** @test */
     public function users_can_send_confirmation_emails_in_moderate_intervals()
     {
-        for ($i=0; $i<2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $response = $this->send(
                 $this->request('POST', '/api/users/3/send-confirmation', [
                     'authenticatedAs' => 3,
@@ -45,7 +45,7 @@ class SendActivationEmailTest extends TestCase
 
             // We don't want to delay tests too long.
             EmailActivationThrottler::$timeout = 5;
-            sleep(EmailActivationThrottler::$timeout+1);
+            sleep(EmailActivationThrottler::$timeout + 1);
         }
 
         $this->assertEquals(204, $response->getStatusCode());
@@ -54,7 +54,7 @@ class SendActivationEmailTest extends TestCase
     /** @test */
     public function users_cant_send_confirmation_emails_too_fast()
     {
-        for ($i=0; $i<2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $response = $this->send(
                 $this->request('POST', '/api/users/3/send-confirmation', [
                     'authenticatedAs' => 3,

--- a/framework/core/tests/integration/api/users/SendActivationEmailTest.php
+++ b/framework/core/tests/integration/api/users/SendActivationEmailTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\Throttler\EmailActivationThrottler;
+
+class SendActivationEmailTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                [
+                    'id' => 3,
+                    'username' => 'normal2',
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', // BCrypt hash for "too-obscure"
+                    'email' => 'normal2@machine.local',
+                    'is_email_confirmed' => 0,
+                    'last_seen_at' => Carbon::now()->subSecond(),
+                ],
+            ]
+        ]);
+    }
+
+    /** @test */
+    public function users_can_send_confirmation_emails_in_moderate_intervals()
+    {
+        for ($i=0; $i<2; $i++) {
+            $response = $this->send(
+                $this->request('POST', '/api/users/3/send-confirmation', [
+                    'authenticatedAs' => 3,
+                ])
+            );
+
+            // We don't want to delay tests too long.
+            EmailActivationThrottler::$timeout = 5;
+            sleep(EmailActivationThrottler::$timeout+1);
+        }
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function users_cant_send_confirmation_emails_too_fast()
+    {
+        for ($i=0; $i<2; $i++) {
+            $response = $this->send(
+                $this->request('POST', '/api/users/3/send-confirmation', [
+                    'authenticatedAs' => 3,
+                ])
+            );
+        }
+
+        $this->assertEquals(429, $response->getStatusCode());
+    }
+}

--- a/framework/core/tests/integration/api/users/SendPasswordResetEmailTest.php
+++ b/framework/core/tests/integration/api/users/SendPasswordResetEmailTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\Throttler\EmailActivationThrottler;
+use Flarum\User\Throttler\PasswordResetThrottler;
+
+class SendPasswordResetEmailTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                [
+                    'id' => 3,
+                    'username' => 'normal2',
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', // BCrypt hash for "too-obscure"
+                    'email' => 'normal2@machine.local',
+                    'is_email_confirmed' => 0,
+                    'last_seen_at' => Carbon::now()->subSecond(),
+                ],
+            ]
+        ]);
+    }
+
+    /** @test */
+    public function users_can_send_password_reset_emails_in_moderate_intervals()
+    {
+        for ($i=0; $i<2; $i++) {
+            $response = $this->send(
+                $this->request('POST', '/api/forgot', [
+                    'authenticatedAs' => 3,
+                    'json' => [
+                        'email' => 'normal2@machine.local'
+                    ]
+                ])
+            );
+
+            // We don't want to delay tests too long.
+            PasswordResetThrottler::$timeout = 5;
+            sleep(PasswordResetThrottler::$timeout+1);
+        }
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function users_cant_send_confirmation_emails_too_fast()
+    {
+        for ($i=0; $i<2; $i++) {
+            $response = $this->send(
+                $this->request('POST', '/api/forgot', [
+                    'authenticatedAs' => 3,
+                    'json' => [
+                        'email' => 'normal2@machine.local'
+                    ]
+                ])
+            );
+        }
+
+        $this->assertEquals(429, $response->getStatusCode());
+    }
+}

--- a/framework/core/tests/integration/api/users/SendPasswordResetEmailTest.php
+++ b/framework/core/tests/integration/api/users/SendPasswordResetEmailTest.php
@@ -11,7 +11,6 @@ namespace Flarum\Tests\integration\api\users;
 
 use Carbon\Carbon;
 use Flarum\Testing\integration\TestCase;
-use Flarum\User\Throttler\EmailActivationThrottler;
 use Flarum\User\Throttler\PasswordResetThrottler;
 
 class SendPasswordResetEmailTest extends TestCase
@@ -37,7 +36,7 @@ class SendPasswordResetEmailTest extends TestCase
     /** @test */
     public function users_can_send_password_reset_emails_in_moderate_intervals()
     {
-        for ($i=0; $i<2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $response = $this->send(
                 $this->request('POST', '/api/forgot', [
                     'authenticatedAs' => 3,
@@ -49,7 +48,7 @@ class SendPasswordResetEmailTest extends TestCase
 
             // We don't want to delay tests too long.
             PasswordResetThrottler::$timeout = 5;
-            sleep(PasswordResetThrottler::$timeout+1);
+            sleep(PasswordResetThrottler::$timeout + 1);
         }
 
         $this->assertEquals(204, $response->getStatusCode());
@@ -58,7 +57,7 @@ class SendPasswordResetEmailTest extends TestCase
     /** @test */
     public function users_cant_send_confirmation_emails_too_fast()
     {
-        for ($i=0; $i<2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $response = $this->send(
                 $this->request('POST', '/api/forgot', [
                     'authenticatedAs' => 3,

--- a/framework/core/tests/integration/api/users/UpdateTest.php
+++ b/framework/core/tests/integration/api/users/UpdateTest.php
@@ -180,7 +180,7 @@ class UpdateTest extends TestCase
             );
 
             // We don't want to delay tests too long.
-            EmailChangeThrottler::$timeout = 15;
+            EmailChangeThrottler::$timeout = 5;
             sleep(EmailChangeThrottler::$timeout+1);
         }
 

--- a/framework/core/tests/integration/api/users/UpdateTest.php
+++ b/framework/core/tests/integration/api/users/UpdateTest.php
@@ -162,7 +162,7 @@ class UpdateTest extends TestCase
      */
     public function users_can_request_email_change_in_moderate_intervals()
     {
-        for ($i=0; $i<2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $response = $this->send(
                 $this->request('PATCH', '/api/users/3', [
                     'authenticatedAs' => 3,
@@ -181,7 +181,7 @@ class UpdateTest extends TestCase
 
             // We don't want to delay tests too long.
             EmailChangeThrottler::$timeout = 5;
-            sleep(EmailChangeThrottler::$timeout+1);
+            sleep(EmailChangeThrottler::$timeout + 1);
         }
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -192,7 +192,7 @@ class UpdateTest extends TestCase
      */
     public function users_cant_request_email_change_too_fast()
     {
-        for ($i=0; $i<2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $response = $this->send(
                 $this->request('PATCH', '/api/users/3', [
                     'authenticatedAs' => 3,

--- a/framework/core/tests/integration/api/users/UpdateTest.php
+++ b/framework/core/tests/integration/api/users/UpdateTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\users;
 use Carbon\Carbon;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\Throttler\EmailChangeThrottler;
 use Flarum\User\User;
 
 class UpdateTest extends TestCase
@@ -154,6 +155,62 @@ class UpdateTest extends TestCase
             ])
         );
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function users_can_request_email_change_in_moderate_intervals()
+    {
+        for ($i=0; $i<2; $i++) {
+            $response = $this->send(
+                $this->request('PATCH', '/api/users/3', [
+                    'authenticatedAs' => 3,
+                    'json' => [
+                        'data' => [
+                            'attributes' => [
+                                'email' => 'someOtherEmail@example.com',
+                            ]
+                        ],
+                        'meta' => [
+                            'password' => 'too-obscure'
+                        ]
+                    ],
+                ])
+            );
+
+            // We don't want to delay tests too long.
+            EmailChangeThrottler::$timeout = 15;
+            sleep(EmailChangeThrottler::$timeout+1);
+        }
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function users_cant_request_email_change_too_fast()
+    {
+        for ($i=0; $i<2; $i++) {
+            $response = $this->send(
+                $this->request('PATCH', '/api/users/3', [
+                    'authenticatedAs' => 3,
+                    'json' => [
+                        'data' => [
+                            'attributes' => [
+                                'email' => 'someOtherEmail@example.com',
+                            ]
+                        ],
+                        'meta' => [
+                            'password' => 'too-obscure'
+                        ]
+                    ],
+                ])
+            );
+        }
+
+        $this->assertEquals(429, $response->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
**Closes #3557**
**Closes #3558**
**Closes #3556**

**Changes proposed in this pull request:**
Adds throttling to the endpoints marked in the security roadmap, which are:
* Email change requests.
* Email confirmations.
* Password resets (for logged-in users only).

**Reviewers should focus on:**
For password resets we can only apply this throttling to logged-in users or to the same email requests. If a guest spams the endpoint with different emails there is no way to tie him to the requests.
* I think we need to introduce (outside of this) a rate limiting implementation (like Laravel's) to rate limit any endpoint based on route name and IP and track that info using the Cache store.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
