### PR TITLE
fix: provide web friendly session driver name

### DIFF
--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -113,7 +113,7 @@ class AdminPayload
         }
 
         $document->payload['queueDriver'] = $this->appInfo->identifyQueueDriver();
-        $document->payload['sessionDriver'] = $this->appInfo->identifySessionDriver();
+        $document->payload['sessionDriver'] = $this->appInfo->identifySessionDriver(true);
 
         /**
          * Used in the admin user list. Implemented as this as it matches the API in flarum/statistics.

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -157,7 +157,7 @@ class ApplicationInfoProvider
      *  2. If the configured session driver is invalid, fallback to the default one and mention it.
      *  3. If the actual used driver (i.e `session.handler`) is different from the current one (configured or default), mention it.
      */
-    public function identifySessionDriver(): string
+    public function identifySessionDriver(bool $forWeb = false): string
     {
         /*
          * Get the configured driver and fallback to the default one.
@@ -190,11 +190,11 @@ class ApplicationInfoProvider
         $handlerName = str_replace('sessionhandler', '', $handlerName);
 
         if ($driver !== $handlerName) {
-            return "$handlerName <comment>(Code override. Configured to <options=bold,underscore>$configuredDriver</>)</comment>";
+            return $forWeb ? $handlerName : "$handlerName <comment>(Code override. Configured to <options=bold,underscore>$configuredDriver</>)</comment>";
         }
 
         if ($driver !== $configuredDriver) {
-            return "$driver <comment>(Fallback default driver. Configured to invalid driver <options=bold,underscore>$configuredDriver</>)</comment>";
+            return $forWeb ? $driver : "$driver <comment>(Fallback default driver. Configured to invalid driver <options=bold,underscore>$configuredDriver</>)</comment>";
         }
 
         return $driver;


### PR DESCRIPTION
#3593 introduced some basic system stats to the admin panel. The value for `session driver` returned unuseful content for the web, but was still useful for the CLI response.

![web](https://user-images.githubusercontent.com/16573496/203149745-796d3369-27c8-4044-b74f-62e17db75a95.png)

**Changes proposed in this pull request:**
Pass a `forWeb` boolean (default to `false`) to `identifySessionDriver` when being called from `AdminPayload` and return a shortened version of the text.

![web](https://user-images.githubusercontent.com/16573496/203149997-d24d5804-0e15-403c-8366-fcb57d3bef5f.png)

![cli](https://user-images.githubusercontent.com/16573496/203150049-30f9ded1-92b6-4f54-9cb3-2e579e204ed2.png)

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
- [X] Core developer confirmed locally this works as intended.
- [X] Tests have been added, or are not appropriate here.

