### PR TITLE
chore: hide developer tokens section in if there is nothing to display or create

### DIFF
--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -58,11 +58,7 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
     ) {
       items.add(
         'developerTokensItems',
-        <FieldSet
-          className="UserSecurityPage-developerTokensItems"
-          styles={!this.state.hasLoadedTokens() || !this.state.getDeveloperTokens() ? { display: 'none' } : { color: 'red' }}
-          label={app.translator.trans(`core.forum.security.developer_tokens_heading`)}
-        >
+        <FieldSet className="UserSecurityPage-developerTokensItems" label={app.translator.trans(`core.forum.security.developer_tokens_heading`)}>
           {this.developerTokensItems().toArray()}
         </FieldSet>
       );

--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -58,7 +58,7 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
     ) {
       items.add(
         'developerTokensItems',
-        <FieldSet className="UserSecurityPage-developerTokensItems" label={app.translator.trans(`core.forum.security.developer_tokens_heading`)}>
+        <FieldSet className="UserSecurityPage-developerTokens" label={app.translator.trans(`core.forum.security.developer_tokens_heading`)}>
           {this.developerTokensItems().toArray()}
         </FieldSet>
       );
@@ -68,7 +68,7 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
 
     items.add(
       'sessionsItems',
-      <FieldSet className="UserSecurityPage-sessionsItems" label={app.translator.trans(`core.forum.security.sessions_heading`)}>
+      <FieldSet className="UserSecurityPage-sessions" label={app.translator.trans(`core.forum.security.sessions_heading`)}>
         {this.sessionsItems().toArray()}
       </FieldSet>
     );

--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -57,17 +57,17 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
       (this.state.hasLoadedTokens() && this.state.getDeveloperTokens()?.length)
     ) {
       items.add(
-        'developerTokensItems',
+        'developerTokens',
         <FieldSet className="UserSecurityPage-developerTokens" label={app.translator.trans(`core.forum.security.developer_tokens_heading`)}>
           {this.developerTokensItems().toArray()}
         </FieldSet>
       );
     } else if (!this.state.hasLoadedTokens()) {
-      items.add('developerTokensItems', <LoadingIndicator />);
+      items.add('developerTokens', <LoadingIndicator />);
     }
 
     items.add(
-      'sessionsItems',
+      'sessions',
       <FieldSet className="UserSecurityPage-sessions" label={app.translator.trans(`core.forum.security.sessions_heading`)}>
         {this.sessionsItems().toArray()}
       </FieldSet>

--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -51,17 +51,30 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
   settingsItems() {
     const items = new ItemList<Mithril.Children>();
 
-    ['developerTokens', 'sessions'].forEach((section) => {
-      const sectionName = `${section}Items` as 'developerTokensItems' | 'sessionsItems';
-      const sectionLocale = camelCaseToSnakeCase(section);
-
+    if (
+      app.forum.attribute('canCreateAccessToken') || app.forum.attribute('canModerateAccessTokens')
+      || (this.state.hasLoadedTokens() && this.state.getDeveloperTokens()?.length)
+    ) {
       items.add(
-        section,
-        <FieldSet className={`UserSecurityPage-${section}`} label={app.translator.trans(`core.forum.security.${sectionLocale}_heading`)}>
-          {this[sectionName]().toArray()}
+        'developerTokensItems',
+        <FieldSet
+          className="UserSecurityPage-developerTokensItems"
+          styles={!this.state.hasLoadedTokens() || !this.state.getDeveloperTokens() ? {display: 'none'} : {color: 'red'}}
+          label={app.translator.trans(`core.forum.security.developer_tokens_heading`)}
+        >
+          {this.developerTokensItems().toArray()}
         </FieldSet>
       );
-    });
+    } else if (!this.state.hasLoadedTokens()) {
+      items.add('developerTokensItems', <LoadingIndicator/>);
+    }
+
+    items.add(
+      'sessionsItems',
+      <FieldSet className="UserSecurityPage-sessionsItems" label={app.translator.trans(`core.forum.security.sessions_heading`)}>
+        {this.sessionsItems().toArray()}
+      </FieldSet>
+    );
 
     if (this.user!.id() === app.session.user!.id()) {
       items.add(

--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -52,21 +52,22 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
     const items = new ItemList<Mithril.Children>();
 
     if (
-      app.forum.attribute('canCreateAccessToken') || app.forum.attribute('canModerateAccessTokens')
-      || (this.state.hasLoadedTokens() && this.state.getDeveloperTokens()?.length)
+      app.forum.attribute('canCreateAccessToken') ||
+      app.forum.attribute('canModerateAccessTokens') ||
+      (this.state.hasLoadedTokens() && this.state.getDeveloperTokens()?.length)
     ) {
       items.add(
         'developerTokensItems',
         <FieldSet
           className="UserSecurityPage-developerTokensItems"
-          styles={!this.state.hasLoadedTokens() || !this.state.getDeveloperTokens() ? {display: 'none'} : {color: 'red'}}
+          styles={!this.state.hasLoadedTokens() || !this.state.getDeveloperTokens() ? { display: 'none' } : { color: 'red' }}
           label={app.translator.trans(`core.forum.security.developer_tokens_heading`)}
         >
           {this.developerTokensItems().toArray()}
         </FieldSet>
       );
     } else if (!this.state.hasLoadedTokens()) {
-      items.add('developerTokensItems', <LoadingIndicator/>);
+      items.add('developerTokensItems', <LoadingIndicator />);
     }
 
     items.add(


### PR DESCRIPTION
Possible implementation for https://discuss.flarum.org/d/32531-hide-developer-tokens-section-in-security-view-if-user-cant-create-tokens.

It hides this section if user does not have permission to create or moderate tokens, and list of tokens is empty. `LoadingIndicator` is displayed until list of tokens is loaded.


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
