### PR TITLE
fix: empty string displayed as SelectDropdown title

### DIFF
--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -1,6 +1,5 @@
 import Dropdown, { IDropdownAttrs } from './Dropdown';
 import icon from '../helpers/icon';
-import extractText from '../utils/extractText';
 import classList from '../utils/classList';
 import type Component from '../Component';
 import type Mithril from 'mithril';

--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -50,7 +50,7 @@ export default class SelectDropdown<CustomAttrs extends ISelectDropdownAttrs = I
     const activeChild = children.find(isActive);
     let label = (activeChild && typeof activeChild === 'object' && 'children' in activeChild && activeChild.children) || this.attrs.defaultLabel;
 
-    label = extractText(label);
+    if (label instanceof Array) label = label[0];
 
     return [<span className="Button-label">{label}</span>, this.attrs.caretIcon ? icon(this.attrs.caretIcon, { className: 'Button-caret' }) : null];
   }

--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -50,7 +50,7 @@ export default class SelectDropdown<CustomAttrs extends ISelectDropdownAttrs = I
     let label = (activeChild && typeof activeChild === 'object' && 'children' in activeChild && activeChild.children) || this.attrs.defaultLabel;
 
     // @ts-ignore
-    if (label instanceof Array) label = label[0];
+    if (Array.isArray(label)) label = label[0];
 
     return [<span className="Button-label">{label}</span>, this.attrs.caretIcon ? icon(this.attrs.caretIcon, { className: 'Button-caret' }) : null];
   }

--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -49,6 +49,7 @@ export default class SelectDropdown<CustomAttrs extends ISelectDropdownAttrs = I
     const activeChild = children.find(isActive);
     let label = (activeChild && typeof activeChild === 'object' && 'children' in activeChild && activeChild.children) || this.attrs.defaultLabel;
 
+    // @ts-ignore
     if (label instanceof Array) label = label[0];
 
     return [<span className="Button-label">{label}</span>, this.attrs.caretIcon ? icon(this.attrs.caretIcon, { className: 'Button-caret' }) : null];


### PR DESCRIPTION
Reverts the change to using `extractText` introduced in https://github.com/flarum/framework/pull/3608/

Whilst using `extractText`, the button title is rendered as an empty string. This PR reverts that change so that expected behaviour is restored.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
