### PR TITLE
feat(actions): allow running JS tests in GH actions 

### DIFF
--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -28,6 +28,11 @@ on:
         type: string
         required: false
         default: check-typings-coverage
+      test_script:
+        description: "Script to run for tests. Empty value to disable."
+        type: string
+        required: false
+        default: test
 
       enable_bundlewatch:
         description: "Enable Bundlewatch?"
@@ -43,6 +48,11 @@ on:
         description: "Enable TypeScript?"
         type: boolean
         default: true
+        required: false
+      enable_tests:
+        description: "Enable Tests?"
+        type: boolean
+        default: false
         required: false
 
       backend_directory:
@@ -96,10 +106,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.js_package_manager }}
@@ -130,6 +140,7 @@ jobs:
           format_script: ${{ inputs.enable_prettier == true && inputs.format_script || '' }}
           check_typings_script: ${{ inputs.enable_typescript == true && inputs.check_typings_script || '' }}
           type_coverage_script: ${{ inputs.enable_typescript == true && inputs.type_coverage_script || '' }}
+          test_script: ${{ inputs.enable_tests == true && inputs.test_script || '' }}
           package_manager: ${{ inputs.js_package_manager }}
           js_path: ${{ inputs.frontend_directory }}
           do_not_commit: ${{ github.ref != format('refs/heads/{0}', inputs.main_git_branch) || github.event_name != 'push' }}

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -132,7 +132,7 @@ jobs:
         working-directory: ${{ inputs.frontend_directory }}
 
       - name: JS Checks & Production Build
-        uses: flarum/action-build@3
+        uses: flarum/action-build@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: ${{ inputs.build_script }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -11,6 +11,9 @@ jobs:
       js_package_manager: yarn
       cache_dependency_path: ./yarn.lock
       main_git_branch: main
+      enable_tests: true
+      # @TODO: fix bundlewatch
+      enable_bundlewatch: false
 
     secrets:
       bundlewatch_github_token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}


### PR DESCRIPTION
**Changes proposed in this pull request:**
Now that we have frontend Jest tests (#3678, #3679), we can add the workflow step using (flarum/action-build#12) to take care of it.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.