### PR TITLE
fix: 3 digit hex color value in color input not supported

### DIFF
--- a/framework/core/js/src/common/components/ColorPreviewInput.tsx
+++ b/framework/core/js/src/common/components/ColorPreviewInput.tsx
@@ -10,6 +10,11 @@ export default class ColorPreviewInput extends Component {
 
     attrs.type ||= 'text';
 
+    // If the input is a 3 digit hex code, convert it to 6 digits.
+    if (attrs.value.length === 4) {
+      attrs.value = attrs.value.replace(/#([a-f0-9])([a-f0-9])([a-f0-9])/, '#$1$1$2$2$3$3');
+    }
+
     return (
       <div className="ColorInput">
         <input className={classList('FormControl', className)} id={id} {...attrs} />


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
When a 3 digit dex color is provided in a `color` input, the preview remains black, due to the [color picker spec](https://www.w3schools.com/TAGS/att_input_type_color.asp) requiring 6 digits. To combat this, if a short hex color is provided, convert it.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
