### PR TITLE
chore: Indicate cross-origin request in generic error message

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -584,7 +584,7 @@ export default class Application {
    * @protected
    */
   protected requestWasCrossOrigin(error: RequestError): boolean {
-    return (new URL(error.options.url, document.baseURI)).origin !== window.location.origin;
+    return new URL(error.options.url, document.baseURI).origin !== window.location.origin;
   }
 
   protected requestErrorDefaultHandler(e: unknown, isDebug: boolean, formattedErrors: string[]): void {

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -547,7 +547,11 @@ export default class Application {
         break;
 
       default:
-        content = app.translator.trans('core.lib.error.generic_message');
+        if (this.requestWasCrossOrigin(error)) {
+          content = app.translator.trans('core.lib.error.generic_cross_origin_message');
+        } else {
+          content = app.translator.trans('core.lib.error.generic_message');
+        }
     }
 
     const isDebug: boolean = app.forum.attribute('debug');
@@ -569,6 +573,18 @@ export default class Application {
     }
 
     return Promise.reject(error);
+  }
+
+  /**
+   * Used to modify the error message shown on the page to help troubleshooting.
+   * While not certain, a failing cross-origin request likely indicates a missing redirect to Flarum canonical URL.
+   * Because XHR errors do not expose CORS information, we can only compare the requested URL origin to the page origin.
+   *
+   * @param error
+   * @protected
+   */
+  protected requestWasCrossOrigin(error: RequestError): boolean {
+    return (new URL(error.options.url, document.baseURI)).origin !== window.location.origin;
   }
 
   protected requestErrorDefaultHandler(e: unknown, isDebug: boolean, formattedErrors: string[]): void {

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -550,7 +550,7 @@ core:
       dependent_extensions_message: "Cannot disable {extension} until the following dependent extensions are disabled: {extensions}"
       extension_initialiation_failed_message: "{extension} failed to initialize, check the browser console for further information."
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
-      generic_cross_origin_message: "Oops! Something went wrong. Please reload the page and try again (cross origin request)."
+      generic_cross_origin_message: "Oops! Something went wrong (cross origin request). Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
       not_found_message: The requested resource was not found.
       payload_too_large_message: The request payload was too large.

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -550,6 +550,7 @@ core:
       dependent_extensions_message: "Cannot disable {extension} until the following dependent extensions are disabled: {extensions}"
       extension_initialiation_failed_message: "{extension} failed to initialize, check the browser console for further information."
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
+      generic_cross_origin_message: "Oops! Something went wrong. Please reload the page and try again (cross origin request)."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
       not_found_message: The requested resource was not found.
       payload_too_large_message: The request payload was too large.

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -550,7 +550,7 @@ core:
       dependent_extensions_message: "Cannot disable {extension} until the following dependent extensions are disabled: {extensions}"
       extension_initialiation_failed_message: "{extension} failed to initialize, check the browser console for further information."
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
-      generic_cross_origin_message: "Oops! Something went wrong (cross origin request). Please reload the page and try again."
+      generic_cross_origin_message: "Oops! Something went wrong during a cross-origin request. Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
       not_found_message: The requested resource was not found.
       payload_too_large_message: The request payload was too large.


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
This is another change intended to help with troubleshooting requests. Most URL misconfiguration issues lead to CORS errors, but the generic request error message from Flarum doesn't allow to recognize those immediately since it covers a wide range of client-side and server-side errors.

This PR adds a "(cross-origin request)" indicator at the end of the generic "Ooops" message if the request URL origin and page origin are different. The regular message is unchanged if both origins match.

**Reviewers should focus on:**
Here were some of the reflections behind the approach:

Since the error is purely client-side and doesn't expose anything sensitive, I think it makes perfect sense to expose it to every visitor, including when debug mode is OFF.

The message shouldn't be hidden behind a debug button, otherwise nobody would include it in their initial support request.

I don't think the message should mention the Flarum URL config, that would be a bit too specific since users *could* legitimately run Flarum and its API on different domains with proper CORS headers. It might also be too delicate to straight up say the website is misconfigured if anyone might encounter the message. The proposed wording is quite discreet, while still being an obvious clue to any Flarum support agent.

There's the possibility the `new URL()` call fails if the URL given to `m.request()` is completely invalid. I'm not sure if that's worth catching. The request was going to fail anyway if that happened.

**Screenshot**
![image](https://user-images.githubusercontent.com/5264300/200087931-4f19b4ef-72ee-4776-83ea-591897c9e8d9.png)
![image](https://user-images.githubusercontent.com/5264300/200087948-84a3d188-4851-45d0-a3a9-369c5cdabd03.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
