### PR TITLE
Enable conditional migrations through `when` callback

### DIFF
--- a/framework/core/src/Database/Migrator.php
+++ b/framework/core/src/Database/Migrator.php
@@ -128,7 +128,7 @@ class Migrator
 
         // If a "when" callback in defined in a migration array, a falsy return value will cause the migration to skip
         if (is_array($migration) && array_key_exists('when', $migration)) {
-            if (!call_user_func($migration['when'], $this->connection->getSchemaBuilder())) {
+            if (! call_user_func($migration['when'], $this->connection->getSchemaBuilder())) {
                 $this->note("<info>Skipped:</info> $file");
 
                 return;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
A new feature that allows extensions to skip database migrations while keeping the ability to execute them again later.

Since Flarum always attempts running all migrations for all extensions on each extension activation, this works well to add tables, columns and constraints that are only needed with optional dependencies.

This cannot be achieved with regular migrations because not doing anything in the `up` callback will still get the migration logged as run and will never be attempted again. And extensions can't easily affect the migration repository to invalidate the recent migration since it's only updated at a later point after the migration callback has run.

This feature only applies to `up` migrations. `down` migrations don't need the ability to be skipped. If the thing to roll down no longer exists, migrations are already expected to become a no-op and will then successfully be marked as run down. Also, they will only run down if they successfully ran up before.

This feature has been successfully implemented in `flamarkt/backoffice` and used by `flamarkt/taxonomies` since March 2022. Implementing it in core will enable more extensions to use this feature without the need to add `flamarkt/backoffice` as a dependency.

Since there is intention to use this for the mentions-tags optional integration, it makes sense to put it in core.

Example implementation in a migration https://github.com/flamarkt/taxonomies/blob/main/migrations/20210401_000400_create_product_term_table.php

**Reviewers should focus on:**
Other options considered were to use a special return value in the `up` callback or throwing a special exception from `up`. But the dedicated `when` callback is the option I find most elegant.

I have dropped the `protected` method `resolveAndRunClosureMigration` that was introduced very recently in #3664 because it was making things more complex than necessary since we need the ability to `return` early in the `runUp` method.

**Screenshot**
The only part visible to the user is that the "Skipped" message will be shown every time they run `migrate` if the migration conditions are not met:
![image](https://user-images.githubusercontent.com/5264300/203069406-f0ba752c-b3f9-4110-b3b9-c0aeb7f9ad49.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: https://github.com/flarum/docs/pull/442
