### PR TITLE
fix: groupmentions have poor contrast on some backgrounds

### DIFF
--- a/extensions/mentions/js/src/forum/utils/textFormatter.js
+++ b/extensions/mentions/js/src/forum/utils/textFormatter.js
@@ -1,6 +1,7 @@
 import app from 'flarum/forum/app';
 import username from 'flarum/common/helpers/username';
 import extractText from 'flarum/common/utils/extractText';
+import isDark from 'flarum/common/utils/isDark';
 
 export function filterUserMentions(tag) {
   let user;
@@ -40,6 +41,7 @@ export function filterGroupMentions(tag) {
       tag.setAttribute('groupname', extractText(group.namePlural()));
       tag.setAttribute('icon', group.icon());
       tag.setAttribute('color', group.color());
+      tag.setAttribute('class', isDark(group.color()) ? 'GroupMention--light' : 'GroupMention--dark');
 
       return true;
     }

--- a/extensions/mentions/less/forum.less
+++ b/extensions/mentions/less/forum.less
@@ -98,15 +98,26 @@
   .Button--color(@tooltip-color, @tooltip-bg);
 }
 .GroupMention {
-  color: @body-bg;
+  &--light {
+    color: @text-on-light;
+
+    &:hover,
+    &:active {
+      color: @text-on-light;
+    }
+  }
+
+  &--dark {
+    color: @text-on-dark;
+
+    &:hover,
+    &:active {
+      color: @text-on-dark;
+    }
+  }
 
   .icon {
     margin-left: 5px;
-  }
-
-  &:hover,
-  &:active {
-    color: @body-bg;
   }
 }
 .MentionsDropdown .Badge {

--- a/extensions/mentions/less/forum.less
+++ b/extensions/mentions/less/forum.less
@@ -98,13 +98,23 @@
   .Button--color(@tooltip-color, @tooltip-bg);
 }
 .GroupMention {
-  &--light {
-    color: @text-on-light;
-
-    & when (@config-dark-mode = true) {
+  & when (@config-dark-mode = false) {
+    &,
+    &:hover,
+    &:active {
+      color: @text-on-light;
+    }
+  }
+  & when (@config-dark-mode = true) {
+    &,
+    &:hover,
+    &:active {
       color: @text-on-dark;
     }
+  }
 
+  &--light {
+    &,
     &:hover,
     &:active {
       color: @text-on-light;
@@ -112,12 +122,7 @@
   }
 
   &--dark {
-    color: @text-on-dark;
-
-    & when (@config-dark-mode = true) {
-      color: @text-on-light;
-    }
-
+    &,
     &:hover,
     &:active {
       color: @text-on-dark;

--- a/extensions/mentions/less/forum.less
+++ b/extensions/mentions/less/forum.less
@@ -101,6 +101,10 @@
   &--light {
     color: @text-on-light;
 
+    & when (@config-dark-mode = true) {
+      color: @text-on-dark;
+    }
+
     &:hover,
     &:active {
       color: @text-on-light;
@@ -109,6 +113,10 @@
 
   &--dark {
     color: @text-on-dark;
+
+    & when (@config-dark-mode = true) {
+      color: @text-on-light;
+    }
 
     &:hover,
     &:active {

--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -14,6 +14,7 @@ use Flarum\Http\UrlGenerator;
 use Flarum\Post\CommentPost;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
+use Illuminate\Support\Str;
 use s9e\TextFormatter\Configurator;
 
 class ConfigureMentions
@@ -147,12 +148,13 @@ class ConfigureMentions
         $tag->attributes->add('groupname');
         $tag->attributes->add('icon');
         $tag->attributes->add('color');
+        $tag->attributes->add('class');
         $tag->attributes->add('id')->filterChain->append('#uint');
 
         $tag->template = '
             <xsl:choose>
                 <xsl:when test="@deleted != 1">
-                    <span class="GroupMention" style="background: {@color}">@<xsl:value-of select="@groupname"/><i class="icon {@icon}"></i></span>
+                    <span class="GroupMention {@class}" style="background: {@color}">@<xsl:value-of select="@groupname"/><i class="icon {@icon}"></i></span>
                 </xsl:when>
                 <xsl:otherwise>
                     <span class="GroupMention GroupMention--deleted" style="background: {@color}">@<xsl:value-of select="@groupname"/><i class="icon {@icon}"></i></span>
@@ -177,10 +179,34 @@ class ConfigureMentions
             $tag->setAttribute('groupname', $group->name_plural);
             $tag->setAttribute('icon', $group->icon ?? 'fas fa-at');
             $tag->setAttribute('color', $group->color);
-
+            $tag->setAttribute('class', self::isDark($group->color) ? 'GroupMention--light' : 'GroupMention--dark');
             return true;
         }
 
         $tag->invalidate();
+    }
+
+    /**
+    * The `isDark` utility converts a hex color to rgb, and then calcul a YIQ
+    * value in order to get the appropriate brightness value (is it dark or is it
+    * light?) See https://www.w3.org/TR/AERT/#color-contrast for references. A YIQ
+    * value >= 128 is a light color.
+    */
+    public static function isDark(?string $hexColor): bool
+    {
+        if (!$hexColor) {
+            return false;
+        }
+        
+        $hexNumbers = Str::replace('#', '', $hexColor);
+        if (Str::length($hexNumbers) === 3) {
+            $hexNumbers += $hexNumbers;
+        }
+
+        $r = (int) Str::substr($hexNumbers, 0, 2);
+        $g = (int) Str::subStr($hexNumbers, 2, 2);
+        $b = (int) Str::subStr($hexNumbers, 4, 2);
+        $yiq = ($r * 299 + $g *587 + $b * 114) / 1000;
+        return $yiq >= 128 ? false : true;
     }
 }

--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -174,12 +174,16 @@ class ConfigureMentions
     {
         $group = Group::find($tag->getAttribute('id'));
 
-        if (isset($group) && ! in_array($group->id, [Group::GUEST_ID, Group::MEMBER_ID])) {
+        if (isset($group) && !in_array($group->id, [Group::GUEST_ID, Group::MEMBER_ID])) {
             $tag->setAttribute('id', $group->id);
             $tag->setAttribute('groupname', $group->name_plural);
             $tag->setAttribute('icon', $group->icon ?? 'fas fa-at');
             $tag->setAttribute('color', $group->color);
-            $tag->setAttribute('class', self::isDark($group->color) ? 'GroupMention--light' : 'GroupMention--dark');
+            if (!empty($group->color)) {
+                $tag->setAttribute('class', self::isDark($group->color) ? 'GroupMention--light' : 'GroupMention--dark');
+            } else {
+                $tag->setAttribute('class', '');
+            }
 
             return true;
         }
@@ -195,7 +199,7 @@ class ConfigureMentions
      */
     public static function isDark(?string $hexColor): bool
     {
-        if (! $hexColor) {
+        if (!$hexColor) {
             return false;
         }
 

--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -174,12 +174,12 @@ class ConfigureMentions
     {
         $group = Group::find($tag->getAttribute('id'));
 
-        if (isset($group) && !in_array($group->id, [Group::GUEST_ID, Group::MEMBER_ID])) {
+        if (isset($group) && ! in_array($group->id, [Group::GUEST_ID, Group::MEMBER_ID])) {
             $tag->setAttribute('id', $group->id);
             $tag->setAttribute('groupname', $group->name_plural);
             $tag->setAttribute('icon', $group->icon ?? 'fas fa-at');
             $tag->setAttribute('color', $group->color);
-            if (!empty($group->color)) {
+            if (! empty($group->color)) {
                 $tag->setAttribute('class', self::isDark($group->color) ? 'GroupMention--light' : 'GroupMention--dark');
             } else {
                 $tag->setAttribute('class', '');
@@ -199,7 +199,7 @@ class ConfigureMentions
      */
     public static function isDark(?string $hexColor): bool
     {
-        if (!$hexColor) {
+        if (! $hexColor) {
             return false;
         }
 

--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -180,6 +180,7 @@ class ConfigureMentions
             $tag->setAttribute('icon', $group->icon ?? 'fas fa-at');
             $tag->setAttribute('color', $group->color);
             $tag->setAttribute('class', self::isDark($group->color) ? 'GroupMention--light' : 'GroupMention--dark');
+
             return true;
         }
 
@@ -187,17 +188,17 @@ class ConfigureMentions
     }
 
     /**
-    * The `isDark` utility converts a hex color to rgb, and then calcul a YIQ
-    * value in order to get the appropriate brightness value (is it dark or is it
-    * light?) See https://www.w3.org/TR/AERT/#color-contrast for references. A YIQ
-    * value >= 128 is a light color.
-    */
+     * The `isDark` utility converts a hex color to rgb, and then calcul a YIQ
+     * value in order to get the appropriate brightness value (is it dark or is it
+     * light?) See https://www.w3.org/TR/AERT/#color-contrast for references. A YIQ
+     * value >= 128 is a light color.
+     */
     public static function isDark(?string $hexColor): bool
     {
-        if (!$hexColor) {
+        if (! $hexColor) {
             return false;
         }
-        
+
         $hexNumbers = Str::replace('#', '', $hexColor);
         if (Str::length($hexNumbers) === 3) {
             $hexNumbers += $hexNumbers;
@@ -206,7 +207,8 @@ class ConfigureMentions
         $r = (int) Str::substr($hexNumbers, 0, 2);
         $g = (int) Str::subStr($hexNumbers, 2, 2);
         $b = (int) Str::subStr($hexNumbers, 4, 2);
-        $yiq = ($r * 299 + $g *587 + $b * 114) / 1000;
+        $yiq = ($r * 299 + $g * 587 + $b * 114) / 1000;
+
         return $yiq >= 128 ? false : true;
     }
 }

--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -180,7 +180,6 @@ class ConfigureMentions
             $tag->setAttribute('icon', $group->icon ?? 'fas fa-at');
             $tag->setAttribute('color', $group->color);
             $tag->setAttribute('class', self::isDark($group->color) ? 'GroupMention--light' : 'GroupMention--dark');
-
             return true;
         }
 
@@ -188,27 +187,26 @@ class ConfigureMentions
     }
 
     /**
-     * The `isDark` utility converts a hex color to rgb, and then calcul a YIQ
-     * value in order to get the appropriate brightness value (is it dark or is it
-     * light?) See https://www.w3.org/TR/AERT/#color-contrast for references. A YIQ
-     * value >= 128 is a light color.
-     */
+    * The `isDark` utility converts a hex color to rgb, and then calcul a YIQ
+    * value in order to get the appropriate brightness value (is it dark or is it
+    * light?) See https://www.w3.org/TR/AERT/#color-contrast for references. A YIQ
+    * value >= 128 is a light color.
+    */
     public static function isDark(?string $hexColor): bool
     {
-        if (! $hexColor) {
+        if (!$hexColor) {
             return false;
         }
-
+        
         $hexNumbers = Str::replace('#', '', $hexColor);
         if (Str::length($hexNumbers) === 3) {
             $hexNumbers += $hexNumbers;
         }
 
-        $r = (int) Str::substr($hexNumbers, 0, 2);
-        $g = (int) Str::subStr($hexNumbers, 2, 2);
-        $b = (int) Str::subStr($hexNumbers, 4, 2);
-        $yiq = ($r * 299 + $g * 587 + $b * 114) / 1000;
-
+        $r = hexdec(Str::substr($hexNumbers, 0, 2));
+        $g = hexdec(Str::subStr($hexNumbers, 2, 2));
+        $b = hexdec(Str::subStr($hexNumbers, 4, 2));
+        $yiq = ($r * 299 + $g *587 + $b * 114) / 1000;
         return $yiq >= 128 ? false : true;
     }
 }

--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -180,6 +180,7 @@ class ConfigureMentions
             $tag->setAttribute('icon', $group->icon ?? 'fas fa-at');
             $tag->setAttribute('color', $group->color);
             $tag->setAttribute('class', self::isDark($group->color) ? 'GroupMention--light' : 'GroupMention--dark');
+
             return true;
         }
 
@@ -187,17 +188,17 @@ class ConfigureMentions
     }
 
     /**
-    * The `isDark` utility converts a hex color to rgb, and then calcul a YIQ
-    * value in order to get the appropriate brightness value (is it dark or is it
-    * light?) See https://www.w3.org/TR/AERT/#color-contrast for references. A YIQ
-    * value >= 128 is a light color.
-    */
+     * The `isDark` utility converts a hex color to rgb, and then calcul a YIQ
+     * value in order to get the appropriate brightness value (is it dark or is it
+     * light?) See https://www.w3.org/TR/AERT/#color-contrast for references. A YIQ
+     * value >= 128 is a light color.
+     */
     public static function isDark(?string $hexColor): bool
     {
-        if (!$hexColor) {
+        if (! $hexColor) {
             return false;
         }
-        
+
         $hexNumbers = Str::replace('#', '', $hexColor);
         if (Str::length($hexNumbers) === 3) {
             $hexNumbers += $hexNumbers;
@@ -206,7 +207,8 @@ class ConfigureMentions
         $r = hexdec(Str::substr($hexNumbers, 0, 2));
         $g = hexdec(Str::subStr($hexNumbers, 2, 2));
         $b = hexdec(Str::subStr($hexNumbers, 4, 2));
-        $yiq = ($r * 299 + $g *587 + $b * 114) / 1000;
+        $yiq = ($r * 299 + $g * 587 + $b * 114) / 1000;
+
         return $yiq >= 128 ? false : true;
     }
 }

--- a/extensions/mentions/tests/integration/api/GroupMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/GroupMentionsTest.php
@@ -84,7 +84,7 @@ class GroupMentionsTest extends TestCase
 
         $response = json_decode($response->getBody(), true);
 
-        $this->assertStringContainsString('<p>One of the <span style="background:#80349E" class="GroupMention">@Mods<i class="icon fas fa-bolt"></i></span> will look at this</p>', $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('<p>One of the <span style="background:#80349E" class="GroupMention ">@Mods<i class="icon fas fa-bolt"></i></span> will look at this</p>', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsGroups->find(4));
     }
 


### PR DESCRIPTION
First noticed on `discuss` today, some group colors present poor text contrast. 

For the record, I would not have been able to complete this without the help of @davwheat - thank you David!

**Changes proposed in this pull request:**
Utilize the `yiq` helper recently introduced to add either a `--light` or `--dark` class

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before:
![image](https://user-images.githubusercontent.com/16573496/200329024-b8ca3a29-7e13-4487-a016-88c74bc7460d.png)
![image](https://user-images.githubusercontent.com/16573496/200329061-47889c9b-4999-40a8-aa5b-9b5f3d2b5263.png)

After:
![image](https://user-images.githubusercontent.com/16573496/200342392-f03172ea-3a61-4508-84af-a27c2a26d9e1.png)
![image](https://user-images.githubusercontent.com/16573496/200342427-c7bf398b-d828-4634-b1ce-adaed9e86465.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
