### PR TITLE
fix(mentions): correctly convert a 3 char. hex color to a 6 char. one

### DIFF
--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -205,7 +205,7 @@ class ConfigureMentions
 
         $hexNumbers = Str::replace('#', '', $hexColor);
         if (Str::length($hexNumbers) === 3) {
-            $hexNumbers = $hexNumbers . $hexNumbers;
+            $hexNumbers = $hexNumbers.$hexNumbers;
         }
 
         $r = hexdec(Str::substr($hexNumbers, 0, 2));

--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -205,7 +205,7 @@ class ConfigureMentions
 
         $hexNumbers = Str::replace('#', '', $hexColor);
         if (Str::length($hexNumbers) === 3) {
-            $hexNumbers += $hexNumbers;
+            $hexNumbers = $hexNumbers . $hexNumbers;
         }
 
         $r = hexdec(Str::substr($hexNumbers, 0, 2));


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3693**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Quick fix for https://github.com/flarum/framework/blob/67dd2c21b6c2a2b1bde948015edd0f5a51569229/extensions/mentions/src/ConfigureMentions.php#L206-L209, which seems to be unsupported (string + string operation)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

The before/after behavior should be tested first. See the steps to reproduce in #3693

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
