### PR TITLE
feat: expose assets base url to frontend forum model

### DIFF
--- a/framework/core/src/Api/Serializer/ForumSerializer.php
+++ b/framework/core/src/Api/Serializer/ForumSerializer.php
@@ -92,7 +92,7 @@ class ForumSerializer extends AbstractSerializer
             'canViewForum' => $this->actor->can('viewForum'),
             'canStartDiscussion' => $this->actor->can('startDiscussion'),
             'canSearchUsers' => $this->actor->can('searchUsers'),
-            'assetsBaseUrl' => $this->assetsFilesystem->url(''),
+            'assetsBaseUrl' => rtrim($this->assetsFilesystem->url(''), '/'),
         ];
 
         if ($this->actor->can('administrate')) {

--- a/framework/core/src/Api/Serializer/ForumSerializer.php
+++ b/framework/core/src/Api/Serializer/ForumSerializer.php
@@ -91,7 +91,8 @@ class ForumSerializer extends AbstractSerializer
             'defaultRoute'  => $this->settings->get('default_route'),
             'canViewForum' => $this->actor->can('viewForum'),
             'canStartDiscussion' => $this->actor->can('startDiscussion'),
-            'canSearchUsers' => $this->actor->can('searchUsers')
+            'canSearchUsers' => $this->actor->can('searchUsers'),
+            'assetsBaseUrl' => $this->assetsFilesystem->url(''),
         ];
 
         if ($this->actor->can('administrate')) {


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Currently extensions have to guess the assets base URL or serialize it to the frontend themselves, resulting in either a lot of extra needless data, or extensions assuming assets will always be at `<baseUrl>/assets`.

This can cause issues if, for example, the assets are on a cloud provider like S3.

E.g., https://github.com/FriendsOfFlarum/profile-image-crop/blob/02e2e524d3355495c4ed0915f342a7e7bf8e2565/js/src/forum/components/ProfileImageCropModal.js#L55

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
