### PR TITLE
fix: larastan v1 incompatible with phpstan v1.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4",
         "phpunit/phpunit": "^9.0",
-        "phpstan/phpstan": "^1.2",
+        "phpstan/phpstan": ">=1.8.11 < 1.9.0",
         "nunomaduro/larastan": "^1.0"
     },
     "config": {

--- a/php-packages/phpstan/composer.json
+++ b/php-packages/phpstan/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "dev",
     "license": "MIT",
     "require": {
-        "phpstan/phpstan": "^1.2",
+        "phpstan/phpstan": ">=1.8.11 < 1.9.0",
         "nunomaduro/larastan": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
**Changes proposed**
We can't update to larastan v2 until we update to laravel v9 which has to wait for Flarum v2, so we need to stay on phpstan v1.8.