### PR TITLE
feat: Restart the queue worker after cache clearing, ext enable/disable, save settings

### DIFF
--- a/framework/core/src/Queue/QueueRestarter.php
+++ b/framework/core/src/Queue/QueueRestarter.php
@@ -1,8 +1,14 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Queue;
 
-use Carbon\Carbon;
 use Flarum\Extension\Event\Disabled;
 use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\Event\ClearingCache;

--- a/framework/core/src/Queue/QueueRestarter.php
+++ b/framework/core/src/Queue/QueueRestarter.php
@@ -25,7 +25,7 @@ class QueueRestarter
      * @var Container
      */
     protected $container;
-    
+
     /**
      * @var RestartCommand
      */

--- a/framework/core/src/Queue/QueueRestarter.php
+++ b/framework/core/src/Queue/QueueRestarter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Flarum\Queue;
+
+use Carbon\Carbon;
+use Flarum\Extension\Event\Disabled;
+use Flarum\Extension\Event\Enabled;
+use Flarum\Foundation\Event\ClearingCache;
+use Flarum\Settings\Event\Saved;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Console\RestartCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class QueueRestarter
+{
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen([
+            ClearingCache::class, Saved::class,
+            Enabled::class, Disabled::class
+        ], [$this, 'restart']);
+    }
+
+    public function restart()
+    {
+        /** @var Container $container */
+        $container = resolve(Container::class);
+        /** @var RestartCommand $command */
+        $command = resolve(RestartCommand::class);
+
+        $command->setLaravel($container);
+
+        $command->run(
+            new ArrayInput([]),
+            new NullOutput
+        );
+    }
+}

--- a/framework/core/src/Queue/QueueRestarter.php
+++ b/framework/core/src/Queue/QueueRestarter.php
@@ -21,6 +21,22 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class QueueRestarter
 {
+    /**
+     * @var Container
+     */
+    protected $container;
+    
+    /**
+     * @var RestartCommand
+     */
+    protected $command;
+
+    public function __construct(Container $container, RestartCommand $command)
+    {
+        $this->container = $container;
+        $this->command = $command;
+    }
+
     public function subscribe(Dispatcher $events)
     {
         $events->listen([
@@ -31,14 +47,9 @@ class QueueRestarter
 
     public function restart()
     {
-        /** @var Container $container */
-        $container = resolve(Container::class);
-        /** @var RestartCommand $command */
-        $command = resolve(RestartCommand::class);
+        $this->command->setLaravel($this->container);
 
-        $command->setLaravel($container);
-
-        $command->run(
+        $this->command->run(
             new ArrayInput([]),
             new NullOutput
         );

--- a/framework/core/src/Queue/QueueServiceProvider.php
+++ b/framework/core/src/Queue/QueueServiceProvider.php
@@ -161,5 +161,7 @@ class QueueServiceProvider extends AbstractServiceProvider
                 }
             }
         });
+
+        $events->subscribe(QueueRestarter::class);
     }
 }


### PR DESCRIPTION

**Fixes #3563 **

**Changes proposed in this pull request:**
Adds a subscriber to trigger the queue to restart after certain events

**Reviewers should focus on:**
Tested locally with a standard redis based queue. Doesn't work with `blomstra/horizon`, although I think there's a seperate issue with that extension, which I'll start to investigate now

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

