### PR TITLE
feat(seo): Use h2 header for discussions on discussions list

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -117,7 +117,7 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
           <ul className="DiscussionListItem-badges badges">{listItems(discussion.badges().toArray())}</ul>
 
           <Link href={app.route.discussion(discussion, jumpTo)} className="DiscussionListItem-main">
-            <h3 className="DiscussionListItem-title">{highlight(discussion.title(), this.highlightRegExp)}</h3>
+            <h2 className="DiscussionListItem-title">{highlight(discussion.title(), this.highlightRegExp)}</h2>
             <ul className="DiscussionListItem-info">{listItems(this.infoItems().toArray())}</ul>
           </Link>
           {this.replyCountItem()}

--- a/framework/core/js/src/forum/components/DiscussionListPane.js
+++ b/framework/core/js/src/forum/components/DiscussionListPane.js
@@ -22,7 +22,7 @@ export default class DiscussionListPane extends Component {
       return;
     }
 
-    return <div className="DiscussionPage-list">{this.enoughSpace() && <DiscussionList state={this.attrs.state} />}</div>;
+    return <aside className="DiscussionPage-list">{this.enoughSpace() && <DiscussionList state={this.attrs.state} />}</aside>;
   }
 
   oncreate(vnode) {

--- a/framework/core/views/frontend/content/discussion.blade.php
+++ b/framework/core/views/frontend/content/discussion.blade.php
@@ -1,15 +1,15 @@
 <div class="container">
-    <h2>{{ $apiDocument->data->attributes->title }}</h2>
+    <h1>{{ $apiDocument->data->attributes->title }}</h1>
 
     <div>
         @foreach ($posts as $post)
-            <div>
+            <article>
                 @php $user = ! empty($post->relationships->user->data) ? $getResource($post->relationships->user->data) : null; @endphp
                 <h3>{{ $user ? $user->attributes->displayName : $translator->trans('core.lib.username.deleted_text') }}</h3>
                 <div class="Post-body">
                     {!! $post->attributes->contentHtml !!}
                 </div>
-            </div>
+            </article>
 
             <hr>
         @endforeach

--- a/framework/core/views/frontend/content/index.blade.php
+++ b/framework/core/views/frontend/content/index.blade.php
@@ -1,7 +1,7 @@
 @inject('url', 'Flarum\Http\UrlGenerator')
 
 <div class="container">
-    <h2>{{ $translator->trans('core.views.index.all_discussions_heading') }}</h2>
+    <h1>{{ $translator->trans('core.views.index.all_discussions_heading') }}</h1>
 
     <ul>
         @foreach ($apiDocument->data as $discussion)


### PR DESCRIPTION
**Changes proposed in this pull request:**

Continuation of https://github.com/flarum/framework/pull/3724 - since tag/mainpage header changed from h2 to h1, next header should be h2. See https://github.com/flarum/framework/pull/3724#discussion_r1083536881

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

