### PR TITLE
fix: user has wrong discussion read status

### DIFF
--- a/framework/core/src/Discussion/DiscussionServiceProvider.php
+++ b/framework/core/src/Discussion/DiscussionServiceProvider.php
@@ -19,6 +19,7 @@ class DiscussionServiceProvider extends AbstractServiceProvider
     public function boot(Dispatcher $events)
     {
         $events->subscribe(DiscussionMetadataUpdater::class);
+        $events->subscribe(UserStateUpdater::class);
 
         $events->listen(
             Renamed::class,

--- a/framework/core/src/Discussion/UserState.php
+++ b/framework/core/src/Discussion/UserState.php
@@ -47,6 +47,13 @@ class UserState extends AbstractModel
     protected $dates = ['last_read_at'];
 
     /**
+     * The attributes that are mass assignable.
+     *
+     * @var string[]
+     */
+    protected $fillable = ['last_read_post_number'];
+
+    /**
      * Mark the discussion as being read up to a certain point. Raises the
      * DiscussionWasRead event.
      *

--- a/framework/core/src/Discussion/UserStateUpdater.php
+++ b/framework/core/src/Discussion/UserStateUpdater.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Discussion;
+
+use Flarum\Post\Event\Deleted;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class UserStateUpdater
+{
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Deleted::class, [$this, 'whenPostWasDeleted']);
+    }
+
+    /**
+     * Updates a user state relative to a discussion.
+     * If user A read a discussion all the way to post number N, and X last posts were deleted,
+     * then we need to update user A's read status to the new N-X post number so that they get notified by new posts.
+     */
+    public function whenPostWasDeleted(Deleted $event)
+    {
+        /*
+         * We check if it's greater because at this point the DiscussionMetadataUpdater should have updated the last post.
+         */
+        if ($event->post->number > $event->post->discussion->last_post_number) {
+            UserState::query()
+                ->where('discussion_id', $event->post->discussion_id)
+                ->where('last_read_post_number', '>', $event->post->discussion->last_post_number)
+                ->update(['last_read_post_number' => $event->post->discussion->last_post_number]);
+        }
+    }
+}

--- a/framework/core/tests/integration/api/posts/DeleteTest.php
+++ b/framework/core/tests/integration/api/posts/DeleteTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\posts;
+
+use Carbon\Carbon;
+use Flarum\Discussion\UserState;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'acme2', 'email' => 'acme2@machine.local', 'is_email_confirmed' => 1],
+            ],
+            'discussions' => [
+                ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 5, 'last_post_number' => 5, 'last_post_id' => 10],
+            ],
+            'posts' => [
+                ['id' => 5, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 1],
+                ['id' => 6, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 2],
+                ['id' => 7, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 3],
+                ['id' => 8, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 4],
+                ['id' => 9, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 5],
+                ['id' => 10, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 6],
+            ],
+            'discussion_user' => [
+                ['discussion_id' => 3, 'user_id' => 2, 'last_read_post_number' => 6],
+                ['discussion_id' => 3, 'user_id' => 4, 'last_read_post_number' => 3],
+            ]
+        ]);
+    }
+
+    /**
+     * @dataProvider deleteLastPostsProvider
+     * @test
+     */
+    public function deleting_last_posts_syncs_discussion_state_for_other_users(array $postIds, int $newLastReadNumber, int $userId)
+    {
+        // Delete the last post.
+        foreach ($postIds as $postId) {
+            $this->send(
+                $this->request('DELETE', '/api/posts/'.$postId, ['authenticatedAs' => 1])
+            );
+        }
+
+        // User 2 should now have last_read_post_number set to the new last one
+        $this->assertEquals(
+            $newLastReadNumber,
+            UserState::query()
+                ->where('discussion_id', 3)
+                ->where('user_id', $userId)
+                ->first()
+                ->last_read_post_number
+        );
+    }
+
+    public function deleteLastPostsProvider(): array
+    {
+        return [
+            // User 2
+            [[10], 5, 2],
+            [[9, 10], 4, 2],
+            [[10, 9, 8], 3, 2],
+            [[8, 9, 10], 3, 2],
+            [[7, 8, 9, 10], 2, 2],
+
+            // User 4
+            [[10], 3, 4],
+            [[9, 10], 3, 4],
+            [[10, 9, 8], 3, 4],
+            [[8, 9, 10], 3, 4],
+            [[10, 9, 8, 7], 2, 4],
+            [[7, 8, 9, 10], 2, 4],
+        ];
+    }
+}


### PR DESCRIPTION
**Fixes #3524**

**Changes proposed in this pull request:**
Updates the user state of a discussion when a last post is deleted. The idea is to decrement the `last_read_post_number` to the actual new lat post number, so that users can still be notified of replies and read status is correctly computed as both rely on the `last_read_post_number` field.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.