### PR TITLE
fix: prevent admin/mod deleting themselves

### DIFF
--- a/framework/core/src/User/Access/UserPolicy.php
+++ b/framework/core/src/User/Access/UserPolicy.php
@@ -39,4 +39,15 @@ class UserPolicy extends AbstractPolicy
             return $this->allow();
         }
     }
+
+    /**
+     * @param User $actor
+     * @param User $user
+     */
+    public function delete(User $actor, User $user)
+    {
+        if ($user->id === $actor->id) {
+            return $this->deny();
+        }
+    }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**

Currently, a user with permission to delete other users (admins, mods, etc) may also delete themselves. This happened to me today as a forum admin user 🙈 

This PR proposes to prevent a user with elevated delete user permissions from deleting themselves.

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

