### PR TITLE
Make some headers translatable in `StatusWidget`

### DIFF
--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -49,8 +49,16 @@ export default class StatusWidget extends DashboardWidget {
       );
     }
 
-    items.add('queue-driver', [<strong>{app.translator.trans('core.admin.dashboard.status.headers.queue-driver')}</strong>, <br />, app.data.queueDriver], 60);
-    items.add('session-driver', [<strong>{app.translator.trans('core.admin.dashboard.status.headers.session-driver')}</strong>, <br />, app.data.sessionDriver], 50);
+    items.add(
+      'queue-driver',
+      [<strong>{app.translator.trans('core.admin.dashboard.status.headers.queue-driver')}</strong>, <br />, app.data.queueDriver],
+      60
+    );
+    items.add(
+      'session-driver',
+      [<strong>{app.translator.trans('core.admin.dashboard.status.headers.session-driver')}</strong>, <br />, app.data.sessionDriver],
+      50
+    );
 
     return items;
   }

--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -39,7 +39,7 @@ export default class StatusWidget extends DashboardWidget {
         'schedule-status',
         [
           <span>
-            <strong>Scheduler</strong>{' '}
+            <strong>{app.translator.trans('core.admin.dashboard.status.headers.scheduler-status')}</strong>{' '}
             <LinkButton href="https://discuss.flarum.org/d/24118" external={true} target="_blank" icon="fas fa-info-circle" />
           </span>,
           <br />,
@@ -49,8 +49,8 @@ export default class StatusWidget extends DashboardWidget {
       );
     }
 
-    items.add('queue-driver', [<strong>Queue Driver</strong>, <br />, app.data.queueDriver], 60);
-    items.add('session-driver', [<strong>Session Driver</strong>, <br />, app.data.sessionDriver], 50);
+    items.add('queue-driver', [<strong>{app.translator.trans('core.admin.dashboard.status.headers.queue-driver')}</strong>, <br />, app.data.queueDriver], 60);
+    items.add('session-driver', [<strong>{app.translator.trans('core.admin.dashboard.status.headers.session-driver')}</strong>, <br />, app.data.sessionDriver], 50);
 
     return items;
   }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -58,6 +58,10 @@ core:
       description: Your forum at a glance.
       io_error_message: "Could not write to filesystem. Check your filesystem permissions and try again. Or try running from the command line."
       status:
+        headers:
+          scheduler-status: Scheduler
+          queue-driver: Queue Driver
+          session-driver: Session Driver
         scheduler:
           active: Active
           inactive: Inactive

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -69,7 +69,7 @@ core:
       title: Dashboard
       tools_button: Tools
 
-    # These translations are usin in the debug warning widget.
+    # These translations are used in the debug warning widget.
     debug-warning:
       detail: |
         When <code>debug</code> mode is active, Flarum will rebuild its <code>JavaScript</code> and <code>CSS</code> assets on every request, and could also potentially leak other information, such as database secrets, environment variables, etc.


### PR DESCRIPTION
This PR makes this section translatable:

![19dd68cd](https://user-images.githubusercontent.com/5972388/224515689-0f574a1a-fb7a-4ddd-b1ee-c02c927047b8.png)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
