### PR TITLE
test: prevent running both `push` and `pull_request` actions at the same time

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -88,7 +88,9 @@ jobs:
 
     name: 'PHP ${{ matrix.php }} / ${{ matrix.db }} ${{ matrix.prefixStr }}'
 
-    if: inputs.enable_backend_testing
+    if: >-
+      inputs.enable_backend_testing &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -91,6 +91,9 @@ jobs:
     name: Checks & Build
     runs-on: ubuntu-latest
 
+    if: >-
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
**Changes proposed in this pull request:**
Not a 100% perfect solution, however as us maintainers always push branches directly to the original repository and make PRs from those, this is plenty enough. Instead of having 300+ actions in each PR which takes time, we'll just have the normal 171 `push` actions.

This makes sure to still run `pull_request` actions from contributors as they'd be forking the repo.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.