### PR TITLE
feat: increase margin between notifications list control icons

### DIFF
--- a/framework/core/less/forum/NotificationList.less
+++ b/framework/core/less/forum/NotificationList.less
@@ -2,7 +2,7 @@
   overflow: hidden;
 
   .App-primaryControl > button:not(:last-of-type) {
-    margin-right: 8px;
+    margin-right: 12px;
   }
 
   &-header {

--- a/framework/core/less/forum/NotificationList.less
+++ b/framework/core/less/forum/NotificationList.less
@@ -2,7 +2,7 @@
   overflow: hidden;
 
   .App-primaryControl > button:not(:last-of-type) {
-    margin-right: 4px;
+    margin-right: 8px;
   }
 
   &-header {


### PR DESCRIPTION
This feels cleaner, and reduces the chances of a misclick.

**Changes proposed in this pull request:**
Increase button margin

**Reviewers should focus on:**
This leaves slightly less room for other buttons, but the difference is very minor, while the benefits outweigh IMO.

**Screenshot**
Before:
![image](https://user-images.githubusercontent.com/38059171/188608551-cb6d4320-3e35-47fa-83d8-de36ff3388a8.png)

After:
![image](https://user-images.githubusercontent.com/38059171/188608601-51a954ab-c99e-47ec-b137-626f95202aeb.png)



**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

