### PR TITLE
fix: column `id` can be ambiguous in group filter with extensions

### DIFF
--- a/framework/core/src/User/Query/GroupFilterGambit.php
+++ b/framework/core/src/User/Query/GroupFilterGambit.php
@@ -61,7 +61,7 @@ class GroupFilterGambit extends AbstractRegexGambit implements FilterInterface
             }
         }
 
-        $groupQuery->whereIn('group.id', $ids)
+        $groupQuery->whereIn('groups.id', $ids)
             ->orWhereIn('name_singular', $names)
             ->orWhereIn('name_plural', $names);
 

--- a/framework/core/src/User/Query/GroupFilterGambit.php
+++ b/framework/core/src/User/Query/GroupFilterGambit.php
@@ -61,7 +61,7 @@ class GroupFilterGambit extends AbstractRegexGambit implements FilterInterface
             }
         }
 
-        $groupQuery->whereIn('id', $ids)
+        $groupQuery->whereIn('group.id', $ids)
             ->orWhereIn('name_singular', $names)
             ->orWhereIn('name_plural', $names);
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Changed 'id' to 'groups.id' to avoid `Column 'id' in where clause is ambiguous` error.

This error normally doesn't occur, but if an extension adds an `id` column to the `group_user` table, then this error would occur. 

(Adding that column helps when one wants to `chunkById()` on the `group_user` model)

**Reviewers should focus on:**
Nothing is broken by this minor change.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
