### PR TITLE
fix: apply flex for AppearancePage colors input

### DIFF
--- a/framework/core/less/admin/AppearancePage.less
+++ b/framework/core/less/admin/AppearancePage.less
@@ -13,6 +13,7 @@
   }
 }
 .AppearancePage-colors-input {
+  display: flex;
   overflow: hidden;
 
   .Form-group {


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
- Colors input on mobile is broken, apply flex to fix this

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**

Before:
![Screenshot 2022-09-24 at 12 09 04](https://user-images.githubusercontent.com/56961917/192081019-5d30a56f-8a54-4350-8d03-26ca87196701.png)

After:
![Screenshot 2022-09-24 at 12 08 49](https://user-images.githubusercontent.com/56961917/192081010-f0bd5ab1-be8f-4fe2-823b-8fb7ae4e9304.png)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
