### PR TITLE
feat: include current user as forum relation

### DIFF
--- a/framework/core/src/Api/Controller/ShowForumController.php
+++ b/framework/core/src/Api/Controller/ShowForumController.php
@@ -25,7 +25,7 @@ class ShowForumController extends AbstractShowController
     /**
      * {@inheritdoc}
      */
-    public $include = ['groups', 'currentUser'];
+    public $include = ['groups', 'actor'];
 
     /**
      * {@inheritdoc}

--- a/framework/core/src/Api/Controller/ShowForumController.php
+++ b/framework/core/src/Api/Controller/ShowForumController.php
@@ -36,7 +36,7 @@ class ShowForumController extends AbstractShowController
 
         return [
             'groups' => Group::whereVisibleTo($actor)->get(),
-            'currentUser' => $actor->isGuest() ? null : $actor
+            'actor' => $actor->isGuest() ? null : $actor
         ];
     }
 }

--- a/framework/core/src/Api/Controller/ShowForumController.php
+++ b/framework/core/src/Api/Controller/ShowForumController.php
@@ -25,15 +25,18 @@ class ShowForumController extends AbstractShowController
     /**
      * {@inheritdoc}
      */
-    public $include = ['groups'];
+    public $include = ['groups', 'currentUser'];
 
     /**
      * {@inheritdoc}
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
+        $actor = RequestUtil::getActor($request);
+
         return [
-            'groups' => Group::whereVisibleTo(RequestUtil::getActor($request))->get()
+            'groups' => Group::whereVisibleTo($actor)->get(),
+            'currentUser' => $actor->isGuest() ? null : $actor
         ];
     }
 }

--- a/framework/core/src/Api/Serializer/ForumSerializer.php
+++ b/framework/core/src/Api/Serializer/ForumSerializer.php
@@ -15,6 +15,7 @@ use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory;
+use Tobscure\JsonApi\Relationship;
 
 class ForumSerializer extends AbstractSerializer
 {
@@ -68,7 +69,7 @@ class ForumSerializer extends AbstractSerializer
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultAttributes($model)
+    protected function getDefaultAttributes($model): array
     {
         $attributes = [
             'title' => $this->settings->get('forum_title'),
@@ -104,9 +105,9 @@ class ForumSerializer extends AbstractSerializer
     }
 
     /**
-     * @return \Tobscure\JsonApi\Relationship
+     * @return Relationship
      */
-    protected function groups($model)
+    protected function groups($model): Relationship
     {
         return $this->hasMany($model, GroupSerializer::class);
     }
@@ -114,7 +115,7 @@ class ForumSerializer extends AbstractSerializer
     /**
      * @return null|string
      */
-    protected function getLogoUrl()
+    protected function getLogoUrl(): ?string
     {
         $logoPath = $this->settings->get('logo_path');
 
@@ -124,7 +125,7 @@ class ForumSerializer extends AbstractSerializer
     /**
      * @return null|string
      */
-    protected function getFaviconUrl()
+    protected function getFaviconUrl(): ?string
     {
         $faviconPath = $this->settings->get('favicon_path');
 
@@ -137,9 +138,9 @@ class ForumSerializer extends AbstractSerializer
     }
 
     /**
-     * @return \Tobscure\JsonApi\Relationship|null
+     * @return Relationship|null
      */
-    protected function actor($model)
+    protected function actor($model): ?Relationship
     {
         return $this->hasOne($model, CurrentUserSerializer::class);
     }

--- a/framework/core/src/Api/Serializer/ForumSerializer.php
+++ b/framework/core/src/Api/Serializer/ForumSerializer.php
@@ -139,7 +139,7 @@ class ForumSerializer extends AbstractSerializer
     /**
      * @return \Tobscure\JsonApi\Relationship|null
      */
-    protected function currentUser($model)
+    protected function actor($model)
     {
         return $this->hasOne($model, CurrentUserSerializer::class);
     }

--- a/framework/core/src/Api/Serializer/ForumSerializer.php
+++ b/framework/core/src/Api/Serializer/ForumSerializer.php
@@ -135,4 +135,12 @@ class ForumSerializer extends AbstractSerializer
     {
         return $this->assetsFilesystem->url($assetPath);
     }
+
+    /**
+     * @return \Tobscure\JsonApi\Relationship|null
+     */
+    protected function currentUser($model)
+    {
+        return $this->hasOne($model, CurrentUserSerializer::class);
+    }
 }

--- a/framework/core/tests/integration/api/forum/ShowTest.php
+++ b/framework/core/tests/integration/api/forum/ShowTest.php
@@ -67,8 +67,8 @@ class ShowTest extends TestCase
         $this->assertEquals('http://localhost/api', Arr::get($json, 'data.attributes.apiUrl'));
 
         $this->assertArrayNotHasKey('adminUrl', Arr::get($json, 'data.attributes'));
-        $this->assertArrayHasKey('currentUser', Arr::get($json, 'data.relationships'));
-        $this->assertEquals(2, Arr::get($json, 'data.relationships.currentUser.data.id'));
+        $this->assertArrayHasKey('actor', Arr::get($json, 'data.relationships'));
+        $this->assertEquals(2, Arr::get($json, 'data.relationships.actor.data.id'));
     }
 
     /**

--- a/framework/core/tests/integration/api/forum/ShowTest.php
+++ b/framework/core/tests/integration/api/forum/ShowTest.php
@@ -34,7 +34,7 @@ class ShowTest extends TestCase
     /**
      * @test
      */
-    public function guest_user_does_not_have_user_relationship()
+    public function guest_user_does_not_see_actor_relationship()
     {
         $response = $this->send(
             $this->request('GET', '/api')
@@ -44,7 +44,7 @@ class ShowTest extends TestCase
 
         $json = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertArrayNotHasKey('currentUser', Arr::get($json, 'data.relationships'));
+        $this->assertArrayNotHasKey('actor', Arr::get($json, 'data.relationships'));
     }
 
     /**

--- a/framework/core/tests/integration/api/forum/ShowTest.php
+++ b/framework/core/tests/integration/api/forum/ShowTest.php
@@ -34,6 +34,22 @@ class ShowTest extends TestCase
     /**
      * @test
      */
+    public function guest_user_does_not_have_user_relationship()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('currentUser', Arr::get($json, 'data.relationships'));
+    }
+
+    /**
+     * @test
+     */
     public function normal_user_sees_most_information()
     {
         $response = $this->send(
@@ -51,6 +67,8 @@ class ShowTest extends TestCase
         $this->assertEquals('http://localhost/api', Arr::get($json, 'data.attributes.apiUrl'));
 
         $this->assertArrayNotHasKey('adminUrl', Arr::get($json, 'data.attributes'));
+        $this->assertArrayHasKey('currentUser', Arr::get($json, 'data.relationships'));
+        $this->assertEquals(2, Arr::get($json, 'data.relationships.currentUser.data.id'));
     }
 
     /**


### PR DESCRIPTION
**Changes proposed in this pull request:**
Except for `Guest` users, include the current user as a relation on `ForumSerializer`.

The need for this came about when I was asked to introduce a way of identifying a user on the API, without knowing the `user_id` in advance, but only an `AccessToken`.

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [X] Tests have been added, or are not appropriate here.
