### PR TITLE
fix: load actor.groups on showforumcontroller

### DIFF
--- a/framework/core/src/Api/Controller/ShowForumController.php
+++ b/framework/core/src/Api/Controller/ShowForumController.php
@@ -25,7 +25,7 @@ class ShowForumController extends AbstractShowController
     /**
      * {@inheritdoc}
      */
-    public $include = ['groups', 'actor'];
+    public $include = ['groups', 'actor', 'actor.groups'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
SInce the changes here https://github.com/flarum/framework/commit/67c0d75ebc9db2b3bc7544849cf6eb8b5002c858#, th `actor` groups relation is no longer loaded.

This PR forces the groups to be included by default