### PR TITLE
perf: Add `loading="lazy"` attribute for avatars

### DIFF
--- a/framework/core/js/src/common/helpers/avatar.tsx
+++ b/framework/core/js/src/common/helpers/avatar.tsx
@@ -12,7 +12,7 @@ export interface AvatarAttrs extends ComponentAttrs {}
  */
 export default function avatar(user: User | null, attrs: ComponentAttrs = {}): Mithril.Vnode {
   attrs.className = 'Avatar ' + (attrs.className || '');
-  attrs.loading = attrs.loading || 'lazy';
+  attrs.loading ??= 'lazy';
   let content: string = '';
 
   // If the `title` attribute is set to null or false, we don't want to give the

--- a/framework/core/js/src/common/helpers/avatar.tsx
+++ b/framework/core/js/src/common/helpers/avatar.tsx
@@ -12,6 +12,7 @@ export interface AvatarAttrs extends ComponentAttrs {}
  */
 export default function avatar(user: User | null, attrs: ComponentAttrs = {}): Mithril.Vnode {
   attrs.className = 'Avatar ' + (attrs.className || '');
+  attrs.loading = attrs.loading || 'lazy';
   let content: string = '';
 
   // If the `title` attribute is set to null or false, we don't want to give the

--- a/framework/core/js/src/forum/components/AvatarEditor.js
+++ b/framework/core/js/src/forum/components/AvatarEditor.js
@@ -41,7 +41,7 @@ export default class AvatarEditor extends Component {
 
     return (
       <div className={classList(['AvatarEditor', 'Dropdown', this.attrs.className, this.loading && 'loading', this.isDraggedOver && 'dragover'])}>
-        {avatar(user)}
+        {avatar(user, { loading: 'eager' })}
         <a
           className={user.avatarUrl() ? 'Dropdown-toggle' : 'Dropdown-toggle AvatarEditor--noAvatar'}
           title={app.translator.trans('core.forum.user.avatar_upload_tooltip')}

--- a/framework/core/js/src/forum/components/UserCard.js
+++ b/framework/core/js/src/forum/components/UserCard.js
@@ -54,7 +54,7 @@ export default class UserCard extends Component {
                   [AvatarEditor.component({ user, className: 'UserCard-avatar' }), username(user)]
                 ) : (
                   <Link href={app.route.user(user)}>
-                    <div className="UserCard-avatar">{avatar(user)}</div>
+                    <div className="UserCard-avatar">{avatar(user, { loading: 'eager' })}</div>
                     {username(user)}
                   </Link>
                 )}


### PR DESCRIPTION
**Changes proposed in this pull request:**

This enables lazy loading for avatars. It should slightly improve loading time and allows to avoid loading these images when they're hidden by custom styles.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
