### PR TITLE
fix: permissions table on mobile is unusable

### DIFF
--- a/framework/core/less/admin/PermissionsPage.less
+++ b/framework/core/less/admin/PermissionsPage.less
@@ -63,9 +63,12 @@
     z-index: 1;
 
     &:first-child {
-      left: 0;
       z-index: 3;
       background: var(--body-bg);
+
+      @media @tablet-up {
+        left: 0;
+      }
     }
 
     &:not(:hover) .PermissionGrid-removeScope {
@@ -74,12 +77,15 @@
   }
   tbody {
     th {
-      position: -webkit-sticky;
-      position: sticky;
-      left: 0;
       padding-right: 50px;
       z-index: 4;
       background: inherit;
+
+      @media @tablet-up {
+        position: -webkit-sticky;
+        position: sticky;
+        left: 0;
+      }
 
       .icon {
         margin-right: 5px;

--- a/framework/core/less/admin/PermissionsPage.less
+++ b/framework/core/less/admin/PermissionsPage.less
@@ -50,7 +50,6 @@
     color: var(--muted-color);
   }
   thead th {
-    position: -webkit-sticky;
     position: sticky;
     top: 0;
     padding-bottom: 10px;

--- a/framework/core/less/admin/PermissionsPage.less
+++ b/framework/core/less/admin/PermissionsPage.less
@@ -82,7 +82,6 @@
       background: inherit;
 
       @media @tablet-up {
-        position: -webkit-sticky;
         position: sticky;
         left: 0;
       }


### PR DESCRIPTION
**Fixes #3649**

**Changes proposed in this pull request:**
Removes sticky positioning on mobile.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
