### PR TITLE
feat: conditional extenders

### DIFF
--- a/framework/core/src/Extend/Conditional.php
+++ b/framework/core/src/Extend/Conditional.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;

--- a/framework/core/src/Extend/Conditional.php
+++ b/framework/core/src/Extend/Conditional.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
+use Illuminate\Contracts\Container\Container;
+
+class Conditional implements ExtenderInterface
+{
+    /**
+     * @var array<array{condition: bool|callable, extenders: ExtenderInterface[]}>
+     */
+    protected $conditions = [];
+
+    /**
+     * @param ExtenderInterface[] $extenders
+     */
+    public function whenExtensionEnabled(string $extensionId, array $extenders): self
+    {
+        return $this->when(function (ExtensionManager $extensions) use ($extensionId) {
+            return $extensions->isEnabled($extensionId);
+        }, $extenders);
+    }
+
+    /**
+     * @param bool|callable $condition
+     * @param ExtenderInterface[] $extenders
+     */
+    public function when($condition, array $extenders): self
+    {
+        $this->conditions[] = [
+            'condition' => $condition,
+            'extenders' => $extenders,
+        ];
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        foreach ($this->conditions as $condition) {
+            if (is_callable($condition['condition'])) {
+                $condition['condition'] = $container->call($condition['condition']);
+            }
+
+            if ($condition['condition']) {
+                foreach ($condition['extenders'] as $extender) {
+                    $extender->extend($container, $extension);
+                }
+            }
+        }
+    }
+}

--- a/framework/core/src/Extension/Extension.php
+++ b/framework/core/src/Extension/Extension.php
@@ -414,19 +414,19 @@ class Extension implements Arrayable
             $links['source'] = $sourceUrl;
         }
 
-        if (($discussUrl = $this->composerJsonAttribute('support.forum'))) {
+        if ($discussUrl = $this->composerJsonAttribute('support.forum')) {
             $links['discuss'] = $discussUrl;
         }
 
-        if (($documentationUrl = $this->composerJsonAttribute('support.docs'))) {
+        if ($documentationUrl = $this->composerJsonAttribute('support.docs')) {
             $links['documentation'] = $documentationUrl;
         }
 
-        if (($websiteUrl = $this->composerJsonAttribute('homepage'))) {
+        if ($websiteUrl = $this->composerJsonAttribute('homepage')) {
             $links['website'] = $websiteUrl;
         }
 
-        if (($supportEmail = $this->composerJsonAttribute('support.email'))) {
+        if ($supportEmail = $this->composerJsonAttribute('support.email')) {
             $links['support'] = "mailto:$supportEmail";
         }
 

--- a/framework/core/src/User/Access/Gate.php
+++ b/framework/core/src/User/Access/Gate.php
@@ -65,7 +65,7 @@ class Gate
         $appliedPolicies = [];
 
         if ($model) {
-            $modelClasses = is_string($model) ? [$model] : array_merge(class_parents(($model)), [get_class($model)]);
+            $modelClasses = is_string($model) ? [$model] : array_merge(class_parents($model), [get_class($model)]);
 
             foreach ($modelClasses as $class) {
                 $appliedPolicies = array_merge($appliedPolicies, $this->getPolicies($class));
@@ -87,7 +87,7 @@ class Gate
         // If no policy covered this permission query, we will only grant
         // the permission if the actor's groups have it. Otherwise, we will
         // not allow the user to perform this action.
-        if ($actor->isAdmin() || ($actor->hasPermission($ability))) {
+        if ($actor->isAdmin() || $actor->hasPermission($ability)) {
             return true;
         }
 

--- a/framework/core/tests/integration/extenders/ConditionalTest.php
+++ b/framework/core/tests/integration/extenders/ConditionalTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Exception;
+use Flarum\Api\Serializer\ForumSerializer;
+use Flarum\Extend;
+use Flarum\Extension\ExtensionManager;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class ConditionalTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /** @test */
+    public function conditional_works_if_condition_is_primitive_true()
+    {
+        $this->extend(
+            (new Extend\Conditional())
+                ->when(true, [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
+
+    /** @test */
+    public function conditional_does_not_work_if_condition_is_primitive_false()
+    {
+        $this->extend(
+            (new Extend\Conditional())
+                ->when(false, [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
+
+    /** @test */
+    public function conditional_works_if_condition_is_callable_true()
+    {
+        $this->extend(
+            (new Extend\Conditional())
+                ->when(function () {
+                    return true;
+                }, [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
+
+    /** @test */
+    public function conditional_does_not_work_if_condition_is_callable_false()
+    {
+        $this->extend(
+            (new Extend\Conditional())
+                ->when(function () {
+                    return false;
+                }, [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
+
+    /** @test */
+    public function conditional_injects_dependencies_to_condition_callable()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->extend(
+            (new Extend\Conditional())
+                ->when(function (?ExtensionManager $extensions) {
+                    if (! $extensions) {
+                        throw new Exception('ExtensionManager not injected');
+                    }
+                }, [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+    }
+}

--- a/framework/core/tests/integration/extenders/LocalesTest.php
+++ b/framework/core/tests/integration/extenders/LocalesTest.php
@@ -42,7 +42,7 @@ class LocalesTest extends TestCase
     public function custom_translation_exists_if_added()
     {
         $this->extend(
-            (new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales'))
+            new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales')
         );
 
         $this->app()->getContainer()->make('flarum.locales');
@@ -57,7 +57,7 @@ class LocalesTest extends TestCase
     public function custom_translation_exists_if_added_with_intl_suffix()
     {
         $this->extend(
-            (new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales'))
+            new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales')
         );
 
         $this->app()->getContainer()->make('flarum.locales');
@@ -72,7 +72,7 @@ class LocalesTest extends TestCase
     public function messageformat_works_in_translations()
     {
         $this->extend(
-            (new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales'))
+            new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales')
         );
 
         $this->app()->getContainer()->make('flarum.locales');
@@ -87,7 +87,7 @@ class LocalesTest extends TestCase
     public function laravel_interface_methods_work()
     {
         $this->extend(
-            (new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales'))
+            new Extend\Locales(dirname(__FILE__, 3).'/fixtures/locales')
         );
 
         $this->app()->getContainer()->make('flarum.locales');


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds support for conditional extenders, needed especially when adding extenders when certain extensions are enabled. (needed for tag mentions).

Here are some usage examples:
```php
return [
    (new Extend\Conditional)
        ->whenExtensionEnabled('flarum-tags', [
                (new Extend\Formatter)
                    ->parse(FormatTagMentions::class)
                    ->unparse(UnparseTagMentions::class),

                (new Extend\ApiController(ListPostsController::class)
                    ->load('mentionsTags'),

                (new Extend\Model(Post::class)
                    ->belongsToMany('mentionsTags', Tag::class, 'post_mentions_tag', 'post_id', 'mentions_tag_id'),

                (new Extend\ApiSerializer(BasicPostSerializer::class))
                    ->hasMany('mentionsTags', TagSerializer::class),
        ]),
]
```


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
