### PR TITLE
fix: evaluated page title content

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -417,16 +417,15 @@ export default class Application {
 
     title = count + title;
 
-    // We set the title directly to the title element's innerHTML to properly display raw entities,
-    // while preventing XSS attacks from user input.
-    // https://github.com/flarum/framework/issues/3514
-    // https://github.com/flarum/framework/pull/3684
-    const titleNodes = document.getElementsByTagName('title');
-    if (titleNodes.length) {
-      titleNodes[0].innerHTML = title;
-    } else {
-      document.title = title;
-    }
+    // We pass the title through a DOMParser to allow HTML entities
+    // to be rendered correctly, while still preventing XSS attacks
+    // from user input by using a script-disabled environment.
+	// https://github.com/flarum/framework/issues/3514
+	// https://github.com/flarum/framework/pull/3684
+    const parser = new DOMParser();
+    const safeTitle = parser.parseFromString(title, 'text/html').body.innerText;
+    
+    document.title = safeTitle;
   }
 
   protected transformRequestOptions<ResponseType>(flarumOptions: FlarumRequestOptions<ResponseType>): InternalFlarumRequestOptions<ResponseType> {

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -410,16 +410,20 @@ export default class Application {
       pageNumber: 1,
     };
 
-    const title =
+    let title =
       onHomepage || !this.title
         ? extractText(app.translator.trans('core.lib.meta_titles.without_page_title', params))
         : extractText(app.translator.trans('core.lib.meta_titles.with_page_title', params));
 
-    const tempEl = document.createElement('div');
-    tempEl.innerHTML = title;
-    const decodedTitle = tempEl.innerText;
+    title = count + title;
 
-    document.title = count + decodedTitle;
+    const titleNodes = document.getElementsByTagName('title');
+
+    if (titleNodes.length) {
+      titleNodes[0].innerHTML = title;
+    } else {
+      document.title = title;
+    }
   }
 
   protected transformRequestOptions<ResponseType>(flarumOptions: FlarumRequestOptions<ResponseType>): InternalFlarumRequestOptions<ResponseType> {

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -417,8 +417,11 @@ export default class Application {
 
     title = count + title;
 
+    // We set the title directly to the title element's innerHTML to properly display raw entities,
+    // while preventing XSS attacks from user input.
+    // https://github.com/flarum/framework/issues/3514
+    // https://github.com/flarum/framework/pull/3684
     const titleNodes = document.getElementsByTagName('title');
-
     if (titleNodes.length) {
       titleNodes[0].innerHTML = title;
     } else {

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -420,11 +420,11 @@ export default class Application {
     // We pass the title through a DOMParser to allow HTML entities
     // to be rendered correctly, while still preventing XSS attacks
     // from user input by using a script-disabled environment.
-	// https://github.com/flarum/framework/issues/3514
-	// https://github.com/flarum/framework/pull/3684
+    // https://github.com/flarum/framework/issues/3514
+    // https://github.com/flarum/framework/pull/3684
     const parser = new DOMParser();
-    const safeTitle = parser.parseFromString(title, 'text/html').body.innerText;
-    
+    const safeTitle = parser.parseFromString(title, 'text/html').body.innerHTML;
+
     document.title = safeTitle;
   }
 

--- a/framework/core/views/frontend/app.blade.php
+++ b/framework/core/views/frontend/app.blade.php
@@ -3,7 +3,7 @@
       @if ($language) lang="{{ $language }}" @endif>
     <head>
         <meta charset="utf-8">
-        <title>{!! $title !!}</title>
+        <title>{{ $title }}</title>
 
         {!! $head !!}
     </head>


### PR DESCRIPTION
**Changes proposed in this pull request:**
Properly escapes HTML entities when setting page titles. Otherwise, any decoded title content is evaluated as HTML code.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.