### PR TITLE
feat: Allow additional reset password params, introduce `ForgotPasswordValidator`

### DIFF
--- a/framework/core/js/src/forum/components/ForgotPasswordModal.tsx
+++ b/framework/core/js/src/forum/components/ForgotPasswordModal.tsx
@@ -5,6 +5,7 @@ import extractText from '../../common/utils/extractText';
 import Stream from '../../common/utils/Stream';
 import Mithril from 'mithril';
 import RequestError from '../../common/utils/RequestError';
+import ItemList from '../../common/utils/ItemList';
 
 export interface IForgotPasswordModalAttrs extends IInternalModalAttrs {
   email?: string;
@@ -52,36 +53,53 @@ export default class ForgotPasswordModal<CustomAttrs extends IForgotPasswordModa
       );
     }
 
-    const emailLabel = extractText(app.translator.trans('core.forum.forgot_password.email_placeholder'));
-
     return (
       <div className="Modal-body">
         <div className="Form Form--centered">
           <p className="helpText">{app.translator.trans('core.forum.forgot_password.text')}</p>
-          <div className="Form-group">
-            <input
-              className="FormControl"
-              name="email"
-              type="email"
-              placeholder={emailLabel}
-              aria-label={emailLabel}
-              bidi={this.email}
-              disabled={this.loading}
-            />
-          </div>
-          <div className="Form-group">
-            {Button.component(
-              {
-                className: 'Button Button--primary Button--block',
-                type: 'submit',
-                loading: this.loading,
-              },
-              app.translator.trans('core.forum.forgot_password.submit_button')
-            )}
-          </div>
+          {this.fields().toArray()}
         </div>
       </div>
     );
+  }
+
+  fields() {
+    const items = new ItemList();
+
+    const emailLabel = extractText(app.translator.trans('core.forum.forgot_password.email_placeholder'));
+
+    items.add(
+      'email',
+      <div className="Form-group">
+        <input
+          className="FormControl"
+          name="email"
+          type="email"
+          placeholder={emailLabel}
+          aria-label={emailLabel}
+          bidi={this.email}
+          disabled={this.loading}
+        />
+      </div>,
+      50
+    );
+
+    items.add(
+      'submit',
+      <div className="Form-group">
+        {Button.component(
+          {
+            className: 'Button Button--primary Button--block',
+            type: 'submit',
+            loading: this.loading,
+          },
+          app.translator.trans('core.forum.forgot_password.submit_button')
+        )}
+      </div>,
+      -10
+    );
+
+    return items;
   }
 
   onsubmit(e: SubmitEvent) {
@@ -93,7 +111,7 @@ export default class ForgotPasswordModal<CustomAttrs extends IForgotPasswordModa
       .request({
         method: 'POST',
         url: app.forum.attribute('apiUrl') + '/forgot',
-        body: { email: this.email() },
+        body: this.requestParams(),
         errorHandler: this.onerror.bind(this),
       })
       .then(() => {
@@ -102,6 +120,14 @@ export default class ForgotPasswordModal<CustomAttrs extends IForgotPasswordModa
       })
       .catch(() => {})
       .then(this.loaded.bind(this));
+  }
+
+  requestParams(): Record<string, unknown> {
+    const data = {
+      email: this.email(),
+    };
+
+    return data;
   }
 
   onerror(error: RequestError) {

--- a/framework/core/src/Api/ForgotPasswordValidator.php
+++ b/framework/core/src/Api/ForgotPasswordValidator.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Api;
 
 /*
@@ -17,6 +24,6 @@ class ForgotPasswordValidator extends AbstractValidator
      * {@inheritdoc}
      */
     protected $rules = [
-        'email' => ['required','email']
+        'email' => ['required', 'email']
     ];
 }

--- a/framework/core/src/Api/ForgotPasswordValidator.php
+++ b/framework/core/src/Api/ForgotPasswordValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Flarum\Api;
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Flarum\Foundation\AbstractValidator;
+
+class ForgotPasswordValidator extends AbstractValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $rules = [
+        'email' => ['required','email']
+    ];
+}


### PR DESCRIPTION
Related to https://github.com/flarum/framework/pull/3670

Allows for 3rd party extensions to extend the functionality of the Forgot Password modal. ie Adding a captcha, etc.

**Changes proposed in this pull request:**
`ForgotPasswordModal`:
- Extracts fields to an extendable function
- Extract params into an extendable function so that additional params can be added
`ForgotPasswordController`
- Replaces the validator factory with a new `ForgotPasswordValidator`, with the same rule as existed previously
- This can be extended by 3rd party extensions to add any additional rules, where required.

**Reviewers should focus on:**

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
