### PR TITLE
fix: sticky nav content displays below post stream

### DIFF
--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -28,6 +28,7 @@
     position: sticky;
     top: var(--header-height);
     padding-top: 32px;
+    z-index: 1;
 
     &, > ul {
       width: 150px;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- fixes nav bar content showing below post content

See: https://discuss.flarum.org/d/31319-dropdown-menu-is-hidden-behind-post-content/3

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/182138359-0c542b86-9111-45f6-bc82-d8e745f27810.png)

![image](https://user-images.githubusercontent.com/7406822/182138307-b5389daa-3278-4a0b-a32e-841fadf44fb0.png)



**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
