### PR TITLE
Fix: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous

### DIFF
--- a/extensions/mentions/src/Listener/UpdateMentionsMetadataWhenVisible.php
+++ b/extensions/mentions/src/Listener/UpdateMentionsMetadataWhenVisible.php
@@ -103,7 +103,7 @@ class UpdateMentionsMetadataWhenVisible
         $post->unsetRelation('mentionsGroups');
 
         $users = User::whereHas('groups', function ($query) use ($mentioned) {
-            $query->whereIn('id', $mentioned);
+            $query->whereIn('groups.id', $mentioned);
         })
             ->get()
             ->filter(function (User $user) use ($post) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Analog to https://github.com/flarum/framework/pull/3696, changed 'id' to 'groups.id' to avoid `Column 'id' in where clause is ambiguous` error.

This error normally doesn't occur, but if an extension adds an `id` column to the `group_user` table, then this error would occur. 

(Adding that column helps when one wants to `chunkById()` on the `group_user` model)

**Reviewers should focus on:**
Nothing is broken by this minor change.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

