### PR TITLE
Log migration path when up/down keys are missing

### DIFF
--- a/framework/core/src/Database/Exception/MigrationKeyMissing.php
+++ b/framework/core/src/Database/Exception/MigrationKeyMissing.php
@@ -19,7 +19,7 @@ class MigrationKeyMissing extends Exception
     {
         $this->direction = $direction;
 
-        $fileNameWithSpace = $file ? ' ' . realpath($file) : '';
+        $fileNameWithSpace = $file ? ' '.realpath($file) : '';
         parent::__construct("Migration file$fileNameWithSpace should contain an array with up/down (looking for $direction)");
     }
 

--- a/framework/core/src/Database/Exception/MigrationKeyMissing.php
+++ b/framework/core/src/Database/Exception/MigrationKeyMissing.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Database\Exception;
+
+use Exception;
+
+class MigrationKeyMissing extends Exception
+{
+    protected $direction;
+
+    public function __construct(string $direction, string $file = null)
+    {
+        $this->direction = $direction;
+
+        $fileNameWithSpace = $file ? ' ' . realpath($file) : '';
+        parent::__construct("Migration file$fileNameWithSpace should contain an array with up/down (looking for $direction)");
+    }
+
+    public function withFile(string $file = null): self
+    {
+        return new self($this->direction, $file);
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
When a migration array is not formatted correctly, the output of the migrate command and the entry in the log file are completely useless as they doesn't say which migration caused the issue. This causes a lot of headache when it comes up in a support request and the user has hundreds of extensions installed.

To make things easier, a new exception class is introduced for the `should contain an array with up/down` exception.

Before:

CLI:
```
$ php flarum migrate
Migrating Flarum...

In Migrator.php line 200:

  Migration file should contain an array with up/down.  


migrate
```

Log:

```
[2022-11-01 17:40:12] flarum.ERROR: Exception: Migration file should contain an array with up/down. in /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php:200
Stack trace:
#0 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php(129): Flarum\Database\Migrator->runClosureMigration()
#1 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php(113): Flarum\Database\Migrator->runUp()
#2 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php(87): Flarum\Database\Migrator->runMigrationList()
#3 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Console/MigrateCommand.php(77): Flarum\Database\Migrator->run()
#4 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Console/MigrateCommand.php(63): Flarum\Database\Console\MigrateCommand->upgrade()
#5 /home/clark/Projects/flarum-master/framework/framework/core/src/Console/AbstractCommand.php(37): Flarum\Database\Console\MigrateCommand->fire()
#6 /home/clark/Projects/flarum-master/vendor/symfony/console/Command/Command.php(298): Flarum\Console\AbstractCommand->execute()
#7 /home/clark/Projects/flarum-master/vendor/symfony/console/Application.php(1046): Symfony\Component\Console\Command\Command->run()
#8 /home/clark/Projects/flarum-master/vendor/symfony/console/Application.php(299): Symfony\Component\Console\Application->doRunCommand()
#9 /home/clark/Projects/flarum-master/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun()
#10 /home/clark/Projects/flarum-master/framework/framework/core/src/Console/Server.php(42): Symfony\Component\Console\Application->run()
#11 /home/clark/Projects/flarum-master/flarum(24): Flarum\Console\Server->listen()
#12 {main}  
```

After:

CLI:
```
php flarum migrate
Migrating Flarum...

In MigrationKeyMissing.php line 28:
                                                                               
  Migration file /home/clark/Projects/flarum-master/framework/framework/core/  
  migrations/2022_12_01_000000_create_test_table.php should contain an array   
  with up/down (looking for up)                                                
                                                                               

migrate
```

Log:

```
[2022-11-01 17:41:33] flarum.ERROR: Flarum\Database\Exception\MigrationKeyMissing: Migration file /home/clark/Projects/flarum-master/framework/framework/core/migrations/2022_12_01_000000_create_test_table.php should contain an array with up/down (looking for up) in /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Exception/MigrationKeyMissing.php:28
Stack trace:
#0 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php(215): Flarum\Database\Exception\MigrationKeyMissing->withFile()
#1 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php(127): Flarum\Database\Migrator->resolveAndRunClosureMigration()
#2 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php(113): Flarum\Database\Migrator->runUp()
#3 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Migrator.php(87): Flarum\Database\Migrator->runMigrationList()
#4 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Console/MigrateCommand.php(77): Flarum\Database\Migrator->run()
#5 /home/clark/Projects/flarum-master/framework/framework/core/src/Database/Console/MigrateCommand.php(63): Flarum\Database\Console\MigrateCommand->upgrade()
#6 /home/clark/Projects/flarum-master/framework/framework/core/src/Console/AbstractCommand.php(37): Flarum\Database\Console\MigrateCommand->fire()
#7 /home/clark/Projects/flarum-master/vendor/symfony/console/Command/Command.php(298): Flarum\Console\AbstractCommand->execute()
#8 /home/clark/Projects/flarum-master/vendor/symfony/console/Application.php(1046): Symfony\Component\Console\Command\Command->run()
#9 /home/clark/Projects/flarum-master/vendor/symfony/console/Application.php(299): Symfony\Component\Console\Application->doRunCommand()
#10 /home/clark/Projects/flarum-master/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun()
#11 /home/clark/Projects/flarum-master/framework/framework/core/src/Console/Server.php(42): Symfony\Component\Console\Application->run()
#12 /home/clark/Projects/flarum-master/flarum(24): Flarum\Console\Server->listen()
#13 {main}
```

**Reviewers should focus on:**
I'm not sure why the `Migrator` class has so many `protected` methods as some could be consolidated into a single method.

I opted for a solution that's backward-compatible for any extension that extends the `Migrator` class to override it, even if we technically don't need to provide backward-compatibility for that kind of use case. Should we `@deprecated` the `runClosureMigration()` method with the intent to move its code into `resolveAndRunClosureMigration()` in the future?

`resolve()` is `public` so we probably won't be dropping it anyway.

The only extension I know of that extends the Migrator is [flamarkt/backoffice](https://github.com/flamarkt/backoffice/blob/main/src/Database/AugmentedMigrator.php) but these changes probably don't conflict with it, even if we removed `runClosureMigration()` entirely.

Something I notice just now that I submit the PR: should I name the exception class with an `Exception` suffix? Should I add accessors for the direction and file?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
