### PR TITLE
fix(tags): use default index sortmap

### DIFF
--- a/extensions/tags/src/Content/Tag.php
+++ b/extensions/tags/src/Content/Tag.php
@@ -109,12 +109,7 @@ class Tag
      */
     private function getSortMap()
     {
-        return [
-            'latest' => '-lastPostedAt',
-            'top' => '-commentCount',
-            'newest' => '-createdAt',
-            'oldest' => 'createdAt'
-        ];
+        return resolve('flarum.forum.discussions.sortmap');
     }
 
     /**


### PR DESCRIPTION
**Changes proposed in this pull request:**
The tag content page recreates the index sortmap, which means it isn't aware of any extension-added sort options.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.