### PR TITLE
feat: publish assets on admin dashboard cache clear

### DIFF
--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -60,7 +60,7 @@ export default class StatusWidget extends DashboardWidget {
       .catch((e) => {
         if (e.status === 409) {
           app.alerts.clear();
-          app.alerts.show({ type: 'error' }, app.translator.trans('core.admin.dashboard.io_error_message'))
+          app.alerts.show({ type: 'error' }, app.translator.trans('core.admin.dashboard.io_error_message'));
         }
 
         app.modal.close();

--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -56,6 +56,14 @@ export default class StatusWidget extends DashboardWidget {
         method: 'DELETE',
         url: app.forum.attribute('apiUrl') + '/cache',
       })
-      .then(() => window.location.reload());
+      .then(() => window.location.reload())
+      .catch((e) => {
+        if (e.status === 409) {
+          app.alerts.clear();
+          app.alerts.show({ type: 'error' }, app.translator.trans('core.admin.dashboard.io_error_message'))
+        }
+
+        app.modal.close();
+      });
   }
 }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -53,6 +53,7 @@ core:
     dashboard:
       clear_cache_button: Clear Cache
       description: Your forum at a glance.
+      io_error_message: "Could not write to filesystem. Check your filesystem permissions an try again. Or try running from the command line."
       title: Dashboard
       tools_button: Tools
 

--- a/framework/core/src/Api/Controller/ClearCacheController.php
+++ b/framework/core/src/Api/Controller/ClearCacheController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Foundation\Console\AssetsPublishCommand;
 use Flarum\Foundation\Console\CacheClearCommand;
+use Flarum\Foundation\IOException;
 use Flarum\Http\RequestUtil;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ServerRequestInterface;
@@ -40,6 +41,7 @@ class ClearCacheController extends AbstractDeleteController
 
     /**
      * {@inheritdoc}
+     * @throws IOException|\Flarum\User\Exception\PermissionDeniedException
      */
     protected function delete(ServerRequestInterface $request)
     {
@@ -51,7 +53,7 @@ class ClearCacheController extends AbstractDeleteController
         );
 
         if ($exitCode !== 0) {
-            throw new \Exception('Clearing cache failed. Try running `php flarum cache:clear` from the command line to see more info.');
+            throw new IOException();
         }
 
         $exitCode = $this->assetsPublishCommand->run(
@@ -60,7 +62,7 @@ class ClearCacheController extends AbstractDeleteController
         );
 
         if ($exitCode !== 0) {
-            throw new \Exception('Asset publishing failed. Try running `php flarum assets:publish` from the command line to see more info.');
+            throw new IOException();
         }
 
         return new EmptyResponse(204);

--- a/framework/core/src/Api/Controller/ClearCacheController.php
+++ b/framework/core/src/Api/Controller/ClearCacheController.php
@@ -38,11 +38,15 @@ class ClearCacheController extends AbstractDeleteController
     {
         RequestUtil::getActor($request)->assertAdmin();
 
-        $this->command->run(
+        $exitCode = $this->command->run(
             new ArrayInput([]),
             new NullOutput()
         );
 
-        return new EmptyResponse(204);
+        if ($exitCode === 0) {
+            return new EmptyResponse(204);
+        }
+
+        throw new \Exception('Clear cache command failed.');
     }
 }

--- a/framework/core/src/Api/Controller/ClearCacheController.php
+++ b/framework/core/src/Api/Controller/ClearCacheController.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Api\Controller;
 
+use Flarum\Foundation\Console\AssetsPublishCommand;
 use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\Http\RequestUtil;
 use Laminas\Diactoros\Response\EmptyResponse;
@@ -24,11 +25,17 @@ class ClearCacheController extends AbstractDeleteController
     protected $command;
 
     /**
+     * @var AssetsPublishCommand
+     */
+    protected $assetsPublishCommand;
+
+    /**
      * @param CacheClearCommand $command
      */
-    public function __construct(CacheClearCommand $command)
+    public function __construct(CacheClearCommand $command, AssetsPublishCommand $assetsPublishCommand)
     {
         $this->command = $command;
+        $this->assetsPublishCommand = $assetsPublishCommand;
     }
 
     /**
@@ -43,10 +50,19 @@ class ClearCacheController extends AbstractDeleteController
             new NullOutput()
         );
 
-        if ($exitCode === 0) {
-            return new EmptyResponse(204);
+        if ($exitCode !== 0) {
+            throw new \Exception('Clearing cache failed. Try running `php flarum cache:clear` from the command line to see more info.');
         }
 
-        throw new \Exception('Clear cache command failed.');
+        $exitCode = $this->assetsPublishCommand->run(
+            new ArrayInput([]),
+            new NullOutput()
+        );
+
+        if ($exitCode !== 0) {
+            throw new \Exception('Asset publishing failed. Try running `php flarum assets:publish` from the command line to see more info.');
+        }
+
+        return new EmptyResponse(204);
     }
 }

--- a/framework/core/src/Foundation/ErrorServiceProvider.php
+++ b/framework/core/src/Foundation/ErrorServiceProvider.php
@@ -39,6 +39,9 @@ class ErrorServiceProvider extends AbstractServiceProvider
                 // 405 Method Not Allowed
                 'method_not_allowed' => 405,
 
+                // 409 Conflict
+                'io_error' => 409,
+
                 // 429 Too Many Requests
                 'too_many_requests' => 429,
             ];

--- a/framework/core/src/Foundation/IOException.php
+++ b/framework/core/src/Foundation/IOException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+use Exception;
+
+class IOException extends Exception implements KnownError
+{
+    public function getType(): string
+    {
+        return 'io_error';
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- passes error to frontend when cache clear command returns non-zero exit code
- publish core and extension assets when clearing from the admin dashboard

The reason for this is two-fold:
- clear cache on admin page is often a "go-to" solution for Flarum weirdness, and we should include publishing ext assets in this as it grows more popular with recent FoF Webpack chunking, etc
- publishing assets is important, but otherwise not possible on non-ssh capable shared hosting environments

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Not familiar with this area of core. Did I do it properly? 🙈 

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
