### PR TITLE
phpDoc: return type not correctly

### DIFF
--- a/framework/core/src/Post/PostRepository.php
+++ b/framework/core/src/Post/PostRepository.php
@@ -12,6 +12,8 @@ namespace Flarum\Post;
 use Flarum\Discussion\Discussion;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 
 class PostRepository
 {
@@ -45,12 +47,11 @@ class PostRepository
      * user, or throw an exception.
      *
      * @param int $id
-     * @param \Flarum\User\User $actor
-     * @return \Flarum\Post\Post
+     * @param User|null $actor
+     * @return Builder|Collection|Model
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findOrFail($id, User $actor = null)
+    public function findOrFail(int $id, User $actor = null)
     {
         return $this->queryVisibleTo($actor)->findOrFail($id);
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
This PR is update phpDoc, return type is not as expected

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
