### PR TITLE
fix(mentions): mentions keep firing after a reply

### DIFF
--- a/extensions/mentions/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/mentions/js/src/forum/addComposerAutocomplete.js
@@ -89,17 +89,30 @@ export default function addComposerAutocomplete() {
 
       if (selection[1] - cursor > 0) return;
 
+      // Identify whether we are working with a mention by looking at an @
+      // consider the following scenario's `@"d1spl4Y name"`, `@username`, but also
+      // post mentions `@"d1spl4y name"#p45`. We cancel searching when we see a space or newline
+      // but only if this isn't part of a display name.
+
       // Search backwards from the cursor for an '@' symbol. If we find one,
       // we will want to show the autocomplete dropdown!
       const lastChunk = this.attrs.composer.editor.getLastNChars(30);
-      absMentionStart = 0;
-      for (let i = lastChunk.length - 1; i >= 0; i--) {
-        const character = lastChunk.substr(i, 1);
-        if (character === '@' && (i == 0 || /\s/.test(lastChunk.substr(i - 1, 1)))) {
-          relMentionStart = i + 1;
-          absMentionStart = cursor - lastChunk.length + i + 1;
-          break;
+
+      // Identify whether this is a Display Name mention and we're beyond the mention
+      if (/\s.*/.test(lastChunk) && /@"[^"]+"/.test(lastChunk.substr(0, lastChunk.length - 1))) {
+        // .. skip
+      } else {
+        for (let i = lastChunk.length - 1; i >= 0; i--) {
+          const character = lastChunk.substr(i, 1);
+
+          // We have discovered the start of the mention
+          if (character === '@' && (i == 0 || /\s/.test(lastChunk.substr(i - 1, 1)))) {
+            relMentionStart = i + 1;
+            absMentionStart = cursor - lastChunk.length + i + 1;
+            break;
+          }
         }
+
       }
 
       dropdown.hide();


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3766**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Identify whether we have a completed mention before the current text so that we can stop mentioning. The logic checks for any space and/or follow up text, then also check whether the display name mention exists.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

Did I forget about any edge cases?
Are we okay with this if statement? Imo it increases readability wdyt?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
