### PR TITLE
chore: debug line slipped in while rebasing a PR

### DIFF
--- a/extensions/subscriptions/src/Listener/SendNotificationWhenReplyIsPosted.php
+++ b/extensions/subscriptions/src/Listener/SendNotificationWhenReplyIsPosted.php
@@ -27,12 +27,6 @@ class SendNotificationWhenReplyIsPosted
 
     public function handle(Posted $event)
     {
-        $discussion = $event->post->discussion;
-
-        /** @var \Psr\Log\LoggerInterface $log */
-        $log = resolve('log');
-        $log->info("running subscriptions send notification when reply is posted listener. last_post_number: $discussion->last_post_number");
-
         $this->queue->push(
             new SendReplyNotification($event->post, $event->post->discussion->last_post_number)
         );


### PR DESCRIPTION
**Changes proposed in this pull request:**
http://github.com/flarum/framework/pull/3418#pullrequestreview-1061446667

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.