### PR TITLE
chore: search input padding right to much

### DIFF
--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -75,7 +75,6 @@
     float: left;
     width: 225px;
     padding-left: 32px;
-    padding-right: 32px;
     transition: var(--transition), width 0.4s;
     box-sizing: inherit !important;
   }


### PR DESCRIPTION
<img width="265" alt="image" src="https://user-images.githubusercontent.com/56961917/224555559-be5e075f-bc71-4b69-ac31-43d34af97b99.png">

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
