### PR TITLE
fix(regression): cannot delete users

### DIFF
--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -99,7 +99,7 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
     $map->delete(
         '/users/{id}',
         'users.delete',
-        $route->toController(Controller\DeleteAccessTokenController::class)
+        $route->toController(Controller\DeleteUserController::class)
     );
 
     // Upload avatar

--- a/framework/core/tests/integration/api/users/DeleteTest.php
+++ b/framework/core/tests/integration/api/users/DeleteTest.php
@@ -9,10 +9,8 @@
 
 namespace integration\api\users;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
-use Flarum\User\RegistrationToken;
 use Flarum\User\User;
 
 class DeleteTest extends TestCase

--- a/framework/core/tests/integration/api/users/DeleteTest.php
+++ b/framework/core/tests/integration/api/users/DeleteTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace integration\api\users;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\RegistrationToken;
+use Flarum\User\User;
+
+class DeleteTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'ken', 'is_email_confirmed' => 1],
+            ],
+            'group_user' => [
+                ['group_id' => 3, 'user_id' => 2],
+                ['group_id' => 3, 'user_id' => 3],
+            ]
+        ]);
+    }
+
+    /**
+     * @dataProvider authorizedUsersProvider
+     * @test
+     */
+    public function can_delete_user(int $actorId, int $userId)
+    {
+        $this->database()->table('group_permission')->insert([
+            'permission' => 'user.delete',
+            'group_id' => 3,
+        ]);
+
+        $response = $this->send(
+            $this->request('DELETE', "/api/users/$userId", [
+                'authenticatedAs' => $actorId,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(User::find($userId));
+    }
+
+    public function authorizedUsersProvider()
+    {
+        return [
+            'admin can delete user' => [1, 2],
+            'user with permission can delete self' => [2, 2],
+            'user with permission can delete other users' => [2, 3],
+        ];
+    }
+
+    /**
+     * @dataProvider unauthorizedUsersProvider
+     * @test
+     */
+    public function cannot_delete_user(int $actorId, int $userId)
+    {
+        $response = $this->send(
+            $this->request('DELETE', "/api/users/$userId", [
+                'authenticatedAs' => $actorId,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertNotNull(User::find($userId));
+    }
+
+    public function unauthorizedUsersProvider()
+    {
+        return [
+            'user without permission cannot delete self' => [2, 2],
+            'user without permission cannot delete other users' => [2, 3],
+        ];
+    }
+}


### PR DESCRIPTION
**Fixes #3745**

**Changes proposed in this pull request:**
* Seems like I mistakenly changed the delete controller for users to the access token one in #3587
* Added tests for deleting a user while at it.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
