### PR TITLE
fix: post query wildcard selection causes ambiguity

### DIFF
--- a/framework/core/src/Post/Filter/PostFilterer.php
+++ b/framework/core/src/Post/Filter/PostFilterer.php
@@ -35,6 +35,6 @@ class PostFilterer extends AbstractFilterer
 
     protected function getQuery(User $actor): Builder
     {
-        return $this->posts->query()->whereVisibleTo($actor);
+        return $this->posts->query()->select('posts.*')->whereVisibleTo($actor);
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Explicitly select post columns to avoid ambiguous column names being picked up from other tables. I think we should do the same for other models.

> https://discuss.flarum.org/d/31494-creation-date-of-posts-sometimes-missing-in-mentions-page/2
> I see the mentioned post filter joins the post_mentions_user table onto the posts query. Maybe the post model pulls the wrong created_at from the results? I believe most recent MySQL errors would throw an error if it was happening though, so not sure...

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.