### PR TITLE
test: refactor prefix matrix and add `MySQL 8.0` & `PHP 7.3` to workflows

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -73,6 +73,13 @@ jobs:
             prefix: flarum_
             prefixStr: (prefix)
 
+        # To reduce number of actions, we exclude some PHP versions from running with some DB versions.
+        exclude:
+          - php: ${{ fromJSON(inputs.php_versions)[1] }}
+            service: 'mysql:8.0.30'
+          - php: ${{ fromJSON(inputs.php_versions)[2] }}
+            service: 'mysql:8.0.30'
+
     services:
       mysql:
         image: ${{ matrix.service }}

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -44,23 +44,27 @@ jobs:
       matrix:
         php: ${{ fromJSON(inputs.php_versions) }}
         service: ${{ fromJSON(inputs.db_versions) }}
-        prefix: ['', flarum_]
+        prefix: ['']
 
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
         include:
+          # Expands the matrix by naming DBs.
           - service: 'mysql:5.7'
-            db: MySQL
+            db: MySQL 5.7
           - service: mariadb
             db: MariaDB
-          - prefix: flarum_
-            prefixStr: (prefix)
 
-        exclude:
-          - php: 8.0
+          # Include Database prefix tests with only one PHP version.
+          - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: 'mysql:5.7'
+            db: MySQL 5.7
             prefix: flarum_
-          - php: 8.0
+            prefixStr: (prefix)
+          - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: mariadb
+            db: MariaDB
             prefix: flarum_
+            prefixStr: (prefix)
 
     services:
       mysql:

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -24,7 +24,7 @@ on:
         description: Versions of databases to test with. Should be array of strings encoded as JSON array
         type: string
         required: false
-        default: '["mysql:5.7", "mariadb"]'
+        default: '["mysql:5.7", "mysql:8.0.30", "mariadb"]'
 
       php_ini_values:
         description: PHP ini values
@@ -51,6 +51,8 @@ jobs:
           # Expands the matrix by naming DBs.
           - service: 'mysql:5.7'
             db: MySQL 5.7
+          - service: 'mysql:8.0.30'
+            db: MySQL 8.0
           - service: mariadb
             db: MariaDB
 
@@ -58,6 +60,11 @@ jobs:
           - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: 'mysql:5.7'
             db: MySQL 5.7
+            prefix: flarum_
+            prefixStr: (prefix)
+          - php: ${{ fromJSON(inputs.php_versions)[0] }}
+            service: 'mysql:8.0.30'
+            db: MySQL 8.0
             prefix: flarum_
             prefixStr: (prefix)
           - php: ${{ fromJSON(inputs.php_versions)[0] }}

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -19,7 +19,7 @@ on:
         description: Versions of PHP to test with. Should be array of strings encoded as JSON array
         type: string
         required: false
-        default: '["7.4", "8.0", "8.1"]'
+        default: '["7.3", "7.4", "8.0", "8.1"]'
       db_versions:
         description: Versions of databases to test with. Should be array of strings encoded as JSON array
         type: string


### PR DESCRIPTION
**Changes proposed in this pull request:**
See separate commits to understand changes better.
* The first commit reduces number of actions 132 -> 106
* The second 106 -> 132
* The third 132 -> 197
* The fourth 197 -> 171

To decrease the number of actions further, I have excluded from the matrix `[PHP 8.0, MySQL 8.0]` & `[PHP 7.4, MySQL 8.0]` as I don't think we need to test against all PHP versions with all possible database versions. so having two different PHP versions against MySQL 8.0 seems already plenty enough.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.