### PR TITLE
Fix tag discussion count decreased by 2 when hiding before deleting

### DIFF
--- a/extensions/tags/src/Listener/UpdateTagMetadata.php
+++ b/extensions/tags/src/Listener/UpdateTagMetadata.php
@@ -66,7 +66,9 @@ class UpdateTagMetadata
      */
     public function whenDiscussionIsDeleted(Deleted $event)
     {
-        $this->updateTags($event->discussion, -1);
+        // If already soft deleted when permanently deleted, the -1 delta has already been applied in Hidden listener
+        $delta = $event->discussion->hidden_at ? 0 : -1;
+        $this->updateTags($event->discussion, $delta);
 
         $event->discussion->tags()->detach();
     }


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Check whether the discussion deletion delta was already applied after discussion `Hidden` event before applying it again in `Deleted` event.

This issue was decreasing the discussion count for all tags that belong to the discussion by 2 when the discussion was hidden and then permanently deleted (which would be all of the time when using the web UI to delete discussions permanently). With this fix it will always decrease by one, either if you permanently delete in one go (via REST API) or soft delete and then delete via REST API or UI.

**Reviewers should focus on:**
I found other issues with the tag discussion count calculation, I'm already submitting this one since it's the easier to fix and I don't think there will be much debate on this particular change.

I feel like the long term solution is to drop the delta logic entirely and compute the new total via SQL queries which would be able to account for a lot more situations and auto-fix the count if it somehow gets wrong still. 

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
