### PR TITLE
fix(regression): bad post actions alignment introduced in #3540

### DIFF
--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -33,7 +33,7 @@
     &, > ul {
       width: 150px;
     }
-    
+
     > ul {
       > li {
         margin-bottom: 10px;
@@ -51,9 +51,7 @@
       }
     }
   }
-}
 
-@media @tablet-up {
   .DiscussionPage-stream {
     margin-right: 225px;
   }

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -23,16 +23,24 @@
   }
 }
 @media @tablet-up {
+  .DiscussionPage-discussion {
+    > .container {
+      display: grid;
+      grid-gap: 75px;
+      grid-template-columns: 1fr 150px;
+
+      &::before, &::after {
+        content: none;
+      }
+    }
+  }
+
   .DiscussionPage-nav {
-    float: right;
+    align-self: start;
     position: sticky;
     top: var(--header-height);
     padding-top: 32px;
     z-index: 1;
-
-    &, > ul {
-      width: 150px;
-    }
 
     > ul {
       > li {
@@ -53,7 +61,7 @@
   }
 
   .DiscussionPage-stream {
-    margin-right: 225px;
+    order: -1;
   }
 }
 

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -28,6 +28,7 @@
       display: grid;
       grid-gap: 75px;
       grid-template-columns: 1fr 150px;
+      grid-template-areas: 'stream nav';
 
       &::before, &::after {
         content: none;
@@ -38,6 +39,7 @@
   .DiscussionPage-nav {
     align-self: start;
     position: sticky;
+    grid-area: nav;
     top: var(--header-height);
     padding-top: 32px;
     z-index: 1;
@@ -61,7 +63,7 @@
   }
 
   .DiscussionPage-stream {
-    order: -1;
+    grid-area: stream;
   }
 }
 

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -8,6 +8,7 @@
   position: relative;
   top: 0;
   border-radius: var(--border-radius);
+  .clearfix();
 
   &.editing {
     top: 5px;


### PR DESCRIPTION
**Fixes a regression introduced in #3540**

**Changes proposed in this pull request:**
* We can't reintroduce the clearfix, it messes with first post height (#3540).
* We don't want to un-hide `Post-footer` when it's empty (#2926), but we can do so in normal posts only as it's the only reliable way atm. It doesn't pose a problem anyway unless extensions that add items leave those items hanging in the dom even if they're empty.

**Screenshot**
![Screenshot from 2022-08-26 13-51-25](https://user-images.githubusercontent.com/20267363/186908128-88679606-afd2-4474-aa6b-a123b002531a.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.