### PR TITLE
fix: normal logout affects all sessions

### DIFF
--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -102,11 +102,12 @@ class LogOutController implements RequestHandlerInterface
             return new HtmlResponse($view->render());
         }
 
+        $accessToken = $session->get('access_token');
         $response = new RedirectResponse($url);
 
         $this->authenticator->logOut($session);
 
-        $actor->accessTokens()->delete();
+        $actor->accessTokens()->where('token', $accessToken)->delete();
 
         $this->events->dispatch(new LoggedOut($actor));
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

Previously all user tokens were deleted, which logouts from all sessions. After this change logout only works for current session.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
