### PR TITLE
fix(mentions): accessing `id` of null `user` relation

### DIFF
--- a/extensions/mentions/src/Listener/UpdateMentionsMetadataWhenVisible.php
+++ b/extensions/mentions/src/Listener/UpdateMentionsMetadataWhenVisible.php
@@ -60,7 +60,7 @@ class UpdateMentionsMetadataWhenVisible
         $users = User::whereIn('id', $mentioned)
             ->get()
             ->filter(function ($user) use ($post) {
-                return $post->isVisibleTo($user) && $user->id !== $post->user->id;
+                return $post->isVisibleTo($user) && $user->id !== $post->user_id;
             })
             ->all();
 
@@ -75,8 +75,8 @@ class UpdateMentionsMetadataWhenVisible
         $posts = Post::with('user')
             ->whereIn('id', $mentioned)
             ->get()
-            ->filter(function ($post) use ($reply) {
-                return $post->user && $post->user->id !== $reply->user_id && $reply->isVisibleTo($post->user);
+            ->filter(function (Post $post) use ($reply) {
+                return $post->user && $post->user_id !== $reply->user_id && $reply->isVisibleTo($post->user);
             })
             ->all();
 


### PR DESCRIPTION
**Fixes #3617**

**Changes proposed in this pull request:**
Access `user_id` instead of going through the relation which might be null.
I wish the IDE would point these out, the relation is typed in the model phpDoc as possibly `null`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.