### PR TITLE
fix: `isDark()` utility can receive null value

### DIFF
--- a/framework/core/js/src/common/helpers/textContrastClass.ts
+++ b/framework/core/js/src/common/helpers/textContrastClass.ts
@@ -1,5 +1,5 @@
 import isDark from '../utils/isDark';
 
-export default function textContrastClass(hexcolor: string): string {
+export default function textContrastClass(hexcolor: string | null): string {
   return isDark(hexcolor) ? 'text-contrast--light' : 'text-contrast--dark';
 }

--- a/framework/core/js/src/common/utils/isDark.ts
+++ b/framework/core/js/src/common/utils/isDark.ts
@@ -25,7 +25,7 @@ export default function isDark(hexcolor: string): boolean {
   const b = parseInt(hexnumbers.slice(4, 6), 16);
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 
-  const threshold = parseInt(getComputedStyle(document.body).getPropertyValue("--yiq-threshold").trim()) || 128;
+  const threshold = parseInt(getComputedStyle(document.body).getPropertyValue('--yiq-threshold').trim()) || 128;
   
   return yiq < threshold;
 }

--- a/framework/core/js/src/common/utils/isDark.ts
+++ b/framework/core/js/src/common/utils/isDark.ts
@@ -8,18 +8,25 @@
  * to preserve design consistency.
  */
 export default function isDark(hexcolor: string): boolean {
+  // return if hexcolor is undefined or shorter than 4 characters, shortest hex form is #333;
+  // decided against regex hex color validation for performance considerations
+  if (!hexcolor || hexcolor.length <= 4) {
+    return false;
+  }
+
   let hexnumbers = hexcolor.replace('#', '');
 
   if (hexnumbers.length == 3) {
     hexnumbers += hexnumbers;
   }
 
-  const r = parseInt(hexnumbers.substr(0, 2), 16);
-  const g = parseInt(hexnumbers.substr(2, 2), 16);
-  const b = parseInt(hexnumbers.substr(4, 2), 16);
+  const r = parseInt(hexnumbers.slice(0, 2), 16);
+  const g = parseInt(hexnumbers.slice(2, 4), 16);
+  const b = parseInt(hexnumbers.slice(4, 6), 16);
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 
-  const threshold = parseInt(window.getComputedStyle(document.body).getPropertyValue('--yiq-threshold'));
-
+  const threshold = parseInt(getComputedStyle(document.body).getPropertyValue("--yiq-threshold").trim()) || 128;
+  
   return yiq < threshold;
 }
+

--- a/framework/core/js/src/common/utils/isDark.ts
+++ b/framework/core/js/src/common/utils/isDark.ts
@@ -7,16 +7,16 @@
  * standards, but we use a custom threshold for each light and dark modes
  * to preserve design consistency.
  */
-export default function isDark(hexcolor: string): boolean {
+export default function isDark(hexcolor: string | null): boolean {
   // return if hexcolor is undefined or shorter than 4 characters, shortest hex form is #333;
   // decided against regex hex color validation for performance considerations
-  if (!hexcolor || hexcolor.length <= 4) {
+  if (!hexcolor || hexcolor.length < 4) {
     return false;
   }
 
   let hexnumbers = hexcolor.replace('#', '');
 
-  if (hexnumbers.length == 3) {
+  if (hexnumbers.length === 3) {
     hexnumbers += hexnumbers;
   }
 

--- a/framework/core/js/src/common/utils/isDark.ts
+++ b/framework/core/js/src/common/utils/isDark.ts
@@ -26,7 +26,6 @@ export default function isDark(hexcolor: string): boolean {
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 
   const threshold = parseInt(getComputedStyle(document.body).getPropertyValue('--yiq-threshold').trim()) || 128;
-  
+
   return yiq < threshold;
 }
-


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3764**

**Changes proposed in this pull request:**
Shouldn't be many, was mainly an edge case when there were NULL values in the db that would crash this method.


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
Well, it doesn't crash anymore =)
- [x] If applicable, have various options for solving this problem been considered?
Decided to not make the method too fancypants for performance reasons (e.g. no regex checks for valid hex colors etc.)
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
