### PR TITLE
chore: don't pass password field between auth modals

### DIFF
--- a/framework/core/js/src/forum/components/LogInModal.tsx
+++ b/framework/core/js/src/forum/components/LogInModal.tsx
@@ -184,7 +184,7 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
   onerror(error: RequestError) {
     if (error.status === 401 && error.alert) {
       error.alert.content = app.translator.trans('core.forum.log_in.invalid_login_message');
-      this.password("");
+      this.password('');
     }
 
     super.onerror(error);

--- a/framework/core/js/src/forum/components/LogInModal.tsx
+++ b/framework/core/js/src/forum/components/LogInModal.tsx
@@ -158,7 +158,6 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
 
     const attrs = {
       [identification.includes('@') ? 'email' : 'username']: identification,
-      password: this.password(),
     };
 
     app.modal.show(SignUpModal, attrs);

--- a/framework/core/js/src/forum/components/LogInModal.tsx
+++ b/framework/core/js/src/forum/components/LogInModal.tsx
@@ -184,6 +184,7 @@ export default class LogInModal<CustomAttrs extends ILoginModalAttrs = ILoginMod
   onerror(error: RequestError) {
     if (error.status === 401 && error.alert) {
       error.alert.content = app.translator.trans('core.forum.log_in.invalid_login_message');
+      this.password("");
     }
 
     super.onerror(error);

--- a/framework/core/js/src/forum/components/SignUpModal.tsx
+++ b/framework/core/js/src/forum/components/SignUpModal.tsx
@@ -149,7 +149,6 @@ export default class SignUpModal<CustomAttrs extends ISignupModalAttrs = ISignup
   logIn() {
     const attrs = {
       identification: this.email() || this.username(),
-      password: this.password(),
     };
 
     app.modal.show(LogInModal, attrs);


### PR DESCRIPTION
**Changes proposed in this pull request:**
This avoids potential security issues and user confusion. Also resets the password field on failed attempts.

**Reviewers should focus on:**
I don't believe resetting on failed attempts matters all that much though.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.