### PR TITLE
fix: add viewPrivate visibility scope

### DIFF
--- a/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
+++ b/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
@@ -28,8 +28,11 @@ trait InteractsWithUnapprovedContent
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 3, 'comment_count' => 1, 'is_approved' => 0, 'is_private' => 1],
                 ['id' => 4, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 4, 'comment_count' => 1, 'is_approved' => 1, 'is_private' => 0],
                 ['id' => 5, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 5, 'comment_count' => 1, 'is_approved' => 1, 'is_private' => 0],
-                ['id' => 6, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 6, 'comment_count' => 1, 'is_approved' => 0, 'is_private' => 1],
+                ['id' => 6, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 6, 'comment_count' => 1, 'is_approved' => 0, 'is_private' => 1],
                 ['id' => 7, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 7, 'comment_count' => 1, 'is_approved' => 1, 'is_private' => 0],
+
+                // Normal discussion with first post being private (also means comment_count = 0).
+                ['id' => 8, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 12, 'comment_count' => 0, 'is_approved' => 1, 'is_private' => 0],
             ],
             'posts' => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
@@ -37,39 +40,26 @@ trait InteractsWithUnapprovedContent
                 ['id' => 3, 'discussion_id' => 3, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
                 ['id' => 4, 'discussion_id' => 4, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
                 ['id' => 5, 'discussion_id' => 5, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
-                ['id' => 6, 'discussion_id' => 6, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
+                ['id' => 6, 'discussion_id' => 6, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
                 ['id' => 7, 'discussion_id' => 7, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
 
                 ['id' => 8, 'discussion_id' => 7, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 2],
-                ['id' => 9, 'discussion_id' => 7, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 1, 'is_approved' => 0, 'number' => 3],
+                ['id' => 9, 'discussion_id' => 7, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 1, 'is_approved' => 0, 'number' => 3],
                 ['id' => 10, 'discussion_id' => 7, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 4],
                 ['id' => 11, 'discussion_id' => 7, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 1, 'is_approved' => 0, 'number' => 5],
+
+                // First post of a normal discussion being private.
+                ['id' => 12, 'discussion_id' => 8, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 1, 'is_approved' => 0, 'number' => 1],
             ],
             'groups' => [
-                ['id' => 4, 'name_singular' => 'Acme', 'name_plural' => 'Acme', 'is_hidden' => 0]
+                ['id' => 100, 'name_singular' => 'Acme', 'name_plural' => 'Acme', 'is_hidden' => 0]
             ],
             'group_user' => [
-                ['user_id' => 3, 'group_id' => 4]
+                ['user_id' => 3, 'group_id' => 100]
             ],
             'group_permission' => [
-                ['permission' => 'discussion.approvePosts', 'group_id' => 4]
+                ['permission' => 'discussion.approvePosts', 'group_id' => 100]
             ]
         ]);
-    }
-
-    /**
-     * null: Guest, 2: Normal User.
-     */
-    public function unallowedUsers(): array
-    {
-        return [[null], [2]];
-    }
-
-    /**
-     * 1: Admin, 3: Permission Given, 4: Discussions Author.
-     */
-    public function allowedUsers(): array
-    {
-        return [[1], [3], [4]];
     }
 }

--- a/framework/core/src/Discussion/Access/ScopeDiscussionVisibility.php
+++ b/framework/core/src/Discussion/Access/ScopeDiscussionVisibility.php
@@ -54,6 +54,9 @@ class ScopeDiscussionVisibility
                     ->orWhere('discussions.user_id', $actor->id)
                     ->orWhere(function ($query) use ($actor) {
                         $query->whereVisibleTo($actor, 'editPosts');
+                    })
+                    ->orWhere(function ($query) use ($actor) {
+                        $query->whereVisibleTo($actor, 'viewPrivate');
                     });
             });
         }

--- a/framework/core/src/Discussion/Access/ScopeDiscussionVisibility.php
+++ b/framework/core/src/Discussion/Access/ScopeDiscussionVisibility.php
@@ -54,9 +54,6 @@ class ScopeDiscussionVisibility
                     ->orWhere('discussions.user_id', $actor->id)
                     ->orWhere(function ($query) use ($actor) {
                         $query->whereVisibleTo($actor, 'editPosts');
-                    })
-                    ->orWhere(function ($query) use ($actor) {
-                        $query->whereVisibleTo($actor, 'viewPrivate');
                     });
             });
         }

--- a/framework/core/tests/integration/api/discussions/ListTest.php
+++ b/framework/core/tests/integration/api/discussions/ListTest.php
@@ -27,20 +27,39 @@ class ListTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'papi', 'email' => 'papi@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
+            ],
             'discussions' => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => 'lightsail in title', 'created_at' => Carbon::createFromDate(1985, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(1985, 5, 21)->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
                 ['id' => 3, 'title' => 'not in title', 'created_at' => Carbon::createFromDate(1995, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(1995, 5, 21)->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
                 ['id' => 4, 'title' => 'hidden', 'created_at' => Carbon::createFromDate(2005, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(2005, 5, 21)->toDateTimeString(), 'hidden_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
+
+                // A discussion with a private first post (which means the comment_count = 0 as well).
+                // comment_count=0 discussions are also considered as hidden discussions.
+                // @see HiddenFilterGambit
+                ['id' => 5, 'title' => 'first post private', 'created_at' => Carbon::createFromDate(2007, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(2007, 5, 21)->toDateTimeString(), 'user_id' => 4, 'comment_count' => 0, 'first_post_id' => 5, 'is_private' => 0],
             ],
             'posts' => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>'],
                 ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::createFromDate(1985, 5, 21)->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>not in text</p></t>'],
                 ['id' => 3, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1995, 5, 21)->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
                 ['id' => 4, 'discussion_id' => 4, 'created_at' => Carbon::createFromDate(2005, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
+
+                // Private first post.
+                ['id' => 5, 'discussion_id' => 5, 'created_at' => Carbon::createFromDate(2005, 5, 21)->toDateTimeString(), 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>', 'is_private' => 1],
             ],
-            'users' => [
-                $this->normalUser(),
+            'groups' => [
+                ['id' => 100, 'name_singular' => 'Acme', 'name_plural' => 'Acme', 'is_hidden' => 0]
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 100]
+            ],
+            'group_permission' => [
+                ['permission' => 'discussion.editPosts', 'group_id' => 100]
             ]
         ]);
     }
@@ -200,7 +219,7 @@ class ListTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true)['data'];
 
         // Order-independent comparison
-        $this->assertEquals(['4'], Arr::pluck($data, 'id'), 'IDs do not match');
+        $this->assertEquals(['5', '4'], Arr::pluck($data, 'id'), 'IDs do not match');
     }
 
     /**
@@ -396,7 +415,7 @@ class ListTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true)['data'];
 
         // Order-independent comparison
-        $this->assertEquals(['4'], Arr::pluck($data, 'id'), 'IDs do not match');
+        $this->assertEquals(['5', '4'], Arr::pluck($data, 'id'), 'IDs do not match');
     }
 
     /**
@@ -460,5 +479,33 @@ class ListTest extends TestCase
 
         // Order-independent comparison
         $this->assertEqualsCanonicalizing(['1', '2'], Arr::pluck($data, 'id'), 'IDs do not match');
+    }
+
+    /**
+     * @dataProvider userViewDiscussionPrivateFirstPostDataProvider
+     * @test
+     */
+    public function user_can_only_see_discussion_with_private_first_post_if_allowed(?int $authenticatedAs, bool $canSee)
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', compact('authenticatedAs'))
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $method = $canSee ? 'assertContains' : 'assertNotContains';
+        $this->{$method}('5', Arr::pluck($body['data'], 'id'));
+    }
+
+    public function userViewDiscussionPrivateFirstPostDataProvider(): array
+    {
+        return [
+            'admin can see discussions with private first posts' => [1, true],
+            'guests users cannot see discussions with private first posts' => [null, false],
+            'normal users cannot see discussions with private first posts' => [2, false],
+            'users with discussion.editPosts perm can see discussions with private first posts' => [3, true],
+            'author can see discussions with private first posts' => [4, true],
+        ];
     }
 }


### PR DESCRIPTION
**Fixes #3594 **

**Changes proposed in this pull request:**
Allow discussions to be conditionally visible via `viewPrivate` scopers, when the user does **not** have the `editPosts` permission.

I feel that improving the tests for `flarum/approval` is also required, unfortunately I cannot run them locally atm, so perhaps someone would be kind enough to add?

**Reviewers should focus on:**
I've tested this change with 3rd party extensions, such as `fof/byobu`, which also makes use of `viewPrivate`, and there does not appear to be any side effects, but perhaps there's something I've not considered by opening this up a little?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
