### PR TITLE
Update forum.less to fix the misalignment of the choose tags button

### DIFF
--- a/extensions/tags/less/forum.less
+++ b/extensions/tags/less/forum.less
@@ -36,7 +36,6 @@
 }
 .DiscussionComposer-changeTags {
   margin-right: 15px;
-  vertical-align: 2px;
 
   &.disabled {
     opacity: 0.5;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**

This little PR is simply to remove a CSS rule.

I'm not sure of the reason for this `vertical-align: 2px;` (maybe at some point you had a good reason), but currently this makes the button display misaligned with respect to the Discussion Title input (although in this case it can go unnoticed), but in conjunction with other extensions it's quite noticeable as it's the only misaligned button, as you can see in the case of the screenshot with `flamarkt/taxonomies`

**Reviewers should focus on:**

Is there any need to keep the `vertical-align: 2px;`?

**Screenshots**
<!-- include an image of the most relevant user-facing change, if any -->

Current with `vertical-align: 2px;`
![Screenshot 2023-02-04 195405](https://user-images.githubusercontent.com/15818451/216784783-10f8413c-08fc-4033-8d58-e174a295837d.png)

Without `vertical-align: 2px;` (This PR)
![Screenshot 2023-02-04 195425](https://user-images.githubusercontent.com/15818451/216784779-1019efc9-de92-4e16-b11f-f696084deb78.png)

To add other extensions with which the issue is clearly visible:
- `fof/polls`
- `fof/discussion-language`

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
