### PR TITLE
fix: incorrect centring of deleted user avatars in notification list

### DIFF
--- a/framework/core/less/forum/NotificationList.less
+++ b/framework/core/less/forum/NotificationList.less
@@ -138,8 +138,13 @@
   .Avatar {
     .Avatar--size(24px);
     grid-area: avatar;
-    
-    // We need to do some manual hackery to fix vertical alignment for avatars.
+  }
+
+  // Since images and empty elements don't have baselines, aligning against the
+  // baseline won't work. Instead we need to do some manual hackery to fix then,
+  // otherwise they won't be correctly vertically aligned.
+  img.Avatar,
+  .Avatar:empty {
     align-self: flex-start;
     margin-top: -2px;
   }

--- a/framework/core/less/forum/NotificationList.less
+++ b/framework/core/less/forum/NotificationList.less
@@ -138,12 +138,8 @@
   .Avatar {
     .Avatar--size(24px);
     grid-area: avatar;
-  }
-
-  // Since images don't have baselines, aligning against the baseline won't work.
-  // Instead we need to do some manual hackery to fix then, otherwise they won't
-  // be correctly vertically aligned.
-  img.Avatar {
+    
+    // We need to do some manual hackery to fix vertical alignment for avatars.
     align-self: flex-start;
     margin-top: -2px;
   }


### PR DESCRIPTION

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- fix vertical alignment of user avatars in the notification list when a user has been deleted

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/181576864-4a62e9e4-3ec5-45b3-b7f0-d94c41e391be.png)

![image](https://user-images.githubusercontent.com/7406822/181576807-0704f9f3-55e6-40be-a531-0f3a63209ffa.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
