### PR TITLE
fix: add missing `offline` config when install fresh Flarum

### DIFF
--- a/framework/core/src/Install/Console/FileDataProvider.php
+++ b/framework/core/src/Install/Console/FileDataProvider.php
@@ -20,6 +20,7 @@ use Symfony\Component\Yaml\Yaml;
 class FileDataProvider implements DataProviderInterface
 {
     protected $debug = false;
+    protected $offline = false;
     protected $baseUrl = null;
     protected $databaseConfiguration = [];
     protected $adminUser = [];
@@ -44,6 +45,7 @@ class FileDataProvider implements DataProviderInterface
 
             // Define configuration variables
             $this->debug = $configuration['debug'] ?? false;
+            $this->offline = $configuration['offline'] ?? false;
             $this->baseUrl = $configuration['baseUrl'] ?? 'http://flarum.localhost';
             $this->databaseConfiguration = $configuration['databaseConfiguration'] ?? [];
             $this->adminUser = $configuration['adminUser'] ?? [];
@@ -57,6 +59,7 @@ class FileDataProvider implements DataProviderInterface
     {
         return $installation
             ->debugMode($this->debug)
+            ->offlineMode($this->offline)
             ->baseUrl(BaseUrl::fromString($this->baseUrl))
             ->databaseConfig($this->getDatabaseConfiguration())
             ->adminUser($this->getAdminUser())

--- a/framework/core/src/Install/Console/UserDataProvider.php
+++ b/framework/core/src/Install/Console/UserDataProvider.php
@@ -41,6 +41,7 @@ class UserDataProvider implements DataProviderInterface
     {
         return $installation
             ->debugMode(false)
+            ->offlineMode(false)
             ->baseUrl($this->getBaseUrl())
             ->databaseConfig($this->getDatabaseConfiguration())
             ->adminUser($this->getAdminUser())

--- a/framework/core/src/Install/Installation.php
+++ b/framework/core/src/Install/Installation.php
@@ -61,7 +61,7 @@ class Installation
 
     public function offlineMode($flag)
     {
-        $this->offlinee = $flag;
+        $this->offline = $flag;
 
         return $this;
     }

--- a/framework/core/src/Install/Installation.php
+++ b/framework/core/src/Install/Installation.php
@@ -20,6 +20,7 @@ class Installation
 
     private $configPath;
     private $debug = false;
+    private $offline = false;
     private $baseUrl;
     private $customSettings = [];
     private $enabledExtensions = null;
@@ -54,6 +55,13 @@ class Installation
     public function debugMode($flag)
     {
         $this->debug = $flag;
+
+        return $this;
+    }
+
+    public function offlineMode($flag)
+    {
+        $this->offlinee = $flag;
 
         return $this;
     }
@@ -137,6 +145,7 @@ class Installation
         $pipeline->pipe(function () {
             return new Steps\StoreConfig(
                 $this->debug,
+                $this->offline,
                 $this->dbConfig,
                 $this->baseUrl,
                 $this->getConfigPath()

--- a/framework/core/src/Install/Steps/StoreConfig.php
+++ b/framework/core/src/Install/Steps/StoreConfig.php
@@ -18,15 +18,18 @@ class StoreConfig implements Step, ReversibleStep
 {
     private $debugMode;
 
+    private $offlineMode;
+
     private $dbConfig;
 
     private $baseUrl;
 
     private $configFile;
 
-    public function __construct($debugMode, DatabaseConfig $dbConfig, BaseUrl $baseUrl, $configFile)
+    public function __construct($debugMode, $offlineMode, DatabaseConfig $dbConfig, BaseUrl $baseUrl, $configFile)
     {
         $this->debugMode = $debugMode;
+        $this->offlineMode = $offlineMode;
         $this->dbConfig = $dbConfig;
         $this->baseUrl = $baseUrl;
 
@@ -55,6 +58,7 @@ class StoreConfig implements Step, ReversibleStep
     {
         return [
             'debug'    => $this->debugMode,
+            'offline'    => $this->offlineMode,
             'database' => $this->dbConfig->toArray(),
             'url'      => (string) $this->baseUrl,
             'paths'    => $this->getPathsConfig(),

--- a/php-packages/testing/src/integration/Setup/SetupScript.php
+++ b/php-packages/testing/src/integration/Setup/SetupScript.php
@@ -117,6 +117,7 @@ class SetupScript
         $pipeline = $installation
             ->configPath('config.php')
             ->debugMode(true)
+            ->offlineMode(false)
             ->baseUrl(BaseUrl::fromString('http://localhost'))
             ->databaseConfig($this->dbConfig)
             ->adminUser(new AdminUser(


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
On the doc page https://docs.flarum.org/config/ it mentions `offline` option but currently in core there is no such option when fresh install Flarum.

So this PR adds `offline` configuration option when fresh install Flarum.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
