### PR TITLE
feat: expose {time} to eventPost data, fix renamed tooltip

### DIFF
--- a/extensions/lock/locale/en.yml
+++ b/extensions/lock/locale/en.yml
@@ -29,8 +29,8 @@ flarum-lock:
 
     # These translations are displayed between posts in the post stream.
     post_stream:
-      discussion_locked_text: "{username} locked the discussion."
-      discussion_unlocked_text: "{username} unlocked the discussion."
+      discussion_locked_text: "{username} locked the discussion {time}."
+      discussion_unlocked_text: "{username} unlocked the discussion {time}."
 
     # These translations are used in the Settings page.
     settings:

--- a/extensions/sticky/locale/en.yml
+++ b/extensions/sticky/locale/en.yml
@@ -25,8 +25,8 @@ flarum-sticky:
 
     # These translations are displayed between posts in the post stream.
     post_stream:
-      discussion_stickied_text: "{username} stickied the discussion."
-      discussion_unstickied_text: "{username} unstickied the discussion."
+      discussion_stickied_text: "{username} stickied the discussion {time}."
+      discussion_unstickied_text: "{username} unstickied the discussion {time}."
 
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!

--- a/extensions/tags/locale/en.yml
+++ b/extensions/tags/locale/en.yml
@@ -92,9 +92,9 @@ flarum-tags:
 
     # These translations are displayed between posts in the post stream.
     post_stream:
-      added_and_removed_tags_text: "{username} added the {tagsAdded} and removed the {tagsRemoved}."
-      added_tags_text: "{username} added the {tagsAdded}."
-      removed_tags_text: "{username} removed the {tagsRemoved}."
+      added_and_removed_tags_text: "{username} added the {tagsAdded} and removed the {tagsRemoved} {time}."
+      added_tags_text: "{username} added the {tagsAdded} {time}."
+      removed_tags_text: "{username} removed the {tagsRemoved} {time}."
       tags_text: "{count, plural, one {{tags} tag} other {{tags} tags}}"
 
     # These translations are used when visiting a single tag's discussion list.

--- a/framework/core/js/src/forum/components/DiscussionRenamedPost.js
+++ b/framework/core/js/src/forum/components/DiscussionRenamedPost.js
@@ -1,6 +1,7 @@
 import app from '../../forum/app';
 import EventPost from './EventPost';
 import extractText from '../../common/utils/extractText';
+import Tooltip from '../../common/components/Tooltip';
 
 /**
  * The `DiscussionRenamedPost` component displays a discussion event post
@@ -17,9 +18,8 @@ export default class DiscussionRenamedPost extends EventPost {
 
   description(data) {
     const renamed = app.translator.trans('core.forum.post_stream.discussion_renamed_text', data);
-    const oldName = app.translator.trans('core.forum.post_stream.discussion_renamed_old_tooltip', data);
 
-    return <span title={extractText(oldName)}>{renamed}</span>;
+    return <span>{renamed}</span>;
   }
 
   descriptionData() {
@@ -28,8 +28,11 @@ export default class DiscussionRenamedPost extends EventPost {
     const newTitle = post.content()[1];
 
     return {
-      old: oldTitle,
-      new: <strong className="DiscussionRenamedPost-new">{newTitle}</strong>,
+      new: (
+        <Tooltip text={extractText(app.translator.trans('core.forum.post_stream.discussion_renamed_old_tooltip', { old: oldTitle }))}>
+          <strong className="DiscussionRenamedPost-new">{newTitle}</strong>
+        </Tooltip>
+      ),
     };
   }
 }

--- a/framework/core/js/src/forum/components/EventPost.js
+++ b/framework/core/js/src/forum/components/EventPost.js
@@ -4,6 +4,7 @@ import { ucfirst } from '../../common/utils/string';
 import usernameHelper from '../../common/helpers/username';
 import icon from '../../common/helpers/icon';
 import Link from '../../common/components/Link';
+import humanTime from '../../common/helpers/humanTime';
 
 /**
  * The `EventPost` component displays a post which indicating a discussion
@@ -37,6 +38,7 @@ export default class EventPost extends Post {
       ) : (
         username
       ),
+      time: humanTime(this.attrs.post.createdAt()),
     });
 
     return super.content().concat([icon(this.icon(), { className: 'EventPost-icon' }), <div class="EventPost-info">{this.description(data)}</div>]);

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -445,7 +445,7 @@ core:
     # These translations are displayed between posts in the post stream.
     post_stream:
       discussion_renamed_old_tooltip: 'The old title was: "{old}"'
-      discussion_renamed_text: "{username} changed the title to {new}."
+      discussion_renamed_text: "{username} changed the title to {new} {time}."
       load_more_button: => core.ref.load_more
       reply_placeholder: => core.ref.write_a_reply
       time_lapsed_text: "{period} later"


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
`DiscussionRenamedPost` used the old style tooltip method, plus the tooltip was triggered by hovering anywhere on the text line. We now use the `Tooltip` component, and only on the discussion title itself.

Adds `time` to `EventPost` attrs, enabling the use of it in translations for event posts easily. See attached screenshots for core/bundled usages.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before:
![image](https://user-images.githubusercontent.com/16573496/204136754-23d7f407-0d99-4092-a614-a487368cb7b2.png)

After:
![image](https://user-images.githubusercontent.com/16573496/204136784-5c1fbac7-0be0-43fe-9f3e-95017645696d.png)

Updated translations using the `time` attr
![image](https://user-images.githubusercontent.com/16573496/204136934-37d7b416-59b9-4d30-afb4-32c1cee23138.png)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
