### PR TITLE
fix: package manager failures not showing alerts

### DIFF
--- a/extensions/package-manager/js/src/admin/components/Installer.tsx
+++ b/extensions/package-manager/js/src/admin/components/Installer.tsx
@@ -64,7 +64,6 @@ export default class Installer extends Component<InstallerAttrs> {
         body: {
           data: this.data(),
         },
-        errorHandler,
       })
       .then((response) => {
         if (response.processing) {
@@ -79,12 +78,7 @@ export default class Installer extends Component<InstallerAttrs> {
           window.location.reload();
         }
       })
-      .catch((e) => {
-        if (e.status === 422) {
-          app.alerts.clear();
-          app.alerts.show({ type: 'error' }, e.response.errors[0].detail);
-        }
-      })
+      .catch(errorHandler)
       .finally(() => {
         app.packageManager.control.setLoading(null);
         app.modal.close();

--- a/extensions/package-manager/js/src/admin/components/Installer.tsx
+++ b/extensions/package-manager/js/src/admin/components/Installer.tsx
@@ -79,6 +79,12 @@ export default class Installer extends Component<InstallerAttrs> {
           window.location.reload();
         }
       })
+      .catch((e) => {
+        if (e.status === 422) {
+          app.alerts.clear();
+          app.alerts.show({ type: 'error' }, e.response.errors[0].detail);
+        }
+      })
       .finally(() => {
         app.packageManager.control.setLoading(null);
         app.modal.close();

--- a/extensions/package-manager/js/src/admin/components/Installer.tsx
+++ b/extensions/package-manager/js/src/admin/components/Installer.tsx
@@ -81,6 +81,7 @@ export default class Installer extends Component<InstallerAttrs> {
       })
       .finally(() => {
         app.packageManager.control.setLoading(null);
+        app.modal.close();
         m.redraw();
       });
   }

--- a/extensions/package-manager/js/src/admin/components/MajorUpdater.tsx
+++ b/extensions/package-manager/js/src/admin/components/MajorUpdater.tsx
@@ -104,7 +104,6 @@ export default class MajorUpdater<T extends MajorUpdaterAttrs = MajorUpdaterAttr
         body: {
           data: { dryRun },
         },
-        errorHandler,
       })
       .then((response) => {
         if (response?.processing) {
@@ -114,6 +113,7 @@ export default class MajorUpdater<T extends MajorUpdaterAttrs = MajorUpdaterAttr
           window.location.reload();
         }
       })
+      .catch(errorHandler)
       .catch((e: RequestError) => {
         app.modal.close();
         this.updateState.status = 'failure';

--- a/extensions/package-manager/js/src/admin/components/WhyNotModal.tsx
+++ b/extensions/package-manager/js/src/admin/components/WhyNotModal.tsx
@@ -47,12 +47,12 @@ export default class WhyNotModal<CustomAttrs extends WhyNotModalAttrs = WhyNotMo
             package: this.attrs.package,
           },
         },
-        errorHandler,
       })
       .then((response) => {
         this.loading = false;
         this.whyNot = response.data.reason;
         m.redraw();
-      });
+      })
+      .catch(errorHandler);
   }
 }

--- a/extensions/package-manager/js/src/admin/states/ControlSectionState.ts
+++ b/extensions/package-manager/js/src/admin/states/ControlSectionState.ts
@@ -94,7 +94,6 @@ export default class ControlSectionState {
       .request<AsyncBackendResponse | LastUpdateCheck>({
         method: 'POST',
         url: `${app.forum.attribute('apiUrl')}/package-manager/check-for-updates`,
-        errorHandler,
       })
       .then((response) => {
         if ((response as AsyncBackendResponse).processing) {
@@ -106,6 +105,7 @@ export default class ControlSectionState {
           m.redraw();
         }
       })
+      .catch(errorHandler)
       .finally(() => {
         this.setLoading(null);
         m.redraw();
@@ -121,7 +121,6 @@ export default class ControlSectionState {
         .request<AsyncBackendResponse | null>({
           method: 'POST',
           url: `${app.forum.attribute('apiUrl')}/package-manager/minor-update`,
-          errorHandler,
         })
         .then((response) => {
           if (response?.processing) {
@@ -131,6 +130,7 @@ export default class ControlSectionState {
             window.location.reload();
           }
         })
+        .catch(errorHandler)
         .finally(() => {
           this.setLoading(null);
           app.modal.close();
@@ -147,7 +147,6 @@ export default class ControlSectionState {
       .request<AsyncBackendResponse | null>({
         method: 'PATCH',
         url: `${app.forum.attribute('apiUrl')}/package-manager/extensions/${extension.id}`,
-        errorHandler,
       })
       .then((response) => {
         if (response?.processing) {
@@ -162,6 +161,7 @@ export default class ControlSectionState {
           window.location.reload();
         }
       })
+      .catch(errorHandler)
       .finally(() => {
         this.setLoading(null);
         app.modal.close();
@@ -177,7 +177,6 @@ export default class ControlSectionState {
       .request<AsyncBackendResponse | null>({
         method: 'POST',
         url: `${app.forum.attribute('apiUrl')}/package-manager/global-update`,
-        errorHandler,
       })
       .then((response) => {
         if (response?.processing) {
@@ -187,6 +186,7 @@ export default class ControlSectionState {
           window.location.reload();
         }
       })
+      .catch(errorHandler)
       .finally(() => {
         this.setLoading(null);
         app.modal.close();


### PR DESCRIPTION
`LoadingModal` LoadingModal is not closed when the installation fails

![Screenshot 2022-09-17 at 19 11 18](https://user-images.githubusercontent.com/56961917/190856054-f9e381a3-790e-459c-9326-f004a7840d7c.png)

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
