### PR TITLE
fix: email notifications are sent when unconfirmed

### DIFF
--- a/framework/core/src/Notification/Driver/EmailNotificationDriver.php
+++ b/framework/core/src/Notification/Driver/EmailNotificationDriver.php
@@ -47,7 +47,7 @@ class EmailNotificationDriver implements NotificationDriverInterface
     protected function mailNotifications(MailableInterface $blueprint, array $recipients)
     {
         foreach ($recipients as $user) {
-            if ($user->shouldEmail($blueprint::getType())) {
+            if ($user->is_email_confirmed && $user->shouldEmail($blueprint::getType())) {
                 $this->queue->push(new SendEmailNotificationJob($blueprint, $user));
             }
         }


### PR DESCRIPTION
This fixes an issue with Flarum where users are getting notified through email, even though they haven't confirmed their email address. On discuss we have seen flags from sendgrid where mails have become undeliverable, my process is to mark these users as not having confirmed their email address hoping this prevents them from getting notified. It does not.

Does this solution suffice?

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
