### PR TITLE
fix(subscriptions): add missing table prefix for filter gambit

### DIFF
--- a/extensions/subscriptions/src/Query/SubscriptionFilterGambit.php
+++ b/extensions/subscriptions/src/Query/SubscriptionFilterGambit.php
@@ -43,7 +43,7 @@ class SubscriptionFilterGambit extends AbstractRegexGambit implements FilterInte
     protected function constrain(Builder $query, User $actor, string $subscriptionType, bool $negate)
     {
         $method = $negate ? 'whereNotIn' : 'whereIn';
-        $query->$method('id', function ($query) use ($actor, $subscriptionType) {
+        $query->$method('discussions.id', function ($query) use ($actor, $subscriptionType) {
             $query->select('discussion_id')
             ->from('discussion_user')
             ->where('user_id', $actor->id)


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Adds missing table prefix from `id` column reference in filter gambit constraint.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

