### PR TITLE
fix: post dropdown opens all dropdowns in `.Post-actions`

### DIFF
--- a/framework/core/js/src/forum/components/Post.tsx
+++ b/framework/core/js/src/forum/components/Post.tsx
@@ -97,7 +97,7 @@ export default abstract class Post<CustomAttrs extends IPostAttrs = IPostAttrs> 
     const $actions = this.$('.Post-actions');
     const $controls = this.$('.Post-controls');
 
-    $actions.toggleClass('open', $controls.hasClass('open'));
+    $actions.toggleClass('openWithin', $controls.hasClass('open'));
   }
 
   /**

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -322,7 +322,7 @@
       vertical-align: top;
     }
   }
-  .Post:hover &, .Post:focus-within &, &.open {
+  .Post:hover &, .Post:focus-within &, &.openWithin {
     opacity: 1;
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
I initially implemented this in #3185, but it seems this never actually fixed the issue!

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

Before:
![image](https://user-images.githubusercontent.com/7406822/201227083-b3c9ea26-ee3b-4477-9026-dac47435930b.png)

After:
![image](https://user-images.githubusercontent.com/7406822/201227160-54e85af8-649a-4d23-8a98-5d923d074564.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
