### PR TITLE
chore(approval, likes): use subscribers

### DIFF
--- a/extensions/approval/extend.php
+++ b/extensions/approval/extend.php
@@ -10,12 +10,10 @@
 use Flarum\Api\Serializer\BasicDiscussionSerializer;
 use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Approval\Access;
-use Flarum\Approval\Event\PostWasApproved;
 use Flarum\Approval\Listener;
 use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Post\CommentPost;
-use Flarum\Post\Event\Saving;
 use Flarum\Post\Post;
 use Flarum\Tags\Tag;
 
@@ -50,9 +48,8 @@ return [
     new Extend\Locales(__DIR__.'/locale'),
 
     (new Extend\Event())
-        ->listen(Saving::class, [Listener\ApproveContent::class, 'approvePost'])
-        ->listen(Saving::class, [Listener\UnapproveNewContent::class, 'unapproveNewPosts'])
-        ->listen(PostWasApproved::class, [Listener\ApproveContent::class, 'approveDiscussion']),
+        ->subscribe(Listener\ApproveContent::class)
+        ->subscribe(Listener\UnapproveNewContent::class),
 
     (new Extend\Policy())
         ->modelPolicy(Tag::class, Access\TagPolicy::class),

--- a/extensions/approval/src/Listener/ApproveContent.php
+++ b/extensions/approval/src/Listener/ApproveContent.php
@@ -11,13 +11,23 @@ namespace Flarum\Approval\Listener;
 
 use Flarum\Approval\Event\PostWasApproved;
 use Flarum\Post\Event\Saving;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class ApproveContent
 {
     /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Saving::class, [$this, 'approvePost']);
+        $events->listen(PostWasApproved::class, [$this, 'approveDiscussion']);
+    }
+    
+    /**
      * @param Saving $event
      */
-    public static function approvePost(Saving $event)
+    public function approvePost(Saving $event)
     {
         $attributes = $event->data['attributes'];
         $post = $event->post;
@@ -40,7 +50,7 @@ class ApproveContent
     /**
      * @param PostWasApproved $event
      */
-    public static function approveDiscussion(PostWasApproved $event)
+    public function approveDiscussion(PostWasApproved $event)
     {
         $post = $event->post;
         $discussion = $post->discussion;

--- a/extensions/approval/src/Listener/ApproveContent.php
+++ b/extensions/approval/src/Listener/ApproveContent.php
@@ -23,7 +23,7 @@ class ApproveContent
         $events->listen(Saving::class, [$this, 'approvePost']);
         $events->listen(PostWasApproved::class, [$this, 'approveDiscussion']);
     }
-    
+
     /**
      * @param Saving $event
      */

--- a/extensions/approval/src/Listener/UnapproveNewContent.php
+++ b/extensions/approval/src/Listener/UnapproveNewContent.php
@@ -13,13 +13,22 @@ use Flarum\Discussion\Discussion;
 use Flarum\Flags\Flag;
 use Flarum\Post\CommentPost;
 use Flarum\Post\Event\Saving;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class UnapproveNewContent
 {
     /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Saving::class, [$this, 'unapproveNewPosts']);
+    }
+
+    /**
      * @param Saving $event
      */
-    public static function unapproveNewPosts(Saving $event)
+    public function unapproveNewPosts(Saving $event)
     {
         $post = $event->post;
 

--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -17,8 +17,6 @@ use Flarum\Likes\Event\PostWasLiked;
 use Flarum\Likes\Event\PostWasUnliked;
 use Flarum\Likes\Notification\PostLikedBlueprint;
 use Flarum\Likes\Query\LikedByFilter;
-use Flarum\Post\Event\Deleted;
-use Flarum\Post\Event\Saving;
 use Flarum\Post\Filter\PostFilterer;
 use Flarum\Post\Post;
 use Flarum\User\User;
@@ -60,8 +58,7 @@ return [
     (new Extend\Event())
         ->listen(PostWasLiked::class, Listener\SendNotificationWhenPostIsLiked::class)
         ->listen(PostWasUnliked::class, Listener\SendNotificationWhenPostIsUnliked::class)
-        ->listen(Deleted::class, [Listener\SaveLikesToDatabase::class, 'whenPostIsDeleted'])
-        ->listen(Saving::class, [Listener\SaveLikesToDatabase::class, 'whenPostIsSaving']),
+        ->subscribe(Listener\SaveLikesToDatabase::class),
 
     (new Extend\Filter(PostFilterer::class))
         ->addFilter(LikedByFilter::class),

--- a/extensions/likes/src/Listener/SaveLikesToDatabase.php
+++ b/extensions/likes/src/Listener/SaveLikesToDatabase.php
@@ -57,7 +57,7 @@ class SaveLikesToDatabase
     /**
      * @param Deleted $event
      */
-    public static function whenPostIsDeleted(Deleted $event)
+    public function whenPostIsDeleted(Deleted $event)
     {
         $event->post->likes()->detach();
     }

--- a/extensions/likes/src/Listener/SaveLikesToDatabase.php
+++ b/extensions/likes/src/Listener/SaveLikesToDatabase.php
@@ -13,13 +13,23 @@ use Flarum\Likes\Event\PostWasLiked;
 use Flarum\Likes\Event\PostWasUnliked;
 use Flarum\Post\Event\Deleted;
 use Flarum\Post\Event\Saving;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class SaveLikesToDatabase
 {
     /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Saving::class, [$this, 'whenPostIsSaving']);
+        $events->listen(Deleted::class, [$this, 'whenPostIsDeleted']);
+    }
+
+    /**
      * @param Saving $event
      */
-    public static function whenPostIsSaving(Saving $event)
+    public function whenPostIsSaving(Saving $event)
     {
         $post = $event->post;
         $data = $event->data;


### PR DESCRIPTION
**Changes proposed in this pull request:**
Swap out workaround used prior to `subscribe()` being made available on the settings extender.


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
