### PR TITLE
fix: infinite scroll not initialized for notifications on big screens

### DIFF
--- a/framework/core/js/src/forum/states/NotificationListState.ts
+++ b/framework/core/js/src/forum/states/NotificationListState.ts
@@ -4,7 +4,7 @@ import Notification from '../../common/models/Notification';
 
 export default class NotificationListState extends PaginatedListState<Notification> {
   constructor() {
-    super({}, 1, 10);
+    super({}, 1, 20);
   }
 
   get type(): string {

--- a/framework/core/less/forum/NotificationsDropdown.less
+++ b/framework/core/less/forum/NotificationsDropdown.less
@@ -3,7 +3,7 @@
     padding: 0;
 
     .NotificationList-content {
-      max-height: 70vh;
+      max-height: ~"min(70vh, 800px)";
       overflow: auto;
     }
   }

--- a/framework/core/src/Api/Controller/ListNotificationsController.php
+++ b/framework/core/src/Api/Controller/ListNotificationsController.php
@@ -34,11 +34,6 @@ class ListNotificationsController extends AbstractListController
     ];
 
     /**
-     * {@inheritdoc}
-     */
-    public $limit = 10;
-
-    /**
      * @var NotificationRepository
      */
     protected $notifications;


### PR DESCRIPTION
**Changes proposed in this pull request:**

On QHD screens `70vh` is bigger than space taken by 10 notifications. As a result there is no scroll for this dropdown, and as a result infinite scroll do not work in this place. I mentioned this on Discord a few months ago: https://discord.com/channels/360670804914208769/707030467450372166/1010096800511836261

This PR sets max height of this dropdown to 800px and increases number of notifications loaded in this dropdown, to make sure it is always filled.


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
