### PR TITLE
[statistics] fix: add missing last period to custom date ranges

### DIFF
--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -336,7 +336,7 @@ export default class StatisticsWidget extends DashboardWidget {
           }
         : this.periods![this.selectedPeriod!];
     const periodLength = period.end - period.start;
-    const labels = [];
+    const labels: string[] = [];
     const thisPeriod = [];
     const lastPeriod = [];
 
@@ -361,7 +361,7 @@ export default class StatisticsWidget extends DashboardWidget {
       labels.push(label);
 
       thisPeriod.push(this.getPeriodCount(this.selectedEntity, { start: i, end: i + period.step }));
-      lastPeriod.push(this.getPeriodCount(this.selectedEntity, { start: i - periodLength, end: i - periodLength + period.step }));
+      lastPeriod.push(this.getPeriodCount(this.selectedEntity, { start: i - periodLength, end: i - periodLength }));
     }
 
     if (thisPeriod.length === 0) {

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -126,8 +126,15 @@ class ShowStatisticsData implements RequestHandlerInterface
 
     private function getTimedCounts(Builder $query, string $column, ?DateTime $startDate = null, ?DateTime $endDate = null)
     {
+        $diff = $startDate && $endDate ? $startDate->diff($endDate) : null;
+
         if (! isset($startDate)) {
-            $startDate = new DateTime('-365 days');
+            // need -12 months and period before that
+            $startDate = new DateTime('-2 years');
+        } else {
+            // If the start date is custom, we need to include an equal amount beforehand
+            // to show the data for the previous period.
+            $startDate = (new Carbon($startDate))->subtract($diff)->toDateTime();
         }
 
         if (! isset($endDate)) {

--- a/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
@@ -73,12 +73,15 @@ class CanRequestCustomTimedStatisticsTest extends TestCase
             'users' => [
                 $timeStart->copy()->getTimestamp() => 1,
                 $timeStart->copy()->subDays(1)->getTimestamp() => 1,
+                $timeStart->copy()->subDays(2)->getTimestamp() => 1,
             ], 'discussions' => [
                 $timeStart->copy()->getTimestamp() => 1,
                 $timeStart->copy()->subDays(1)->getTimestamp() => 2,
+                $timeStart->copy()->subDays(2)->getTimestamp() => 1,
             ], 'posts' => [
                 $timeStart->copy()->getTimestamp() => 2,
                 $timeStart->copy()->subDays(1)->getTimestamp() => 2,
+                $timeStart->copy()->subDays(2)->getTimestamp() => 1,
             ]
         ];
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

Fixes a bug introduced with #3622.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- adds support for "last period" for custom date ranges
- fix incorrect offset for previous date ranges

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

- N/A

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![](https://user-images.githubusercontent.com/7406822/198906324-767b8721-6812-4420-85b5-b9a1ab652fa5.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

