### PR TITLE
feat(statistics): support for custom date ranges

### DIFF
--- a/extensions/statistics/js/package.json
+++ b/extensions/statistics/js/package.json
@@ -4,18 +4,19 @@
     "version": "0.0.0",
     "prettier": "@flarum/prettier-config",
     "dependencies": {
+        "dayjs": "^1.11.5",
         "frappe-charts": "^1.6.2"
     },
     "devDependencies": {
-        "@types/mithril": "^2.0.11",
-        "prettier": "^2.7.1",
-        "flarum-webpack-config": "^2.0.0",
-        "webpack": "^5.73.0",
-        "webpack-cli": "^4.10.0",
         "@flarum/prettier-config": "^1.0.0",
+        "@types/mithril": "^2.0.11",
         "flarum-tsconfig": "^1.0.2",
+        "flarum-webpack-config": "^2.0.0",
+        "prettier": "^2.7.1",
         "typescript": "^4.7.4",
-        "typescript-coverage-report": "^0.6.4"
+        "typescript-coverage-report": "^0.6.4",
+        "webpack": "^5.73.0",
+        "webpack-cli": "^4.10.0"
     },
     "scripts": {
         "dev": "webpack --mode development --watch",

--- a/extensions/statistics/js/package.json
+++ b/extensions/statistics/js/package.json
@@ -4,7 +4,6 @@
     "version": "0.0.0",
     "prettier": "@flarum/prettier-config",
     "dependencies": {
-        "dayjs": "^1.11.5",
         "frappe-charts": "^1.6.2"
     },
     "devDependencies": {

--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -355,11 +355,11 @@ export default class StatisticsWidget extends DashboardWidget {
         label = dayjs.unix(i).utc().format('D MMM');
 
         if (period.step > 86400) {
-          // @ts-expect-error dayjs plugin typings not available
           label +=
             ' - ' +
             dayjs
               .unix(i + period.step - 1)
+              // @ts-expect-error dayjs plugin typings not available
               .utc()
               .format('D MMM');
         }

--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -14,12 +14,11 @@ import StatisticsWidgetDateSelectionModal, { IDateSelection, IStatisticsWidgetDa
 
 import type Mithril from 'mithril';
 
+import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 import dayjsLocalizedFormat from 'dayjs/plugin/localizedFormat';
 
-// @ts-expect-error dayjs plugin typings not available
 dayjs.extend(dayjsUtc);
-// @ts-expect-error dayjs plugin typings not available
 dayjs.extend(dayjsLocalizedFormat);
 
 // @ts-expect-error No typings available
@@ -249,9 +248,7 @@ export default class StatisticsWidget extends DashboardWidget {
                         {this.selectedPeriod === 'custom'
                           ? extractText(
                               app.translator.trans(`flarum-statistics.admin.statistics.custom_label_specified`, {
-                                // @ts-expect-error dayjs plugin typings not available
                                 fromDate: dayjs.utc(this.customPeriod!.start! * 1000).format('ll'),
-                                // @ts-expect-error dayjs plugin typings not available
                                 toDate: dayjs.utc(this.customPeriod!.end! * 1000).format('ll'),
                               })
                             )
@@ -348,10 +345,8 @@ export default class StatisticsWidget extends DashboardWidget {
       let label;
 
       if (period.step < 86400) {
-        // @ts-expect-error dayjs plugin typings not available
         label = dayjs.unix(i).utc().format('h A');
       } else {
-        // @ts-expect-error dayjs plugin typings not available
         label = dayjs.unix(i).utc().format('D MMM');
 
         if (period.step > 86400) {
@@ -359,7 +354,6 @@ export default class StatisticsWidget extends DashboardWidget {
             ' - ' +
             dayjs
               .unix(i + period.step - 1)
-              // @ts-expect-error dayjs plugin typings not available
               .utc()
               .format('D MMM');
         }

--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -14,6 +14,14 @@ import StatisticsWidgetDateSelectionModal, { IDateSelection, IStatisticsWidgetDa
 
 import type Mithril from 'mithril';
 
+import dayjsUtc from 'dayjs/plugin/utc';
+import dayjsLocalizedFormat from 'dayjs/plugin/localizedFormat';
+
+// @ts-expect-error dayjs plugin typings not available
+dayjs.extend(dayjsUtc);
+// @ts-expect-error dayjs plugin typings not available
+dayjs.extend(dayjsLocalizedFormat);
+
 // @ts-expect-error No typings available
 import { Chart } from 'frappe-charts';
 
@@ -241,8 +249,10 @@ export default class StatisticsWidget extends DashboardWidget {
                         {this.selectedPeriod === 'custom'
                           ? extractText(
                               app.translator.trans(`flarum-statistics.admin.statistics.custom_label_specified`, {
-                                fromDate: dayjs(this.customPeriod!.start! * 1000).format('DD MMM YYYY'),
-                                toDate: dayjs(this.customPeriod!.end! * 1000).format('DD MMM YYYY'),
+                                // @ts-expect-error dayjs plugin typings not available
+                                fromDate: dayjs.utc(this.customPeriod!.start! * 1000).format('ll'),
+                                // @ts-expect-error dayjs plugin typings not available
+                                toDate: dayjs.utc(this.customPeriod!.end! * 1000).format('ll'),
                               })
                             )
                           : app.translator.trans(`flarum-statistics.admin.statistics.custom_label`)}
@@ -321,8 +331,6 @@ export default class StatisticsWidget extends DashboardWidget {
       return;
     }
 
-    debugger;
-
     const period =
       this.selectedPeriod === 'custom'
         ? {
@@ -340,12 +348,20 @@ export default class StatisticsWidget extends DashboardWidget {
       let label;
 
       if (period.step < 86400) {
-        label = dayjs.unix(i).format('h A');
+        // @ts-expect-error dayjs plugin typings not available
+        label = dayjs.unix(i).utc().format('h A');
       } else {
-        label = dayjs.unix(i).format('D MMM');
+        // @ts-expect-error dayjs plugin typings not available
+        label = dayjs.unix(i).utc().format('D MMM');
 
         if (period.step > 86400) {
-          label += ' - ' + dayjs.unix(i + period.step - 1).format('D MMM');
+          // @ts-expect-error dayjs plugin typings not available
+          label +=
+            ' - ' +
+            dayjs
+              .unix(i + period.step - 1)
+              .utc()
+              .format('D MMM');
         }
       }
 

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -86,7 +86,7 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
     items.add(
       'date_end',
       <div class="Form-group">
-        <label htmlFor={this.state.ids.endDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.start_date')}</label>
+        <label htmlFor={this.state.ids.endDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.end_date')}</label>
         <input type="date" id={this.state.ids.endDate} value={this.state.inputs.endDateVal} onchange={this.updateState('endDateVal')} />
       </div>,
       80

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -63,7 +63,7 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
   }
 
   className(): string {
-    return 'StatisticsWidgetDateSelectionModal';
+    return 'StatisticsWidgetDateSelectionModal Modal--small';
   }
 
   title(): Mithril.Children {

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -83,7 +83,7 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
       'date_start',
       <div class="Form-group">
         <label htmlFor={this.state.ids.startDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.start_date')}</label>
-        <input type="date" id={this.state.ids.startDate} value={this.state.inputs.startDateVal} onchange={this.updateState('startDateVal')} />
+        <input type="date" id={this.state.ids.startDate} value={this.state.inputs.startDateVal} onchange={this.updateState('startDateVal')} className="FormControl" />
       </div>,
       90
     );
@@ -92,7 +92,7 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
       'date_end',
       <div class="Form-group">
         <label htmlFor={this.state.ids.endDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.end_date')}</label>
-        <input type="date" id={this.state.ids.endDate} value={this.state.inputs.endDateVal} onchange={this.updateState('endDateVal')} />
+        <input type="date" id={this.state.ids.endDate} value={this.state.inputs.endDateVal} onchange={this.updateState('endDateVal')} className="FormControl" />
       </div>,
       80
     );

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -120,7 +120,17 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
   onsubmit(e: SubmitEvent): void {
     e.preventDefault();
 
-    this.attrs.onModalSubmit(this.submitData());
+    const data = this.submitData();
+
+    if (data.end < data.start) {
+      this.alertAttrs = {
+        type: 'error',
+        controls: app.translator.trans('flarum-statistics.admin.date_selection_modal.errors.end_before_start'),
+      };
+      return;
+    }
+
+    this.attrs.onModalSubmit(data);
     this.hide();
   }
 }

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -6,6 +6,11 @@ import Modal, { IInternalModalAttrs } from 'flarum/common/components/Modal';
 import Mithril from 'mithril';
 import Button from 'flarum/common/components/Button';
 
+import dayjsUtc from 'dayjs/plugin/utc';
+
+// @ts-expect-error dayjs plugin typings not available
+dayjs.extend(dayjsUtc);
+
 export interface IDateSelection {
   /**
    * Timestamp (seconds, not ms) for start date
@@ -51,8 +56,10 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
 
     if (this.attrs.value) {
       this.state.inputs = {
-        startDateVal: dayjs(this.attrs.value.start * 1000).format('YYYY-MM-DD'),
-        endDateVal: dayjs(this.attrs.value.end * 1000).format('YYYY-MM-DD'),
+        // @ts-expect-error dayjs plugin typings not available
+        startDateVal: dayjs.utc(this.attrs.value.start * 1000).format('YYYY-MM-DD'),
+        // @ts-expect-error dayjs plugin typings not available
+        endDateVal: dayjs.utc(this.attrs.value.end * 1000).format('YYYY-MM-DD'),
       };
     }
   }
@@ -112,8 +119,18 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
   submitData(): IDateSelection {
     // We force 'zulu' time (UTC)
     return {
-      start: Math.floor(new Date(this.state.inputs.startDateVal + 'Z').getTime() / 1000),
-      end: Math.floor(new Date(this.state.inputs.endDateVal + 'Z').getTime() / 1000),
+      // @ts-expect-error dayjs plugin typings not available
+      start: Math.floor(+dayjs.utc(this.state.inputs.startDateVal + 'Z') / 1000),
+      // Ensures that the end date is the end of the day
+      end: Math.floor(
+        +dayjs
+          // @ts-expect-error dayjs plugin typings not available
+          .utc(this.state.inputs.endDateVal + 'Z')
+          .hour(23)
+          .minute(59)
+          .second(59)
+          .millisecond(999) / 1000
+      ),
     };
   }
 

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -83,7 +83,13 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
       'date_start',
       <div class="Form-group">
         <label htmlFor={this.state.ids.startDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.start_date')}</label>
-        <input type="date" id={this.state.ids.startDate} value={this.state.inputs.startDateVal} onchange={this.updateState('startDateVal')} className="FormControl" />
+        <input
+          type="date"
+          id={this.state.ids.startDate}
+          value={this.state.inputs.startDateVal}
+          onchange={this.updateState('startDateVal')}
+          className="FormControl"
+        />
       </div>,
       90
     );
@@ -92,7 +98,13 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
       'date_end',
       <div class="Form-group">
         <label htmlFor={this.state.ids.endDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.end_date')}</label>
-        <input type="date" id={this.state.ids.endDate} value={this.state.inputs.endDateVal} onchange={this.updateState('endDateVal')} className="FormControl" />
+        <input
+          type="date"
+          id={this.state.ids.endDate}
+          value={this.state.inputs.endDateVal}
+          onchange={this.updateState('endDateVal')}
+          className="FormControl"
+        />
       </div>,
       80
     );

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -6,9 +6,9 @@ import Modal, { IInternalModalAttrs } from 'flarum/common/components/Modal';
 import Mithril from 'mithril';
 import Button from 'flarum/common/components/Button';
 
+import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 
-// @ts-expect-error dayjs plugin typings not available
 dayjs.extend(dayjsUtc);
 
 export interface IDateSelection {
@@ -56,9 +56,7 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
 
     if (this.attrs.value) {
       this.state.inputs = {
-        // @ts-expect-error dayjs plugin typings not available
         startDateVal: dayjs.utc(this.attrs.value.start * 1000).format('YYYY-MM-DD'),
-        // @ts-expect-error dayjs plugin typings not available
         endDateVal: dayjs.utc(this.attrs.value.end * 1000).format('YYYY-MM-DD'),
       };
     }
@@ -119,12 +117,10 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
   submitData(): IDateSelection {
     // We force 'zulu' time (UTC)
     return {
-      // @ts-expect-error dayjs plugin typings not available
       start: Math.floor(+dayjs.utc(this.state.inputs.startDateVal + 'Z') / 1000),
       // Ensures that the end date is the end of the day
       end: Math.floor(
         +dayjs
-          // @ts-expect-error dayjs plugin typings not available
           .utc(this.state.inputs.endDateVal + 'Z')
           .hour(23)
           .minute(59)

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -51,7 +51,7 @@ export default class StatisticsWidgetDateSelectionModal extends Modal<IStatistic
     },
   };
 
-  oninit(vnode) {
+  oninit(vnode: Mithril.Vnode<IStatisticsWidgetDateSelectionModalAttrs, this>) {
     super.oninit(vnode);
 
     if (this.attrs.value) {

--- a/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidgetDateSelectionModal.tsx
@@ -1,0 +1,126 @@
+import app from 'flarum/admin/app';
+import ItemList from 'flarum/common/utils/ItemList';
+import generateElementId from 'flarum/admin/utils/generateElementId';
+import Modal, { IInternalModalAttrs } from 'flarum/common/components/Modal';
+
+import Mithril from 'mithril';
+import Button from 'flarum/common/components/Button';
+
+export interface IDateSelection {
+  /**
+   * Timestamp (seconds, not ms) for start date
+   */
+  start: number;
+  /**
+   * Timestamp (seconds, not ms) for end date
+   */
+  end: number;
+}
+
+export interface IStatisticsWidgetDateSelectionModalAttrs extends IInternalModalAttrs {
+  onModalSubmit: (dates: IDateSelection) => void;
+  value?: IDateSelection;
+}
+
+interface IStatisticsWidgetDateSelectionModalState {
+  inputs: {
+    startDateVal: string;
+    endDateVal: string;
+  };
+  ids: {
+    startDate: string;
+    endDate: string;
+  };
+}
+
+export default class StatisticsWidgetDateSelectionModal extends Modal<IStatisticsWidgetDateSelectionModalAttrs> {
+  /* @ts-expect-error core typings don't allow us to set the type of the state attr :( */
+  state: IStatisticsWidgetDateSelectionModalState = {
+    inputs: {
+      startDateVal: dayjs().format('YYYY-MM-DD'),
+      endDateVal: dayjs().format('YYYY-MM-DD'),
+    },
+    ids: {
+      startDate: generateElementId(),
+      endDate: generateElementId(),
+    },
+  };
+
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    if (this.attrs.value) {
+      this.state.inputs = {
+        startDateVal: dayjs(this.attrs.value.start * 1000).format('YYYY-MM-DD'),
+        endDateVal: dayjs(this.attrs.value.end * 1000).format('YYYY-MM-DD'),
+      };
+    }
+  }
+
+  className(): string {
+    return 'StatisticsWidgetDateSelectionModal';
+  }
+
+  title(): Mithril.Children {
+    return app.translator.trans('flarum-statistics.admin.date_selection_modal.title');
+  }
+
+  content(): Mithril.Children {
+    return <div class="Modal-body">{this.items().toArray()}</div>;
+  }
+
+  items(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('intro', <p>{app.translator.trans('flarum-statistics.admin.date_selection_modal.description')}</p>, 100);
+
+    items.add(
+      'date_start',
+      <div class="Form-group">
+        <label htmlFor={this.state.ids.startDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.start_date')}</label>
+        <input type="date" id={this.state.ids.startDate} value={this.state.inputs.startDateVal} onchange={this.updateState('startDateVal')} />
+      </div>,
+      90
+    );
+
+    items.add(
+      'date_end',
+      <div class="Form-group">
+        <label htmlFor={this.state.ids.endDate}>{app.translator.trans('flarum-statistics.admin.date_selection_modal.start_date')}</label>
+        <input type="date" id={this.state.ids.endDate} value={this.state.inputs.endDateVal} onchange={this.updateState('endDateVal')} />
+      </div>,
+      80
+    );
+
+    items.add(
+      'submit',
+      <Button class="Button Button--primary" type="submit">
+        {app.translator.trans('flarum-statistics.admin.date_selection_modal.submit_button')}
+      </Button>,
+      0
+    );
+
+    return items;
+  }
+
+  updateState(field: keyof IStatisticsWidgetDateSelectionModalState['inputs']): (e: InputEvent) => void {
+    return (e: InputEvent) => {
+      this.state.inputs[field] = (e.currentTarget as HTMLInputElement).value;
+    };
+  }
+
+  submitData(): IDateSelection {
+    // We force 'zulu' time (UTC)
+    return {
+      start: Math.floor(new Date(this.state.inputs.startDateVal + 'Z').getTime() / 1000),
+      end: Math.floor(new Date(this.state.inputs.endDateVal + 'Z').getTime() / 1000),
+    };
+  }
+
+  onsubmit(e: SubmitEvent): void {
+    e.preventDefault();
+
+    this.attrs.onModalSubmit(this.submitData());
+    this.hide();
+  }
+}

--- a/extensions/statistics/less/admin.less
+++ b/extensions/statistics/less/admin.less
@@ -109,6 +109,10 @@
     padding: 12px 16px;
     text-align: center;
   }
+
+  .Placeholder {
+    padding-bottom: 32px;
+  }
 }
 
 /*!

--- a/extensions/statistics/locale/en.yml
+++ b/extensions/statistics/locale/en.yml
@@ -11,6 +11,8 @@ flarum-statistics:
         Pick a custom date range to display statistics for. Loading data may take
         multiple minutes on forums with a lot of activity.
       end_date: End date (inclusive)
+      errors:
+        end_before_start: The end date must be after the start date.
       start_date: Start date (inclusive)
       submit_button: Confirm date range
       title: Choose custom date range

--- a/extensions/statistics/locale/en.yml
+++ b/extensions/statistics/locale/en.yml
@@ -1,11 +1,19 @@
 flarum-statistics:
-
   ##
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
   # Translations in this namespace are used by the admin interface.
   admin:
+    # These translations are used in the date selection modal.
+    date_selection_modal:
+      description: |
+        Pick a custom date range to display statistics for. Loading data may take
+        multiple minutes on forums with a lot of activity.
+      end_date: End date (inclusive)
+      start_date: Start date (inclusive)
+      submit_button: Confirm date range
+      title: Choose custom date range
 
     # These translations are used in the Statistics dashboard widget.
     statistics:
@@ -16,9 +24,12 @@ flarum-statistics:
       mini_heading: Forum statistics
       previous_28_days_label: Previous 28 days
       previous_7_days_label: Previous 7 days
+      custom_label: Choose custom range...
+      custom_label_specified: "{fromDate} to {toDate}"
       loading: => core.ref.loading
       posts_heading: => core.ref.posts
       today_label: Today
       total_label: Total
       users_heading: => core.ref.users
       view_full: View more statistics
+      no_data: There is no data available for this date range.

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -85,12 +85,12 @@ class ShowStatisticsData implements RequestHandlerInterface
             return $this->getLifetimeStatistics();
         }
 
-        if (! Arr::exists($this->entities, $model)) {
+        if (!Arr::exists($this->entities, $model)) {
             throw new InvalidParameterException('A model must be specified');
         }
 
         if ($period === 'custom') {
-            if (! $customDateRange) {
+            if (!$customDateRange) {
                 throw new InvalidParameterException('A custom date range must be specified');
             }
 
@@ -121,12 +121,20 @@ class ShowStatisticsData implements RequestHandlerInterface
         });
     }
 
-    private function getTimedCounts(Builder $query, string $column, DateTime $startDate = new DateTime('-365 days'), DateTime $endDate = new DateTime())
+    private function getTimedCounts(Builder $query, string $column, ?DateTime $startDate = null, ?DateTime $endDate = null)
     {
+        if (!isset($startDate)) {
+            $startDate = new DateTime('-365 days');
+        }
+
+        if (!isset($endDate)) {
+            $startDate = new DateTime();
+        }
+
         $results = $query
             ->selectRaw(
                 'DATE_FORMAT(
-                    @date := '.$column.',
+                    @date := ' . $column . ',
                     IF(@date > ?, \'%Y-%m-%d %H:00:00\', \'%Y-%m-%d\') -- if within the last 24 hours, group by hour
                 ) as time_group',
                 [new DateTime('-25 hours')]

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -85,12 +85,12 @@ class ShowStatisticsData implements RequestHandlerInterface
             return $this->getLifetimeStatistics();
         }
 
-        if (!Arr::exists($this->entities, $model)) {
+        if (! Arr::exists($this->entities, $model)) {
             throw new InvalidParameterException('A model must be specified');
         }
 
         if ($period === 'custom') {
-            if (!$customDateRange) {
+            if (! $customDateRange) {
                 throw new InvalidParameterException('A custom date range must be specified');
             }
 
@@ -123,18 +123,18 @@ class ShowStatisticsData implements RequestHandlerInterface
 
     private function getTimedCounts(Builder $query, string $column, ?DateTime $startDate = null, ?DateTime $endDate = null)
     {
-        if (!isset($startDate)) {
+        if (! isset($startDate)) {
             $startDate = new DateTime('-365 days');
         }
 
-        if (!isset($endDate)) {
+        if (! isset($endDate)) {
             $startDate = new DateTime();
         }
 
         $results = $query
             ->selectRaw(
                 'DATE_FORMAT(
-                    @date := ' . $column . ',
+                    @date := '.$column.',
                     IF(@date > ?, \'%Y-%m-%d %H:00:00\', \'%Y-%m-%d\') -- if within the last 24 hours, group by hour
                 ) as time_group',
                 [new DateTime('-25 hours')]

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -128,7 +128,7 @@ class ShowStatisticsData implements RequestHandlerInterface
         }
 
         if (! isset($endDate)) {
-            $startDate = new DateTime();
+            $endDate = new DateTime();
         }
 
         $results = $query

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -90,13 +90,16 @@ class ShowStatisticsData implements RequestHandlerInterface
         }
 
         if ($period === 'custom') {
-            if (! $customDateRange) {
+            $start = (int) $customDateRange['start'];
+            $end = (int) $customDateRange['end'];
+
+            if (! $customDateRange || ! $start || ! $end) {
                 throw new InvalidParameterException('A custom date range must be specified');
             }
 
             // Seconds-based timestamps
-            $startRange = Carbon::createFromTimestampUTC($customDateRange['start'])->toDateTime();
-            $endRange = Carbon::createFromTimestampUTC($customDateRange['end'])->toDateTime();
+            $startRange = Carbon::createFromTimestampUTC($start)->toDateTime();
+            $endRange = Carbon::createFromTimestampUTC($end)->toDateTime();
 
             // We can't really cache this
             return $this->getTimedCounts($this->entities[$model][0], $this->entities[$model][1], $startRange, $endRange);

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -85,21 +85,21 @@ class ShowStatisticsData implements RequestHandlerInterface
             return $this->getLifetimeStatistics();
         }
 
+        if (! Arr::exists($this->entities, $model)) {
+            throw new InvalidParameterException('A model must be specified');
+        }
+
         if ($period === 'custom') {
             if (! $customDateRange) {
                 throw new InvalidParameterException('A custom date range must be specified');
             }
 
-            // We use ms-based timestamp because this is what JS uses, so what the frontend will provide
-            $startRange = Carbon::createFromTimestampMsUTC($customDateRange['start'])->toDateTime();
-            $endRange = Carbon::createFromTimestampMsUTC($customDateRange['end'])->toDateTime();
+            // Seconds-based timestamps
+            $startRange = Carbon::createFromTimestampUTC($customDateRange['start'])->toDateTime();
+            $endRange = Carbon::createFromTimestampUTC($customDateRange['end'])->toDateTime();
 
             // We can't really cache this
             return $this->getTimedCounts($this->entities[$model][0], $this->entities[$model][1], $startRange, $endRange);
-        }
-
-        if (! Arr::exists($this->entities, $model)) {
-            throw new InvalidParameterException();
         }
 
         return $this->getTimedStatistics($model);

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -133,7 +133,7 @@ class ShowStatisticsData implements RequestHandlerInterface
             )
             ->selectRaw('COUNT(id) as count')
             ->where($column, '>', $startDate)
-            ->where($column, '<', $endDate)
+            ->where($column, '<=', $endDate)
             ->groupBy('time_group')
             ->pluck('count', 'time_group');
 

--- a/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Flarum\Statistics\tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class CanRequestCustomTimedStatisticsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected Carbon $nowTime;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nowTime = Carbon::now()->subDays(10);
+
+        $this->extension('flarum-statistics');
+
+        $this->prepareDatabase($this->getDatabaseData());
+    }
+
+    protected function getDatabaseData(): array
+    {
+        return [
+            'users' => [
+                ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()],
+                ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()->subDays(1)],
+                ['id' => 3, 'username' => 'normal2', 'email' => 'normal2@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()->subDays(2)],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 2, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 4, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(2), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()],
+                ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],
+                ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],
+                ['id' => 4, 'discussion_id' => 4, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(2)],
+                ['id' => 5, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 2, 'created_at' => $this->nowTime->copy()],
+            ],
+        ];
+    }
+
+    /** 
+     * @test
+     */
+    public function can_request_timed_stats()
+    {
+        $time = $this->nowTime->copy();
+
+        $start = $time->copy()->subDays(1)->startOfDay()->getTimestamp();
+        $end = $time->copy()->endOfDay()->getTimestamp();
+
+        $timeStart = $time->copy()->startOfDay();
+
+        $models = [
+            "users" => [
+                $timeStart->copy()->getTimestamp() => 1,
+                $timeStart->copy()->subDays(1)->getTimestamp() => 1,
+            ], "discussions" => [
+                $timeStart->copy()->getTimestamp() => 1,
+                $timeStart->copy()->subDays(1)->getTimestamp() => 2,
+            ], "posts" => [
+                $timeStart->copy()->getTimestamp() => 2,
+                $timeStart->copy()->subDays(1)->getTimestamp() => 2,
+            ]
+        ];
+
+        foreach ($models as $model => $data) {
+            $response = $this->send(
+                $this->request('GET', '/api/statistics', ['authenticatedAs' => 1])->withQueryParams([
+                    'model' => $model,
+                    'period' => 'custom',
+                    'dateRange' => [
+                        'start' => $start,
+                        'end' => $end,
+                    ],
+                ])
+            );
+
+            $body = json_decode($response->getBody()->getContents(), true);
+
+            $this->assertEquals(200, $response->getStatusCode());
+
+            $this->assertEquals(
+                $data,
+                $body,
+            );
+        }
+    }
+}

--- a/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
@@ -47,7 +54,7 @@ class CanRequestCustomTimedStatisticsTest extends TestCase
         ];
     }
 
-    /** 
+    /**
      * @test
      */
     public function can_request_timed_stats()
@@ -60,13 +67,13 @@ class CanRequestCustomTimedStatisticsTest extends TestCase
         $timeStart = $time->copy()->startOfDay();
 
         $models = [
-            "users" => [
+            'users' => [
                 $timeStart->copy()->getTimestamp() => 1,
                 $timeStart->copy()->subDays(1)->getTimestamp() => 1,
-            ], "discussions" => [
+            ], 'discussions' => [
                 $timeStart->copy()->getTimestamp() => 1,
                 $timeStart->copy()->subDays(1)->getTimestamp() => 2,
-            ], "posts" => [
+            ], 'posts' => [
                 $timeStart->copy()->getTimestamp() => 2,
                 $timeStart->copy()->subDays(1)->getTimestamp() => 2,
             ]

--- a/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
@@ -17,7 +17,10 @@ class CanRequestCustomTimedStatisticsTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
 
-    protected Carbon $nowTime;
+    /**
+     * @var Carbon
+     */
+    protected $nowTime;
 
     protected function setUp(): void
     {

--- a/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
@@ -17,7 +17,10 @@ class CanRequestLifetimeStatisticsTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
 
-    protected Carbon $nowTime;
+    /**
+     * @var Carbon
+     */
+    protected $nowTime;
 
     protected function setUp(): void
     {

--- a/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
@@ -46,7 +53,7 @@ class CanRequestLifetimeStatisticsTest extends TestCase
         ];
     }
 
-    /** 
+    /**
      * @test
      */
     public function can_request_lifetime_stats()

--- a/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Flarum\Statistics\tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class CanRequestLifetimeStatisticsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected Carbon $nowTime;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nowTime = Carbon::now();
+
+        $this->extension('flarum-statistics');
+
+        $this->prepareDatabase($this->getDatabaseData());
+    }
+
+    protected function getDatabaseData(): array
+    {
+        return [
+            'users' => [
+                ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->subDays(1)],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => $this->nowTime, 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 2, 'title' => __CLASS__, 'created_at' => $this->nowTime->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 4, 'title' => __CLASS__, 'created_at' => $this->nowTime->subDays(2), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1],
+                ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1],
+                ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1],
+                ['id' => 4, 'discussion_id' => 4, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1],
+                ['id' => 5, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 2],
+            ],
+        ];
+    }
+
+    /** 
+     * @test
+     */
+    public function can_request_lifetime_stats()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/statistics', ['authenticatedAs' => 1])->withQueryParams([
+                'period' => 'lifetime',
+            ])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $db = $this->getDatabaseData();
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertEqualsCanonicalizing(
+            [
+                'users' => count($db['users']),
+                'discussions' => count($db['discussions']),
+                'posts' => count($db['posts']),
+            ],
+            $body
+        );
+    }
+}

--- a/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
@@ -46,7 +53,7 @@ class CanRequestTimedStatisticsTest extends TestCase
         ];
     }
 
-    /** 
+    /**
      * @test
      */
     public function can_request_timed_stats()
@@ -55,14 +62,14 @@ class CanRequestTimedStatisticsTest extends TestCase
         $time->setTime(0, 0, 0, 0);
 
         $models = [
-            "users" => [
+            'users' => [
                 $time->copy()->getTimestamp() => 1,
                 $time->copy()->subDays(1)->getTimestamp() => 1,
-            ], "discussions" => [
+            ], 'discussions' => [
                 $time->copy()->getTimestamp() => 1,
                 $time->copy()->subDays(1)->getTimestamp() => 2,
                 $time->copy()->subDays(2)->getTimestamp() => 1,
-            ], "posts" => [
+            ], 'posts' => [
                 $time->copy()->getTimestamp() => 2,
                 $time->copy()->subDays(1)->getTimestamp() => 2,
                 $time->copy()->subDays(2)->getTimestamp() => 1,

--- a/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Flarum\Statistics\tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class CanRequestTimedStatisticsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected Carbon $nowTime;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nowTime = Carbon::now()->subDays(10);
+
+        $this->extension('flarum-statistics');
+
+        $this->prepareDatabase($this->getDatabaseData());
+    }
+
+    protected function getDatabaseData(): array
+    {
+        return [
+            'users' => [
+                ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()],
+                ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()->subDays(1)],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 2, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 4, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(2), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()],
+                ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],
+                ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],
+                ['id' => 4, 'discussion_id' => 4, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(2)],
+                ['id' => 5, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 2, 'created_at' => $this->nowTime->copy()],
+            ],
+        ];
+    }
+
+    /** 
+     * @test
+     */
+    public function can_request_timed_stats()
+    {
+        $time = $this->nowTime->copy();
+        $time->setTime(0, 0, 0, 0);
+
+        $models = [
+            "users" => [
+                $time->copy()->getTimestamp() => 1,
+                $time->copy()->subDays(1)->getTimestamp() => 1,
+            ], "discussions" => [
+                $time->copy()->getTimestamp() => 1,
+                $time->copy()->subDays(1)->getTimestamp() => 2,
+                $time->copy()->subDays(2)->getTimestamp() => 1,
+            ], "posts" => [
+                $time->copy()->getTimestamp() => 2,
+                $time->copy()->subDays(1)->getTimestamp() => 2,
+                $time->copy()->subDays(2)->getTimestamp() => 1,
+            ]
+        ];
+
+        foreach ($models as $model => $data) {
+            $response = $this->send(
+                $this->request('GET', '/api/statistics', ['authenticatedAs' => 1])->withQueryParams([
+                    'model' => $model,
+                ])
+            );
+
+            $body = json_decode($response->getBody()->getContents(), true);
+
+            $this->assertEquals(200, $response->getStatusCode());
+
+            $this->assertEqualsCanonicalizing(
+                $data,
+                $body
+            );
+        }
+    }
+}

--- a/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
@@ -17,7 +17,10 @@ class CanRequestTimedStatisticsTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
 
-    protected Carbon $nowTime;
+    /**
+     * @var Carbon
+     */
+    protected $nowTime;
 
     protected function setUp(): void
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,11 +1739,6 @@ dayjs@^1.10.4, dayjs@^1.10.7:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.8.tgz#267df4bc6276fcb33c04a6735287e3f429abec41"
   integrity sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==
 
-dayjs@^1.11.5:
-  version "1.11.5"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
-  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
-
 debug@^4.1.0, debug@^4.1.1:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,6 +1739,11 @@ dayjs@^1.10.4, dayjs@^1.10.7:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.8.tgz#267df4bc6276fcb33c04a6735287e3f429abec41"
   integrity sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==
 
+dayjs@^1.11.5:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
+
 debug@^4.1.0, debug@^4.1.1:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- add option to choose a custom date range for the statistics widget
- add integration tests for statistics data api requests

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

