### PR TITLE
feat: allow push additional items to the end of the poststream

### DIFF
--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -97,11 +97,7 @@ export default class PostStream extends Component {
 
     // Allow extensions to add items to the end of the post stream.
     if (viewingEnd) {
-      if (this.endItems().toArray().length) {
-        this.endItems()
-          .toArray()
-          .map((item) => items.push(item));
-      }
+      items.push(...this.endItems().toArray());
     }
 
     // If we're viewing the end of the discussion, the user can reply, and

--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -4,6 +4,7 @@ import ScrollListener from '../../common/utils/ScrollListener';
 import PostLoading from './LoadingPost';
 import ReplyPlaceholder from './ReplyPlaceholder';
 import Button from '../../common/components/Button';
+import ItemList from '../../common/utils/ItemList';
 
 /**
  * The `PostStream` component displays an infinitely-scrollable wall of posts in
@@ -94,6 +95,15 @@ export default class PostStream extends Component {
       );
     }
 
+    // Allow extensions to add items to the end of the post stream.
+    if (viewingEnd) {
+      if (this.endItems().toArray().length) {
+        this.endItems()
+          .toArray()
+          .map((item) => items.push(item));
+      }
+    }
+
     // If we're viewing the end of the discussion, the user can reply, and
     // is not already doing so, then show a 'write a reply' placeholder.
     if (viewingEnd && (!app.session.user || this.discussion.canReply())) {
@@ -109,6 +119,12 @@ export default class PostStream extends Component {
         {items}
       </div>
     );
+  }
+
+  endItems() {
+    const items = new ItemList();
+
+    return items;
   }
 
   onupdate(vnode) {

--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -122,8 +122,8 @@ export default class PostStream extends Component {
   }
 
   /**
-    * @returns {ItemList<import('mithril').Children>}
-    */
+   * @returns {ItemList<import('mithril').Children>}
+   */
   endItems() {
     const items = new ItemList();
 

--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -121,6 +121,9 @@ export default class PostStream extends Component {
     );
   }
 
+  /**
+    * @returns {ItemList<import('mithril').Children>}
+    */
   endItems() {
     const items = new ItemList();
 


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Adds an opportunity for extensions to add additional components via an `ItemList` at the end of the `PostStream`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
