### PR TITLE
patch an issue with AWS S3 SDK

### DIFF
--- a/framework/core/src/Api/Serializer/ForumSerializer.php
+++ b/framework/core/src/Api/Serializer/ForumSerializer.php
@@ -93,7 +93,7 @@ class ForumSerializer extends AbstractSerializer
             'canViewForum' => $this->actor->can('viewForum'),
             'canStartDiscussion' => $this->actor->can('startDiscussion'),
             'canSearchUsers' => $this->actor->can('searchUsers'),
-            'assetsBaseUrl' => rtrim($this->assetsFilesystem->url(''), '/'),
+            'assetsBaseUrl' => rtrim($this->assetsFilesystem->url('/'), '/'),
         ];
 
         if ($this->actor->can('administrate')) {


### PR DESCRIPTION
patch an issue with AWS S3 SDK in src/Api/Serializer/ForumSerializer.php
SDK crashes without this patch and we can't use our S3-like buckets