### PR TITLE
Adjust size of FontAwesome icons on extensions list to match size of custom images

### DIFF
--- a/framework/core/less/admin/ExtensionWidget.less
+++ b/framework/core/less/admin/ExtensionWidget.less
@@ -46,6 +46,11 @@
   color: var(--muted-color);
 }
 
+.ExtensionListItem-icon i {
+  line-height: calc(~"var(--size) * 0.6");
+  font-size: calc(~"var(--size) * 0.6");
+}
+
 .ExtensionListItem.disabled {
   .ExtensionListItem-title {
     opacity: 0.5;


### PR DESCRIPTION
**Before:**

![223952bb](https://user-images.githubusercontent.com/5972388/226184745-79401f58-1129-4c48-9ef8-65002f62170a.png)


**After:**

![a2f51291](https://user-images.githubusercontent.com/5972388/226184700-3ea49cd2-9f19-466d-9fa0-821afe854fb0.png)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
