### PR TITLE
Make it possible to extend SetupScript

### DIFF
--- a/php-packages/testing/src/integration/Setup/SetupScript.php
+++ b/php-packages/testing/src/integration/Setup/SetupScript.php
@@ -66,7 +66,19 @@ class SetupScript
     /**
      * @var DatabaseConfig
      */
-    private $dbConfig;
+    protected $dbConfig;
+
+    /**
+     * Settings to be applied during installation.
+     * @var array
+     */
+    protected $settings = ['mail_driver' => 'log'];
+
+    /**
+     * Extensions to activate.
+     * @var array
+     */
+    protected $extensions = [];
 
     public function __construct()
     {
@@ -124,8 +136,8 @@ class SetupScript
                 'password',
                 'admin@machine.local'
             ))
-            ->settings(['mail_driver' => 'log'])
-            ->extensions([])
+            ->settings($this->settings)
+            ->extensions($this->extensions)
             ->build();
 
         // Run the actual configuration
@@ -144,5 +156,19 @@ class SetupScript
             $builder->dropAllTables();
             $builder->dropAllViews();
         }))->run();
+    }
+
+    public function addSettings(array $settings): static
+    {
+        $this->settings = array_merge($this->settings, $settings);
+
+        return $this;
+    }
+
+    public function addExtensions(array $extensions): static
+    {
+        $this->extensions = array_merge($this->extensions, $extensions);
+
+        return $this;
     }
 }

--- a/php-packages/testing/src/integration/Setup/SetupScript.php
+++ b/php-packages/testing/src/integration/Setup/SetupScript.php
@@ -158,14 +158,14 @@ class SetupScript
         }))->run();
     }
 
-    public function addSettings(array $settings): static
+    public function addSettings(array $settings): self
     {
         $this->settings = array_merge($this->settings, $settings);
 
         return $this;
     }
 
-    public function addExtensions(array $extensions): static
+    public function addExtensions(array $extensions): self
     {
         $this->extensions = array_merge($this->extensions, $extensions);
 

--- a/php-packages/testing/src/integration/Setup/SetupScript.php
+++ b/php-packages/testing/src/integration/Setup/SetupScript.php
@@ -74,12 +74,6 @@ class SetupScript
      */
     protected $settings = ['mail_driver' => 'log'];
 
-    /**
-     * Extensions to activate.
-     * @var array
-     */
-    protected $extensions = [];
-
     public function __construct()
     {
         $this->host = getenv('DB_HOST') ?: 'localhost';
@@ -137,7 +131,7 @@ class SetupScript
                 'admin@machine.local'
             ))
             ->settings($this->settings)
-            ->extensions($this->extensions)
+            ->extensions([])
             ->build();
 
         // Run the actual configuration
@@ -158,16 +152,18 @@ class SetupScript
         }))->run();
     }
 
+    /**
+     * Can be used to add settings to the Flarum installation.
+     * Use this only when it is really needed.
+     * This can be useful in rare cases where the settings are required to be set
+     * already when extensions Extenders are executed. In those cases, setting the
+     * settings with the `setting()` method of the `TestCase` will not work.
+     *
+     * @param string $settings (key => value)
+     */
     public function addSettings(array $settings): self
     {
         $this->settings = array_merge($this->settings, $settings);
-
-        return $this;
-    }
-
-    public function addExtensions(array $extensions): self
-    {
-        $this->extensions = array_merge($this->extensions, $extensions);
 
         return $this;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**

Make it possible to extend `Flarum\Testing\integration\Setup\SetupScript` and added a public method to add settings to the initial installation pipeline.

New usage example:

```php
(new SetupScript())
    ->addSettings([...])
    ->run();
```

As documented, the new method can be used to add settings to the Flarum installation.
Should be used only when it is really needed.
This can be useful in rare cases where the settings are required to be set already when extensions Extenders are executed. In those cases, setting the settings with the `setting()` method of the `TestCase` will not work.


**Reviewers should focus on:**
The new methods work and don't break any existing code.


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
