### PR TITLE
feat: improved page navigation for users list

### DIFF
--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -151,6 +151,13 @@ export default class UserListPage extends AdminPage {
       <nav class="UserListPage-gridPagination">
         <Button
           disabled={this.pageNumber === 0}
+          title={app.translator.trans('core.admin.users.pagination.first_page_button')}
+          onclick={this.goToPage.bind(this, 1)}
+          icon="fas fa-step-backward"
+          className="Button Button--icon UserListPage-firstPageBtn"
+        />
+        <Button
+          disabled={this.pageNumber === 0}
           title={app.translator.trans('core.admin.users.pagination.back_button')}
           onclick={this.previousPage.bind(this)}
           icon="fas fa-chevron-left"
@@ -168,6 +175,13 @@ export default class UserListPage extends AdminPage {
           onclick={this.nextPage.bind(this)}
           icon="fas fa-chevron-right"
           className="Button Button--icon UserListPage-nextBtn"
+        />
+        <Button
+          disabled={!this.moreData}
+          title={app.translator.trans('core.admin.users.pagination.last_page_button')}
+          onclick={this.goToPage.bind(this, this.getTotalPageCount())}
+          icon="fas fa-step-forward"
+          className="Button Button--icon UserListPage-lastPageBtn"
         />
       </nav>,
     ];
@@ -389,5 +403,13 @@ export default class UserListPage extends AdminPage {
   previousPage() {
     this.isLoadingPage = true;
     this.loadPage(this.pageNumber - 1);
+  }
+
+  /**
+   * @param page The **1-based** page number
+   */
+  goToPage(page: number) {
+    this.isLoadingPage = true;
+    this.loadPage(page - 1);
   }
 }

--- a/framework/core/less/admin/UsersListPage.less
+++ b/framework/core/less/admin/UsersListPage.less
@@ -69,10 +69,16 @@
   }
 
   &-gridPagination {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto auto 1fr auto auto;
+    gap: 8px;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
     margin-top: 16px;
+  }
+
+  &-pageNumber {
+    text-align: center;
   }
 }
 

--- a/framework/core/less/admin/UsersListPage.less
+++ b/framework/core/less/admin/UsersListPage.less
@@ -80,6 +80,13 @@
   &-pageNumber {
     text-align: center;
   }
+
+  &-pageNumberInput {
+    display: inline-block;
+    margin: 0 8px;
+    width: auto;
+    max-width: 80px;
+  }
 }
 
 // Handles styling of default UserList columns

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -274,6 +274,7 @@ core:
       pagination:
         back_button: Previous page
         first_button: Go to first page
+        go_to_page_textbox_a11y_label: Go directly to page number
         last_button: Go to last page
         next_button: Next page
         page_counter: Page {current} of {total}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -273,6 +273,8 @@ core:
 
       pagination:
         back_button: Previous page
+        first_button: Go to first page
+        last_button: Go to last page
         next_button: Next page
         page_counter: Page {current} of {total}
 


### PR DESCRIPTION
Supersedes #2998

Progresses #3742

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- add first/last page buttons
- add page navigation by query parameter (actually part of the hash due to how the admin navigation system works)
- add text box to navigate directly to a page number

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![](https://user-images.githubusercontent.com/7406822/220329910-9f9f542d-372d-4fec-af90-e8ffa111abb5.png)

![](https://user-images.githubusercontent.com/7406822/220329850-900a1437-3b07-4353-a1fa-49c9939fe536.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
