### PR TITLE
The negate field doesn't get used, which means you cant exclude tags

### DIFF
--- a/extensions/tags/src/Filter/PostTagFilter.php
+++ b/extensions/tags/src/Filter/PostTagFilter.php
@@ -23,6 +23,6 @@ class PostTagFilter implements FilterInterface
     {
         $filterState->getQuery()
             ->join('discussion_tag', 'discussion_tag.discussion_id', '=', 'posts.discussion_id')
-            ->where('discussion_tag.tag_id', $filterValue);
+            ->where('discussion_tag.tag_id', $negate ? '!=' : '=', $filterValue);
     }
 }


### PR DESCRIPTION
Currently you cannot filter discussions/posts by excluding tag ids, as the `$negate` boolean is ignored.

`/api/posts?sort=-createdAt&filter[tag]=14` to include tag 14

and 

`/api/posts?sort=-createdAt&filter[tag]=-14` to exclude tag 14

-------

Unless there's a different way to handle this?