### PR TITLE
fix(tags): clickable tag labels have underline

### DIFF
--- a/extensions/tags/less/common/TagLabel.less
+++ b/extensions/tags/less/common/TagLabel.less
@@ -7,6 +7,7 @@
   background: var(--tag-bg);
   color: var(--tag-color);
   text-transform: none;
+  text-decoration: none !important;
   vertical-align: bottom;
 
   &.untagged {


### PR DESCRIPTION
Currently there is a bug where underline has incorrect color if tag is displayed inside of `.EventPost`:

![2245dc82](https://user-images.githubusercontent.com/5972388/219677466-f2e2461f-3a73-4e53-ac0c-2caffa208862.png)

This PR removes underline in this label completely, since even with fixed color it IMO looks weird.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
