### PR TITLE
feat: add createTableIfNotExists migration helper

### DIFF
--- a/framework/core/src/Database/Migration.php
+++ b/framework/core/src/Database/Migration.php
@@ -39,6 +39,25 @@ abstract class Migration
     }
 
     /**
+     * Create a table if it doesn't already exist.
+     */
+    public static function createTableIfNotExists($name, callable $definition)
+    {
+        return [
+            'up' => function (Builder $schema) use ($name, $definition) {
+                if (! $schema->hasTable($name)) {
+                    $schema->create($name, function (Blueprint $table) use ($definition) {
+                        $definition($table);
+                    });
+                }
+            },
+            'down' => function (Builder $schema) use ($name) {
+                $schema->dropIfExists($name);
+            }
+        ];
+    }
+
+    /**
      * Rename a table.
      */
     public static function renameTable($from, $to)


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds an additional `Migration` helper - `createTableIfNotExists` - self explanitory, really.

**Reviewers should focus on:**
I considered modifying the existing `createTable` function, with an option 3rd param to specify if this should be conditional, but felt that a seperate, although very similar function, would be clearer in it's intended functionality. Hopefully others will agree?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
