### PR TITLE
feat: allow specifying extensions when installing an instance

### DIFF
--- a/framework/core/src/Extension/Extension.php
+++ b/framework/core/src/Extension/Extension.php
@@ -211,7 +211,7 @@ class Extension implements Arrayable
     /**
      * Get the list of flarum extensions that this extension depends on.
      *
-     * @param array $extensionSet: An associative array where keys are the composer package names
+     * @param array<string, mixed> $extensionSet: An associative array where keys are the composer package names
      *                             of installed extensions. Used to figure out which dependencies
      *                             are flarum extensions.
      * @internal

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -441,11 +441,12 @@ class ExtensionManager
      *
      * @param Extension[] $extensionList
      *
-     * @return array with 2 keys: 'valid' points to an ordered array of \Flarum\Extension\Extension
-     *                            'missingDependencies' points to an associative array of extensions that could not be resolved due
-     *                                to missing dependencies, in the format extension id => array of missing dependency IDs.
-     *                            'circularDependencies' points to an array of extensions ids of extensions
-     *                                that cannot be processed due to circular dependencies
+     * @return array{valid: Extension[], missingDependencies: array<string, string[]>, circularDependencies: string[]}
+     *      'valid' points to an ordered array of \Flarum\Extension\Extension
+     *      'missingDependencies' points to an associative array of extensions that could not be resolved due
+     *          to missing dependencies, in the format extension id => array of missing dependency IDs.
+     *      'circularDependencies' points to an array of extensions ids of extensions
+     *          that cannot be processed due to circular dependencies
      *
      * @internal
      */
@@ -471,6 +472,7 @@ class ExtensionManager
             $extensionIdMapping[$extension->getId()] = $extension;
         }
 
+        /** @var Extension $extension */
         foreach ($extensionList as $extension) {
             $optionalDependencies = array_filter($extension->getOptionalDependencyIds(), function ($id) use ($extensionIdMapping) {
                 return array_key_exists($id, $extensionIdMapping);

--- a/framework/core/src/Install/Console/FileDataProvider.php
+++ b/framework/core/src/Install/Console/FileDataProvider.php
@@ -24,6 +24,7 @@ class FileDataProvider implements DataProviderInterface
     protected $databaseConfiguration = [];
     protected $adminUser = [];
     protected $settings = [];
+    protected $extensions = [];
 
     public function __construct(InputInterface $input)
     {
@@ -48,6 +49,7 @@ class FileDataProvider implements DataProviderInterface
             $this->databaseConfiguration = $configuration['databaseConfiguration'] ?? [];
             $this->adminUser = $configuration['adminUser'] ?? [];
             $this->settings = $configuration['settings'] ?? [];
+            $this->extensions = explode(',', $configuration['extensions'] ?? '');
         } else {
             throw new Exception('Configuration file does not exist.');
         }
@@ -60,7 +62,8 @@ class FileDataProvider implements DataProviderInterface
             ->baseUrl(BaseUrl::fromString($this->baseUrl))
             ->databaseConfig($this->getDatabaseConfiguration())
             ->adminUser($this->getAdminUser())
-            ->settings($this->settings);
+            ->settings($this->settings)
+            ->extensions($this->extensions);
     }
 
     private function getDatabaseConfiguration(): DatabaseConfig

--- a/framework/core/src/Install/Steps/EnableBundledExtensions.php
+++ b/framework/core/src/Install/Steps/EnableBundledExtensions.php
@@ -12,6 +12,7 @@ namespace Flarum\Install\Steps;
 use Flarum\Database\DatabaseMigrationRepository;
 use Flarum\Database\Migrator;
 use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
 use Flarum\Install\Step;
 use Flarum\Settings\DatabaseSettingsRepository;
 use Illuminate\Database\ConnectionInterface;
@@ -80,7 +81,7 @@ class EnableBundledExtensions implements Step
 
     public function run()
     {
-        $extensions = $this->loadExtensions();
+        $extensions = ExtensionManager::resolveExtensionOrder($this->loadExtensions()->all())['valid'];
 
         foreach ($extensions as $extension) {
             $extension->migrate($this->getMigrator());
@@ -89,14 +90,15 @@ class EnableBundledExtensions implements Step
             );
         }
 
-        (new DatabaseSettingsRepository($this->database))->set(
-            'extensions_enabled',
-            $extensions->keys()->toJson()
-        );
+        $extensionNames = json_encode(array_map(function (Extension $extension) {
+            return $extension->getId();
+        }, $extensions));
+
+        (new DatabaseSettingsRepository($this->database))->set('extensions_enabled', $extensionNames);
     }
 
     /**
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<Extension>
      */
     private function loadExtensions()
     {
@@ -106,7 +108,7 @@ class EnableBundledExtensions implements Step
         // Composer 2.0 changes the structure of the installed.json manifest
         $installed = $installed['packages'] ?? $installed;
 
-        return (new Collection($installed))
+        $installedExtensions = (new Collection($installed))
             ->filter(function ($package) {
                 return Arr::get($package, 'type') == 'flarum-extension';
             })->filter(function ($package) {
@@ -120,13 +122,19 @@ class EnableBundledExtensions implements Step
                 $extension->setVersion(Arr::get($package, 'version'));
 
                 return $extension;
-            })->filter(function (Extension $extension) {
-                return in_array($extension->getId(), $this->enabledExtensions);
-            })->sortBy(function (Extension $extension) {
-                return $extension->getTitle();
             })->mapWithKeys(function (Extension $extension) {
-                return [$extension->getId() => $extension];
+                return [$extension->name => $extension];
             });
+
+        return $installedExtensions->filter(function (Extension $extension) {
+            return in_array($extension->getId(), $this->enabledExtensions);
+        })->map(function (Extension $extension) use ($installedExtensions) {
+            $extension->calculateDependencies($installedExtensions->map(function () {
+                return true;
+            })->toArray());
+
+            return $extension;
+        });
     }
 
     private function getMigrator(): Migrator


### PR DESCRIPTION
**Changes proposed in this pull request:**
Useful when doing migrations when more than the default extensions are required to migrate the data to flarum. This allows quickly spinning up a flarum database with the necessary schema.

This use case was also raised by the work being done in https://github.com/linc/nitro-porter

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.