### PR TITLE
chore: revert uneffective code for encoding of page title

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -411,22 +411,12 @@ export default class Application {
       pageNumber: 1,
     };
 
-    let title =
+    const title =
       onHomepage || !this.title
         ? extractText(app.translator.trans('core.lib.meta_titles.without_page_title', params))
         : extractText(app.translator.trans('core.lib.meta_titles.with_page_title', params));
 
-    title = count + title;
-
-    // We pass the title through a DOMParser to allow HTML entities
-    // to be rendered correctly, while still preventing XSS attacks
-    // from user input by using a script-disabled environment.
-    // https://github.com/flarum/framework/issues/3514
-    // https://github.com/flarum/framework/pull/3684
-    const parser = new DOMParser();
-    const safeTitle = parser.parseFromString(title, 'text/html').body.innerHTML;
-
-    document.title = safeTitle;
+    document.title = count + title;
   }
 
   protected transformRequestOptions<ResponseType>(flarumOptions: FlarumRequestOptions<ResponseType>): InternalFlarumRequestOptions<ResponseType> {


### PR DESCRIPTION
This PR effectively reverts https://github.com/flarum/framework/pull/3542  and https://github.com/flarum/framework/pull/3684, as both these fixes does not work correctly seems to bring more harm than good. The real issue is described in https://github.com/flarum/framework/issues/3685 and it should be fixed on `trans()` level.

**Use case:**

1. Set forum title to `Flarum & Flarum`.
2. Create new discussion with title `& &amp; & test`.

Before this PR title displayed in browser tab would be: `&amp; &amp; &amp; test - Flarum &amp; Flarum`.
After this PR: `& &amp; & test - Flarum &amp; Flarum`.
Correct title should be: `& &amp; & test - Flarum & Flarum`.

While this PR does not fix issue completely, it makes things better. Currently even on Discuss some discussions have incorrectly encoded title:

![b6037cb7](https://user-images.githubusercontent.com/5972388/226143684-3d9530c8-5b18-4b60-9fcf-832446659a76.png)



**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
