### PR TITLE
fix(compilation): versioner not inject into compilers

### DIFF
--- a/framework/core/src/Frontend/Assets.php
+++ b/framework/core/src/Frontend/Assets.php
@@ -156,12 +156,18 @@ class Assets
 
     protected function makeJsCompiler(string $filename)
     {
-        return new JsCompiler($this->assetsDir, $filename);
+        return resolve(JsCompiler::class, [
+            'assetsDir' => $this->assetsDir,
+            'filename' => $filename
+        ]);
     }
 
     protected function makeLessCompiler(string $filename): LessCompiler
     {
-        $compiler = new LessCompiler($this->assetsDir, $filename);
+        $compiler = resolve(LessCompiler::class, [
+            'assetsDir' => $this->assetsDir,
+            'filename' => $filename
+        ]);
 
         if ($this->cacheDir) {
             $compiler->setCacheDir($this->cacheDir.'/less');


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3583**

**Changes proposed in this pull request:**

While adding the revision versioner, I forgot to actually inject this versioner into the compilers. This PR solves that. 

PS this change does not impact fof/nightmode as it doesn't override the method.

**Reviewers should focus on:**

I noticed we have zero tests (right?) for the Assets and Compilers, I don't feel these should be introduced now. But would it make sense to add an issue for that to be completed inside a 1.x release?

**Screenshot**



**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
