### PR TITLE
feat(compilation): force asset compilation on flush instead of deletion

### DIFF
--- a/framework/core/src/Frontend/RecompileFrontendAssets.php
+++ b/framework/core/src/Frontend/RecompileFrontendAssets.php
@@ -53,19 +53,19 @@ class RecompileFrontendAssets
 
     protected function flushCss()
     {
-        $this->assets->makeCss()->flush();
+        $this->assets->makeCss()->commit();
 
         foreach ($this->locales->getLocales() as $locale => $name) {
-            $this->assets->makeLocaleCss($locale)->flush();
+            $this->assets->makeLocaleCss($locale)->commit();
         }
     }
 
     protected function flushJs()
     {
-        $this->assets->makeJs()->flush();
+        $this->assets->makeJs()->commit();
 
         foreach ($this->locales->getLocales() as $locale => $name) {
-            $this->assets->makeLocaleJs($locale)->flush();
+            $this->assets->makeLocaleJs($locale)->commit();
         }
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**

Instead of deleting compiler generated assets we will now rebuild them on cache clear.

The reason we're doing this is this scenario mainly:

- cronjob or queue worker is running
- admin clears cache and doesn't visit the site thereafter
- no assets are generated
- cronjob or queue worker is processing a task that needs one of the assets, eg sending notification email with lang keys or style

**Reviewers should focus on:**

- Are we sure we want to commit thereafter
- Are other changes required that I've overlooked


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
