### PR TITLE
Fix placeholders names used in 'core.forum.security.token_item_title' translation

### DIFF
--- a/framework/core/js/src/forum/components/AccessTokensList.tsx
+++ b/framework/core/js/src/forum/components/AccessTokensList.tsx
@@ -185,7 +185,7 @@ export default class AccessTokensList<CustomAttrs extends IAccessTokensListAttrs
     const name = token.title() || app.translator.trans('core.forum.security.token_title_placeholder');
     const value = this.tokenValueDisplay(token);
 
-    return app.translator.trans('core.forum.security.token_item_title', { name, value });
+    return app.translator.trans('core.forum.security.token_item_title', { title: name, token: value });
   }
 
   tokenValueDisplay(token: AccessToken): Mithril.Children {


### PR DESCRIPTION
See https://github.com/flarum/framework/blob/da651c722bfca42241478513098358c5af3eb5fa/framework/core/locale/core.yml#L505

Without this change token title always contains only `-`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
