### PR TITLE
fix: typo in Formatter extender docblock

### DIFF
--- a/framework/core/src/Extend/Formatter.php
+++ b/framework/core/src/Extend/Formatter.php
@@ -95,7 +95,7 @@ class Formatter implements ExtenderInterface, LifecycleInterface
      * @param callable|string $callback
      *
      * The callback can be a closure or invokable class, and should accept:
-     * - \s9e\TextFormatter\Rendered $renderer
+     * - \s9e\TextFormatter\Renderer $renderer
      * - mixed $context
      * - string $xml: The xml to be rendered.
      * - ServerRequestInterface $request. This argument MUST either be nullable, or omitted entirely.


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
The classname was wrong in the docblock.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
