### PR TITLE
feat: replace `ColorPreviewInput` for GroupModal color input

### DIFF
--- a/framework/core/js/src/admin/components/EditGroupModal.tsx
+++ b/framework/core/js/src/admin/components/EditGroupModal.tsx
@@ -8,6 +8,7 @@ import Switch from '../../common/components/Switch';
 import Stream from '../../common/utils/Stream';
 import Mithril from 'mithril';
 import extractText from '../../common/utils/extractText';
+import ColorPreviewInput from '../../common/components/ColorPreviewInput';
 
 export interface IEditGroupModalAttrs extends IInternalModalAttrs {
   group?: Group;
@@ -81,7 +82,7 @@ export default class EditGroupModal<CustomAttrs extends IEditGroupModalAttrs = I
       'color',
       <div className="Form-group">
         <label>{app.translator.trans('core.admin.edit_group.color_label')}</label>
-        <input className="FormControl" placeholder="#aaaaaa" bidi={this.color} />
+        <ColorPreviewInput placeholder="#aaaaaa" bidi={this.color} />
       </div>,
       20
     );


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
- Replace text input with `ColorPreviewInput` to make it easier to choose colors.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
![Screenshot 2022-09-23 at 21 59 03](https://user-images.githubusercontent.com/56961917/191991900-3081f34c-181c-4356-821b-59213e1ec278.png)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
