### PR TITLE
feat: send notifications of a new reply when post is approved

### DIFF
--- a/extensions/approval/extend.php
+++ b/extensions/approval/extend.php
@@ -10,6 +10,7 @@
 use Flarum\Api\Serializer\BasicDiscussionSerializer;
 use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Approval\Access;
+use Flarum\Approval\Event\PostWasApproved;
 use Flarum\Approval\Listener;
 use Flarum\Discussion\Discussion;
 use Flarum\Extend;
@@ -48,6 +49,7 @@ return [
     new Extend\Locales(__DIR__.'/locale'),
 
     (new Extend\Event())
+        ->listen(PostWasApproved::class, Listener\UpdateDiscussionAfterPostApproval::class)
         ->subscribe(Listener\ApproveContent::class)
         ->subscribe(Listener\UnapproveNewContent::class),
 

--- a/extensions/approval/src/Listener/ApproveContent.php
+++ b/extensions/approval/src/Listener/ApproveContent.php
@@ -21,12 +21,8 @@ class ApproveContent
     public function subscribe(Dispatcher $events)
     {
         $events->listen(Saving::class, [$this, 'approvePost']);
-        $events->listen(PostWasApproved::class, [$this, 'approveDiscussion']);
     }
 
-    /**
-     * @param Saving $event
-     */
     public function approvePost(Saving $event)
     {
         $attributes = $event->data['attributes'];
@@ -44,34 +40,6 @@ class ApproveContent
             $post->is_approved = true;
 
             $post->raise(new PostWasApproved($post, $event->actor));
-        }
-    }
-
-    /**
-     * @param PostWasApproved $event
-     */
-    public function approveDiscussion(PostWasApproved $event)
-    {
-        $post = $event->post;
-        $discussion = $post->discussion;
-        $user = $discussion->user;
-
-        $discussion->refreshCommentCount();
-        $discussion->refreshLastPost();
-
-        if ($post->number == 1) {
-            $discussion->is_approved = true;
-
-            $discussion->afterSave(function () use ($user) {
-                $user->refreshDiscussionCount();
-            });
-        }
-
-        $discussion->save();
-
-        if ($discussion->user) {
-            $user->refreshCommentCount();
-            $user->save();
         }
     }
 }

--- a/extensions/approval/src/Listener/UpdateDiscussionAfterPostApproval.php
+++ b/extensions/approval/src/Listener/UpdateDiscussionAfterPostApproval.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Approval\Listener;
+
+use Flarum\Approval\Event\PostWasApproved;
+
+class UpdateDiscussionAfterPostApproval
+{
+    public function handle(PostWasApproved $event)
+    {
+        $post = $event->post;
+        $discussion = $post->discussion;
+        $user = $discussion->user;
+
+        $discussion->refreshCommentCount();
+        $discussion->refreshLastPost();
+
+        if ($post->number == 1) {
+            $discussion->is_approved = true;
+
+            $discussion->afterSave(function () use ($user) {
+                $user->refreshDiscussionCount();
+            });
+        }
+
+        $discussion->save();
+
+        if ($discussion->user) {
+            $user->refreshCommentCount();
+            $user->save();
+        }
+    }
+}

--- a/extensions/subscriptions/composer.json
+++ b/extensions/subscriptions/composer.json
@@ -33,6 +33,9 @@
         "flarum-extension": {
             "title": "Subscriptions",
             "category": "feature",
+            "optional-dependencies": [
+                "flarum/approval"
+            ],
             "icon": {
                 "name": "fas fa-star",
                 "backgroundColor": "#ffea7b",
@@ -86,6 +89,7 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^1.0.0"
+        "flarum/testing": "^1.0.0",
+        "flarum/approval": "@dev"
     }
 }

--- a/extensions/subscriptions/extend.php
+++ b/extensions/subscriptions/extend.php
@@ -9,6 +9,7 @@
 
 use Flarum\Api\Serializer\BasicDiscussionSerializer;
 use Flarum\Api\Serializer\DiscussionSerializer;
+use Flarum\Approval\Event\PostWasApproved;
 use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Event\Saving;
 use Flarum\Discussion\Filter\DiscussionFilterer;
@@ -50,6 +51,7 @@ return [
     (new Extend\Event())
         ->listen(Saving::class, Listener\SaveSubscriptionToDatabase::class)
         ->listen(Posted::class, Listener\SendNotificationWhenReplyIsPosted::class)
+        ->listen(PostWasApproved::class, Listener\SendNotificationWhenReplyIsPosted::class)
         ->listen(Hidden::class, Listener\DeleteNotificationWhenPostIsHiddenOrDeleted::class)
         ->listen(Restored::class, Listener\RestoreNotificationWhenPostIsRestored::class)
         ->listen(Deleted::class, Listener\DeleteNotificationWhenPostIsHiddenOrDeleted::class)

--- a/extensions/subscriptions/src/Listener/SendNotificationWhenReplyIsPosted.php
+++ b/extensions/subscriptions/src/Listener/SendNotificationWhenReplyIsPosted.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Subscriptions\Listener;
 
+use Flarum\Approval\Event\PostWasApproved;
 use Flarum\Post\Event\Posted;
 use Flarum\Subscriptions\Job\SendReplyNotification;
 use Illuminate\Contracts\Queue\Queue;
@@ -25,7 +26,11 @@ class SendNotificationWhenReplyIsPosted
         $this->queue = $queue;
     }
 
-    public function handle(Posted $event)
+    /**
+     * @param Posted|PostWasApproved $event
+     * @return void
+     */
+    public function handle($event)
     {
         $this->queue->push(
             new SendReplyNotification($event->post, $event->post->discussion->last_post_number)

--- a/extensions/subscriptions/tests/integration/api/discussions/ReplyNotificationTest.php
+++ b/extensions/subscriptions/tests/integration/api/discussions/ReplyNotificationTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Subscriptions\tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -220,5 +221,61 @@ class ReplyNotificationTest extends TestCase
             [[10, 9, 8]],
             [[8, 9, 10]]
         ];
+    }
+
+    /** @test */
+    public function approving_reply_sends_reply_notification()
+    {
+        // Flags was only specified because it is required for approval.
+        $this->extensions = ['flarum-flags', 'flarum-approval', 'flarum-subscriptions'];
+
+        $this->app();
+
+        $this->database()
+            ->table('group_permission')
+            ->where('group_id', Group::MEMBER_ID)
+            ->where('permission', 'discussion.replyWithoutApproval')
+            ->delete();
+
+        /** @var User $mainUser */
+        $mainUser = User::query()->find(2);
+
+        $this->assertEquals(0, $mainUser->getUnreadNotificationCount());
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 4,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => 'reply with predetermined content for automated testing - too-obscure',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 1]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(0, $mainUser->getUnreadNotificationCount());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        // Approve the previous post
+        $this->send(
+            $this->request('PATCH', '/api/posts/'.$json['data']['id'], [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'isApproved' => 1,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(1, $mainUser->getUnreadNotificationCount());
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Replies held for approval naturally don't send out notifications to users, however currently after a post has been approved users are still not notified that a reply has been posted.

This PR tweaks subscriptions to send notifications once a reply has been approved.

**Reviewers should focus on**
The code in approval was extracted into a listener because no matter what listeners are always executed before subscribers even if the extension is set to load before.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.