### PR TITLE
feat: Add custom class for email confirmation alert

### DIFF
--- a/framework/core/js/src/forum/utils/alertEmailConfirmation.js
+++ b/framework/core/js/src/forum/utils/alertEmailConfirmation.js
@@ -59,9 +59,9 @@ export default function alertEmailConfirmation(app) {
     }
   }
 
-  m.mount($('<div class="Alert--emailConfirmation"/>').insertBefore('#content')[0], {
+  m.mount($('<div class="App-notices"/>').insertBefore('#content')[0], {
     view: () => (
-      <ContainedAlert dismissible={false} controls={[<ResendButton />]}>
+      <ContainedAlert dismissible={false} controls={[<ResendButton />]} className="Alert--emailConfirmation">
         {app.translator.trans('core.forum.user_email_confirmation.alert_message', { email: <strong>{user.email()}</strong> })}
       </ContainedAlert>
     ),

--- a/framework/core/js/src/forum/utils/alertEmailConfirmation.js
+++ b/framework/core/js/src/forum/utils/alertEmailConfirmation.js
@@ -59,7 +59,7 @@ export default function alertEmailConfirmation(app) {
     }
   }
 
-  m.mount($('<div/>').insertBefore('#content')[0], {
+  m.mount($('<div class="Alert--emailConfirmation"/>').insertBefore('#content')[0], {
     view: () => (
       <ContainedAlert dismissible={false} controls={[<ResendButton />]}>
         {app.translator.trans('core.forum.user_email_confirmation.alert_message', { email: <strong>{user.email()}</strong> })}


### PR DESCRIPTION
**Changes proposed in this pull request:**

Currently this alert uses generic classes and it is quite hard to distinguish this particular alert from any other alerts. Custom class should simplify for example adding custom styles for this alert.


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
