### PR TITLE
feat(seo): Do not use h3 header for poster author in posts stream

### DIFF
--- a/framework/core/js/src/forum/components/PostUser.js
+++ b/framework/core/js/src/forum/components/PostUser.js
@@ -22,9 +22,9 @@ export default class PostUser extends Component {
     if (!user) {
       return (
         <div className="PostUser">
-          <div class="PostUser-name">
+          <h3 class="PostUser-name">
             {avatar(user, { className: 'PostUser-avatar' })} {username(user)}
-          </div>
+          </h3>
         </div>
       );
     }
@@ -41,13 +41,13 @@ export default class PostUser extends Component {
 
     return (
       <div className="PostUser">
-        <div class="PostUser-name">
+        <h3 class="PostUser-name">
           <Link href={app.route.user(user)}>
             {avatar(user, { className: 'PostUser-avatar' })}
             {userOnline(user)}
             {username(user)}
           </Link>
-        </div>
+        </h3>
         <ul className="PostUser-badges badges">{listItems(user.badges().toArray())}</ul>
         {card}
       </div>

--- a/framework/core/js/src/forum/components/PostUser.js
+++ b/framework/core/js/src/forum/components/PostUser.js
@@ -22,9 +22,9 @@ export default class PostUser extends Component {
     if (!user) {
       return (
         <div className="PostUser">
-          <h3>
+          <div class="PostUser-name">
             {avatar(user, { className: 'PostUser-avatar' })} {username(user)}
-          </h3>
+          </div>
         </div>
       );
     }
@@ -41,13 +41,13 @@ export default class PostUser extends Component {
 
     return (
       <div className="PostUser">
-        <h3>
+        <div class="PostUser-name">
           <Link href={app.route.user(user)}>
             {avatar(user, { className: 'PostUser-avatar' })}
             {userOnline(user)}
             {username(user)}
           </Link>
-        </h3>
+        </div>
         <ul className="PostUser-badges badges">{listItems(user.badges().toArray())}</ul>
         {card}
       </div>
@@ -60,11 +60,11 @@ export default class PostUser extends Component {
     let timeout;
 
     this.$()
-      .on('mouseover', 'h3 a, .UserCard', () => {
+      .on('mouseover', '.PostUser-name a, .UserCard', () => {
         clearTimeout(timeout);
         timeout = setTimeout(this.showCard.bind(this), 500);
       })
-      .on('mouseout', 'h3 a, .UserCard', () => {
+      .on('mouseout', '.PostUser-name a, .UserCard', () => {
         clearTimeout(timeout);
         timeout = setTimeout(this.hideCard.bind(this), 250);
       });

--- a/framework/core/js/src/forum/components/ReplyPlaceholder.js
+++ b/framework/core/js/src/forum/components/ReplyPlaceholder.js
@@ -21,10 +21,10 @@ export default class ReplyPlaceholder extends Component {
         <article className="Post CommentPost editing" aria-busy="true">
           <header className="Post-header">
             <div className="PostUser">
-              <h3>
+              <div class="PostUser-name">
                 {avatar(app.session.user, { className: 'PostUser-avatar' })}
                 {username(app.session.user)}
-              </h3>
+              </div>
               <ul className="PostUser-badges badges">{listItems(app.session.user.badges().toArray())}</ul>
             </div>
           </header>

--- a/framework/core/js/src/forum/components/ReplyPlaceholder.js
+++ b/framework/core/js/src/forum/components/ReplyPlaceholder.js
@@ -21,10 +21,10 @@ export default class ReplyPlaceholder extends Component {
         <article className="Post CommentPost editing" aria-busy="true">
           <header className="Post-header">
             <div className="PostUser">
-              <div class="PostUser-name">
+              <h3 class="PostUser-name">
                 {avatar(app.session.user, { className: 'PostUser-avatar' })}
                 {username(app.session.user)}
-              </div>
+              </h3>
               <ul className="PostUser-badges badges">{listItems(app.session.user.badges().toArray())}</ul>
             </div>
           </header>

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -40,10 +40,14 @@
   font-weight: normal;
   position: relative;
 
-  h3 {
+  // TODO: remove styles for h3 on Flarum 2.0 cleanup - they may be used by extensions, but they should target `.PostUser-name` class instead
+  h3,
+  .PostUser-name {
     display: inline;
   }
-  h3, h3 a {
+  // TODO: remove styles for h3 on Flarum 2.0 cleanup - they may be used by extensions, but they should target `.PostUser-name` class instead
+  h3, h3 a,
+  .PostUser-name, .PostUser-name a {
     color: var(--heading-color);
     font-weight: bold;
     font-size: 14px;
@@ -190,18 +194,31 @@
 }
 
 .Post--hidden {
-  .Post-header, .Post-header a, .PostUser h3, .PostUser h3 a {
+  .Post-header, .Post-header a,
+  // TODO: remove styles for h3 on Flarum 2.0 cleanup - they may be used by extensions, but they should target `.PostUser-name` class instead
+  .PostUser h3, .PostUser h3 a,
+  .PostUser .PostUser-name, .PostUser .PostUser-name a {
     color: var(--muted-more-color);
   }
   &:not(.revealContent) {
     .Post-header {
       margin-bottom: 0;
     }
-    .Post-body, .Post-footer, h3 .Avatar, .PostUser-badges {
+    .Post-body,
+    .Post-footer,
+    // TODO: remove styles for h3 on Flarum 2.0 cleanup - they may be used by extensions, but they should target `.PostUser-name` class instead
+    h3 .Avatar,
+    .PostUser-name .Avatar,
+    .PostUser-badges {
       display: none;
     }
   }
-  .Post-body, .Post-footer, h3 .Avatar, .PostUser-badges {
+  .Post-body,
+  .Post-footer,
+  // TODO: remove styles for h3 on Flarum 2.0 cleanup - they may be used by extensions, but they should target `.PostUser-name` class instead
+  h3 .Avatar,
+  .PostUser-name .Avatar,
+  .PostUser-badges {
     opacity: 0.5;
   }
   .Post-header .Button--more {

--- a/framework/core/views/frontend/content/discussion.blade.php
+++ b/framework/core/views/frontend/content/discussion.blade.php
@@ -5,7 +5,7 @@
         @foreach ($posts as $post)
             <div>
                 @php $user = ! empty($post->relationships->user->data) ? $getResource($post->relationships->user->data) : null; @endphp
-                <div class="PostUser"><div class="PostUser-name">{{ $user ? $user->attributes->displayName : $translator->trans('core.lib.username.deleted_text') }}</div></div>
+                <div class="PostUser"><h3 class="PostUser-name">{{ $user ? $user->attributes->displayName : $translator->trans('core.lib.username.deleted_text') }}</h3></div>
                 <div class="Post-body">
                     {!! $post->attributes->contentHtml !!}
                 </div>

--- a/framework/core/views/frontend/content/discussion.blade.php
+++ b/framework/core/views/frontend/content/discussion.blade.php
@@ -5,7 +5,7 @@
         @foreach ($posts as $post)
             <div>
                 @php $user = ! empty($post->relationships->user->data) ? $getResource($post->relationships->user->data) : null; @endphp
-                <h3>{{ $user ? $user->attributes->displayName : $translator->trans('core.lib.username.deleted_text') }}</h3>
+                <div class="PostUser"><div class="PostUser-name">{{ $user ? $user->attributes->displayName : $translator->trans('core.lib.username.deleted_text') }}</div></div>
                 <div class="Post-body">
                     {!! $post->attributes->contentHtml !!}
                 </div>


### PR DESCRIPTION
See https://github.com/flarum/framework/pull/3724#discussion_r1083536881

However this is more tricky, as some extensions rely on current markup. During brief testing I found 2 problems:

1. Best Answer extension uses h3 for displaying username and it relies on styles provided by core. That is why I kept old styles for h3 tag - additional styles should not be a big problem and we keep BC this way. Redundant styles could be removed on 2.0 release.
2. FoF Gamification crashed completely, because it searches for `h3` tag: 
   https://github.com/FriendsOfFlarum/gamification/blob/aad90d175fe55b3609de8c7649f9364765a37853/js/src/forum/components/RankingsPage.js#L76
   This could be quite easily fixed in extension, but BC break is obvious and there could be more extensions affected by this change. If we want to keep BC here, I don't think there is other solution than postponing this change to 2.0.

In future it would be better to add CSS classes everywhere and discourage relying on markup, as used tag may always change. Even some basic cases like targeting link using `a` selector may be problematic, because in future this link may be changed to button instead.


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
