### PR TITLE
chore(tags): Replace event helper with event dispatcher

### DIFF
--- a/extensions/tags/src/Command/CreateTagHandler.php
+++ b/extensions/tags/src/Command/CreateTagHandler.php
@@ -12,6 +12,7 @@ namespace Flarum\Tags\Command;
 use Flarum\Tags\Event\Creating;
 use Flarum\Tags\Tag;
 use Flarum\Tags\TagValidator;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class CreateTagHandler
@@ -22,11 +23,18 @@ class CreateTagHandler
     protected $validator;
 
     /**
-     * @param TagValidator $validator
+     * @var Dispatcher
      */
-    public function __construct(TagValidator $validator)
+    protected $events;
+
+    /**
+     * @param TagValidator $validator
+     * @param Dispatcher $events
+     */
+    public function __construct(TagValidator $validator, Dispatcher $events)
     {
         $this->validator = $validator;
+        $this->events = $events;
     }
 
     /**
@@ -65,7 +73,7 @@ class CreateTagHandler
             }
         }
 
-        event(new Creating($tag, $actor, $data));
+        $this->events->dispatch(new Creating($tag, $actor, $data));
 
         $this->validator->assertValid($tag->getAttributes());
 

--- a/extensions/tags/src/Command/DeleteTagHandler.php
+++ b/extensions/tags/src/Command/DeleteTagHandler.php
@@ -11,6 +11,7 @@ namespace Flarum\Tags\Command;
 
 use Flarum\Tags\Event\Deleting;
 use Flarum\Tags\TagRepository;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class DeleteTagHandler
 {
@@ -20,11 +21,18 @@ class DeleteTagHandler
     protected $tags;
 
     /**
-     * @param TagRepository $tags
+     * @var Dispatcher
      */
-    public function __construct(TagRepository $tags)
+    protected $events;
+
+    /**
+     * @param TagRepository $tags
+     * @param Dispatcher $events
+     */
+    public function __construct(TagRepository $tags, Dispatcher $events)
     {
         $this->tags = $tags;
+        $this->events = $events;
     }
 
     /**
@@ -40,7 +48,7 @@ class DeleteTagHandler
 
         $actor->assertCan('delete', $tag);
 
-        event(new Deleting($tag, $actor));
+        $this->events->dispatch(new Deleting($tag, $actor));
 
         $tag->delete();
 

--- a/extensions/tags/src/Command/EditTagHandler.php
+++ b/extensions/tags/src/Command/EditTagHandler.php
@@ -12,6 +12,7 @@ namespace Flarum\Tags\Command;
 use Flarum\Tags\Event\Saving;
 use Flarum\Tags\TagRepository;
 use Flarum\Tags\TagValidator;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class EditTagHandler
@@ -27,13 +28,20 @@ class EditTagHandler
     protected $validator;
 
     /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
      * @param TagRepository $tags
      * @param TagValidator $validator
+     * @param Dispatcher $events
      */
-    public function __construct(TagRepository $tags, TagValidator $validator)
+    public function __construct(TagRepository $tags, TagValidator $validator, Dispatcher $events)
     {
         $this->tags = $tags;
         $this->validator = $validator;
+        $this->events = $events;
     }
 
     /**
@@ -80,7 +88,7 @@ class EditTagHandler
             $tag->is_restricted = (bool) $attributes['isRestricted'];
         }
 
-        event(new Saving($tag, $actor, $data));
+        $this->events->dispatch(new Saving($tag, $actor, $data));
 
         $this->validator->assertValid($tag->getDirty());
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Replaces the deprecated `event()` helper, in favour of using the events `Dispatcher`

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
