### PR TITLE
fix: `$events` property declared dynamically

### DIFF
--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -47,7 +47,7 @@ class AdminPayload
     /**
      * @var Dispatcher $events
      */
-    protected Dispatcher $events;
+    protected $events;
 
     /**
      * @var Config

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -45,6 +45,11 @@ class AdminPayload
     protected $db;
 
     /**
+     * @var Dispatcher $events
+     */
+    protected Dispatcher $events;
+
+    /**
      * @var Config
      */
     protected $config;

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -45,7 +45,7 @@ class AdminPayload
     protected $db;
 
     /**
-     * @var Dispatcher $events
+     * @var Dispatcher
      */
     protected $events;
 


### PR DESCRIPTION
`$events` property has not been declarated


**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
