### PR TITLE
feat: add display name column to admin users list

### DIFF
--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -217,6 +217,15 @@ export default class UserListPage extends AdminPage {
     );
 
     columns.add(
+      'displayName',
+      {
+        name: app.translator.trans('core.admin.users.grid.columns.display_name.title'),
+        content: (user: User) => user.displayName(),
+      },
+      85
+    );
+
+    columns.add(
       'joinDate',
       {
         name: app.translator.trans('core.admin.users.grid.columns.join_time.title'),

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -245,6 +245,9 @@ core:
 
       grid:
         columns:
+          display_name:
+            title: Display name
+
           edit_user:
             button: => core.ref.edit
             title: => core.ref.edit_user


### PR DESCRIPTION
Supersedes #2998

Progresses #3742

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- Adds a new display name column to the admin users list

Not all users have the same username and display name, so we should show both in the list of users.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![image](https://user-images.githubusercontent.com/7406822/220313784-e9ca2631-61fd-4f2b-ac51-d6d51bb9e0db.png)



**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

