### PR TITLE
fix: remove result from local

### DIFF
--- a/framework/core/js/src/forum/components/UsersSearchSource.tsx
+++ b/framework/core/js/src/forum/components/UsersSearchSource.tsx
@@ -31,11 +31,6 @@ export default class UsersSearchResults implements SearchSource {
     query = query.toLowerCase();
 
     const results = (this.results.get(query) || [])
-      .concat(
-        app.store
-          .all<User>('users')
-          .filter((user) => [user.username(), user.displayName()].some((value) => value.toLowerCase().substr(0, query.length) === query))
-      )
       .filter((e, i, arr) => arr.lastIndexOf(e) === i)
       .sort((a, b) => a.displayName().localeCompare(b.displayName()));
 


### PR DESCRIPTION
Easy limit search result. Only from server.

if A cancel B, B is not usually collected in the search results。
This makes it easy to limit the results from the server。