### PR TITLE
feat: add statistics chart export button

### DIFF
--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -318,6 +318,18 @@ export default class StatisticsWidget extends DashboardWidget {
         </>
 
         {this.noData && <Placeholder text={app.translator.trans(`flarum-statistics.admin.statistics.no_data`)} />}
+
+        {!this.noData && !!this.chart && (
+          <Button
+            className="StatisticsWidget-chartExport Button"
+            icon="fas fa-file-export"
+            onclick={() => {
+              this.chart.export();
+            }}
+          >
+            {app.translator.trans('flarum-statistics.admin.statistics.export_chart_button')}
+          </Button>
+        )}
       </div>
     );
   }

--- a/extensions/statistics/less/admin.less
+++ b/extensions/statistics/less/admin.less
@@ -109,6 +109,13 @@
   .Placeholder {
     padding-bottom: 32px;
   }
+
+  &-chartExport {
+    position: relative;
+    z-index: 1;
+    margin: 16px;
+    margin-top: -32px;
+  }
 }
 
 /*!
@@ -119,9 +126,9 @@
   position: relative; /* for absolutely positioned tooltip */
 
   /* https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/ */
-  font-family: -apple-system, BlinkMacSystemFont,
-  'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
-  'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
 
   .axis,
   .chart-label {

--- a/extensions/statistics/locale/en.yml
+++ b/extensions/statistics/locale/en.yml
@@ -20,6 +20,7 @@ flarum-statistics:
     # These translations are used in the Statistics dashboard widget.
     statistics:
       discussions_heading: => core.ref.discussions
+      export_chart_button: Export chart to SVG
       last_12_months_label: Last 12 months
       last_28_days_label: Last 28 days
       last_7_days_label: Last 7 days


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- add button to save chart to SVG file

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![image](https://user-images.githubusercontent.com/7406822/198907465-eb8af0f5-8fd1-41be-b80c-0f95238ce2d3.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
