### PR TITLE
fix: invalid translation key for scheduler dashboard

### DIFF
--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -119,7 +119,7 @@ class ApplicationInfoProvider
         // If the schedule has not run in the last 5 minutes, mark it as inactive.
         return Carbon::parse($status) > Carbon::now()->subMinutes(5)
             ? $this->translator->trans('core.admin.dashboard.status.scheduler.active')
-            : $this->translator->trans('core.admin.status.scheduler.inactive');
+            : $this->translator->trans('core.admin.dashboard.status.scheduler.inactive');
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/flarum/framework/issues/3697


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
