### PR TITLE
feat: clear password & email tokens when appropriate

### DIFF
--- a/framework/core/src/Forum/Controller/SavePasswordController.php
+++ b/framework/core/src/Forum/Controller/SavePasswordController.php
@@ -89,6 +89,7 @@ class SavePasswordController implements RequestHandlerInterface
         } catch (ValidationException $e) {
             $request->getAttribute('session')->put('errors', new MessageBag($e->errors()));
 
+            // @todo: must return a 422 instead, look into renderable exceptions.
             return new RedirectResponse($this->url->to('forum')->route('resetPassword', ['token' => $token->token]));
         }
 

--- a/framework/core/src/Forum/Controller/SavePasswordController.php
+++ b/framework/core/src/Forum/Controller/SavePasswordController.php
@@ -98,8 +98,6 @@ class SavePasswordController implements RequestHandlerInterface
 
         $this->dispatchEventsFor($token->user);
 
-        $token->delete();
-
         $session = $request->getAttribute('session');
         $accessToken = SessionAccessToken::generate($token->user->id);
         $this->authenticator->logIn($session, $accessToken);

--- a/framework/core/src/User/TokensClearer.php
+++ b/framework/core/src/User/TokensClearer.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User;
+
+use Flarum\User\Event\PasswordChanged;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class TokensClearer
+{
+    public function subscribe(Dispatcher $events): array
+    {
+        return [
+            PasswordChanged::class => 'clearPasswordTokens',
+        ];
+    }
+
+    /**
+     * @param PasswordChanged $event
+     */
+    public function clearPasswordTokens($event): void
+    {
+        PasswordToken::query()->where('user_id', $event->user->id)->delete();
+    }
+}

--- a/framework/core/src/User/TokensClearer.php
+++ b/framework/core/src/User/TokensClearer.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\User;
 
+use Flarum\User\Event\EmailChanged;
 use Flarum\User\Event\PasswordChanged;
 use Illuminate\Contracts\Events\Dispatcher;
 
@@ -18,6 +19,7 @@ class TokensClearer
     {
         $events->listen(PasswordChanged::class, [$this, 'clearPasswordTokens']);
         $events->listen(PasswordChanged::class, [$this, 'clearEmailTokens']);
+        $events->listen(EmailChanged::class, [$this, 'clearPasswordTokens']);
     }
 
     /**

--- a/framework/core/src/User/TokensClearer.php
+++ b/framework/core/src/User/TokensClearer.php
@@ -17,9 +17,8 @@ class TokensClearer
 {
     public function subscribe(Dispatcher $events): void
     {
-        $events->listen(PasswordChanged::class, [$this, 'clearPasswordTokens']);
+        $events->listen([PasswordChanged::class, EmailChanged::class], [$this, 'clearPasswordTokens']);
         $events->listen(PasswordChanged::class, [$this, 'clearEmailTokens']);
-        $events->listen(EmailChanged::class, [$this, 'clearPasswordTokens']);
     }
 
     /**

--- a/framework/core/src/User/TokensClearer.php
+++ b/framework/core/src/User/TokensClearer.php
@@ -14,11 +14,10 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class TokensClearer
 {
-    public function subscribe(Dispatcher $events): array
+    public function subscribe(Dispatcher $events): void
     {
-        return [
-            PasswordChanged::class => 'clearPasswordTokens',
-        ];
+        $events->listen(PasswordChanged::class, [$this, 'clearPasswordTokens']);
+        $events->listen(PasswordChanged::class, [$this, 'clearEmailTokens']);
     }
 
     /**
@@ -27,5 +26,13 @@ class TokensClearer
     public function clearPasswordTokens($event): void
     {
         PasswordToken::query()->where('user_id', $event->user->id)->delete();
+    }
+
+    /**
+     * @param PasswordChanged $event
+     */
+    public function clearEmailTokens($event): void
+    {
+        EmailToken::query()->where('user_id', $event->user->id)->delete();
     }
 }

--- a/framework/core/src/User/TokensClearer.php
+++ b/framework/core/src/User/TokensClearer.php
@@ -23,11 +23,11 @@ class TokensClearer
     }
 
     /**
-     * @param PasswordChanged $event
+     * @param PasswordChanged|EmailChanged $event
      */
     public function clearPasswordTokens($event): void
     {
-        PasswordToken::query()->where('user_id', $event->user->id)->delete();
+        $event->user->passwordTokens()->delete();
     }
 
     /**
@@ -35,6 +35,6 @@ class TokensClearer
      */
     public function clearEmailTokens($event): void
     {
-        EmailToken::query()->where('user_id', $event->user->id)->delete();
+        $event->user->emailTokens()->delete();
     }
 }

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -719,6 +719,16 @@ class User extends AbstractModel
     }
 
     /**
+     * Define the relationship with the user's email tokens.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function passwordTokens()
+    {
+        return $this->hasMany(PasswordToken::class);
+    }
+
+    /**
      * Define the relationship with the permissions of all of the groups that
      * the user is in.
      *

--- a/framework/core/src/User/UserServiceProvider.php
+++ b/framework/core/src/User/UserServiceProvider.php
@@ -108,6 +108,7 @@ class UserServiceProvider extends AbstractServiceProvider
         $events->listen(EmailChangeRequested::class, EmailConfirmationMailer::class);
 
         $events->subscribe(UserMetadataUpdater::class);
+        $events->subscribe(TokensClearer::class);
 
         User::registerPreference('discloseOnline', 'boolval', true);
         User::registerPreference('indexProfile', 'boolval', true);

--- a/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
+++ b/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Flarum\Tests\integration\api\users;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\EmailToken;
+use Flarum\User\PasswordToken;
+
+class PasswordEmailTokensTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function actor_has_no_tokens_by_default()
+    {
+        $this->app();
+
+        $this->assertEquals(0, PasswordToken::query()->where('user_id', 2)->count());
+        $this->assertEquals(0, EmailToken::query()->where('user_id', 2)->count());
+    }
+
+    /** @test */
+    public function password_tokens_are_generated_when_requesting_password_reset()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/forgot', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'email' => 'normal@machine.local'
+                ]
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(1, PasswordToken::query()->where('user_id', 2)->count());
+    }
+
+    /** @test */
+    public function password_tokens_are_deleted_after_password_reset()
+    {
+        $this->app();
+
+        // Request password change to generate a token.
+        $response = $this->send(
+            $this->request('POST', '/api/forgot', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'email' => 'normal@machine.local'
+                ]
+            ])
+        );
+
+        // Additional Tokens
+        PasswordToken::generate(2)->save();
+        PasswordToken::generate(2)->save();
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(3, PasswordToken::query()->where('user_id', 2)->count());
+
+        // Use a token to reset password
+        $response = $this->send(
+            $request = $this->requestWithCsrfToken(
+                $this->request('POST', '/reset', [
+                    'authenticatedAs' => 2,
+                ])->withParsedBody([
+                    'passwordToken' => PasswordToken::query()->latest()->first()->token,
+                    'password' => 'new-password',
+                    'password_confirmation' => 'new-password',
+                ])
+            )
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(0, PasswordToken::query()->where('user_id', 2)->count());
+    }
+}

--- a/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
+++ b/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
@@ -169,4 +169,27 @@ class PasswordEmailTokensTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals(0, EmailToken::query()->where('user_id', 2)->count());
     }
+
+    /** @test */
+    public function password_tokens_are_deleted_when_confirming_email()
+    {
+        $this->app();
+
+        PasswordToken::generate(2)->save();
+        PasswordToken::generate(2)->save();
+
+        $token = EmailToken::generate('new-normal@machine.local', 2);
+        $token->save();
+
+        $response = $this->send(
+            $this->requestWithCsrfToken(
+                $this->request('POST', '/confirm/'.$token->token, [
+                    'authenticatedAs' => 2
+                ])
+            )
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(0, PasswordToken::query()->where('user_id', 2)->count());
+    }
 }

--- a/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
+++ b/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Tests\integration\api\users;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;

--- a/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
+++ b/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
@@ -130,4 +130,43 @@ class PasswordEmailTokensTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals(0, EmailToken::query()->where('user_id', 2)->count());
     }
+
+    /** @test */
+    public function email_tokens_are_deleted_after_password_reset()
+    {
+        $this->app();
+
+        // Request password change to generate a token.
+        $response = $this->send(
+            $this->request('POST', '/api/forgot', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'email' => 'normal@machine.local'
+                ]
+            ])
+        );
+
+        // Additional Tokens
+        EmailToken::generate('new-normal@machine.local', 2)->save();
+        EmailToken::generate('new-normal@machine.local', 2)->save();
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(2, EmailToken::query()->where('user_id', 2)->count());
+
+        // Use a token to reset password
+        $response = $this->send(
+            $request = $this->requestWithCsrfToken(
+                $this->request('POST', '/reset', [
+                    'authenticatedAs' => 2,
+                ])->withParsedBody([
+                    'passwordToken' => PasswordToken::query()->latest()->first()->token,
+                    'password' => 'new-password',
+                    'password_confirmation' => 'new-password',
+                ])
+            )
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(0, EmailToken::query()->where('user_id', 2)->count());
+    }
 }

--- a/php-packages/testing/src/integration/BuildsHttpRequests.php
+++ b/php-packages/testing/src/integration/BuildsHttpRequests.php
@@ -14,6 +14,7 @@ use Dflydev\FigCookies\SetCookie;
 use Illuminate\Support\Str;
 use Laminas\Diactoros\CallbackStream;
 use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 /**
@@ -65,5 +66,16 @@ trait BuildsHttpRequests
         );
 
         return $req->withCookieParams($cookies);
+    }
+
+    protected function requestWithCsrfToken(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $initial = $this->send(
+            $this->request('GET', '/')
+        );
+
+        $token = $initial->getHeaderLine('X-CSRF-Token');
+
+        return $this->requestWithCookiesFrom($request->withHeader('X-CSRF-Token', $token), $initial);
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Delete password tokens when the password is changed (40e60c61b844e6db79e5bdaad52f64831b87113a).
* Delete password tokens after email change (edf19f18ce24ee043044cde8e67a13324b37f255).
* Delete email tokens after password reset (8bcc6e6198ca5fe67fc92a9846de269b5b7d7cad).

**Reviewers should focus on:**
For users with permission to edit credentials who can change an email without confirmation, email tokens aren't deleted, I kept that behavior unchanged, not sure if we should delete the tokens in that case as well.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
