### PR TITLE
fix: statistics previous period chart is unclear

### DIFF
--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -17,12 +17,11 @@ import type Mithril from 'mithril';
 import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 import dayjsLocalizedFormat from 'dayjs/plugin/localizedFormat';
+// @ts-expect-error No typings available
+import { Chart } from 'frappe-charts';
 
 dayjs.extend(dayjsUtc);
 dayjs.extend(dayjsLocalizedFormat);
-
-// @ts-expect-error No typings available
-import { Chart } from 'frappe-charts';
 
 interface IPeriodDeclaration {
   start: number;
@@ -374,7 +373,16 @@ export default class StatisticsWidget extends DashboardWidget {
       m.redraw();
     }
 
-    const datasets = [{ values: lastPeriod }, { values: thisPeriod }];
+    const datasets = [
+      {
+        name: extractText(app.translator.trans('flarum-statistics.admin.statistics.current_period')),
+        values: thisPeriod,
+      },
+      {
+        name: extractText(app.translator.trans('flarum-statistics.admin.statistics.previous_period')),
+        values: lastPeriod,
+      },
+    ];
     const data = {
       labels,
       datasets,
@@ -394,8 +402,9 @@ export default class StatisticsWidget extends DashboardWidget {
         },
         lineOptions: {
           hideDots: 1,
+          regionFill: 1,
         },
-        colors: ['black', app.forum.attribute('themePrimaryColor')],
+        colors: [app.forum.attribute('themePrimaryColor'), 'black'],
       });
     } else {
       this.chart.update(data);

--- a/extensions/statistics/less/admin.less
+++ b/extensions/statistics/less/admin.less
@@ -93,14 +93,10 @@
   }
 
   .chart-container {
-    .dataset-0 {
+    .dataset-1 {
       opacity: 0.2;
     }
     .chart-legend {
-      display: none;
-    }
-    // Hide the "last period" data from the tooltip
-    .graph-svg-tip ul.data-point-list > li:first-child {
       display: none;
     }
   }
@@ -198,6 +194,10 @@
       min-width: 90px;
       flex: 1;
       font-weight: 600;
+
+      &:nth-child(2) {
+        border-top-color: #5a5a5a !important;
+      }
     }
   }
   strong {

--- a/extensions/statistics/locale/en.yml
+++ b/extensions/statistics/locale/en.yml
@@ -35,3 +35,5 @@ flarum-statistics:
       users_heading: => core.ref.users
       view_full: View more statistics
       no_data: There is no data available for this date range.
+      current_period: Current period
+      previous_period: Previous period


### PR DESCRIPTION
**Fixes #3604**

**Changes proposed in this pull request:**
Improves the statistics chart to be more clear on what the grey line is by adding the name of the line along with the values (Screenshot below).

**Reviewers should focus on:**
I sneaked in a `regionFill` for a slight design change 👀 

**Screenshot**
Before | After
-- | --
![Screenshot from 2022-10-02 13-13-22](https://user-images.githubusercontent.com/20267363/193453443-d3d2e05a-f09b-412b-af02-c34b2f159ede.png) | ![Screenshot from 2022-10-02 13-11-08](https://user-images.githubusercontent.com/20267363/193453448-3fdafc0a-7b32-467c-8858-1421e6f3e3f1.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.