### PR TITLE
Sm/fulltext scoring issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,8 @@
         "mockery/mockery": "^1.4",
         "phpunit/phpunit": "^9.0",
         "phpstan/phpstan": ">=1.8.11 < 1.9.0",
-        "nunomaduro/larastan": "^1.0"
+        "nunomaduro/larastan": "^1.0",
+        "symfony/var-dumper": "*"
     },
     "config": {
         "sort-packages": true

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -88,7 +88,8 @@
         "wikimedia/less.php": "^3.2"
     },
     "require-dev": {
-        "flarum/testing": "^1.0.0"
+        "flarum/testing": "^1.0.0",
+        "symfony/var-dumper": "*"
     },
     "autoload": {
         "psr-4": {

--- a/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
+++ b/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
@@ -27,9 +27,21 @@ class ListWithFulltextSearchTest extends TestCase
 
         $this->database()->rollBack();
 
+        $this->populateSimpleTestData();
+
+        $this->populateRealDataForScoreTests();
+
+        // We need to call these again, since we rolled back the transaction started by `::app()`.
+        $this->database()->beginTransaction();
+
+        $this->populateDatabase();
+    }
+
+    private function populateSimpleTestData(): void
+    {
         // We need to insert these outside of a transaction, because FULLTEXT indexing,
         // which is needed for search, doesn't happen in transactions.
-        // We clean it up explcitly at the end.
+        // We clean it up explicitly at the end.
         $this->database()->table('discussions')->insert([
             ['id' => 1, 'title' => 'lightsail in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
             ['id' => 2, 'title' => 'lightsail in title too', 'created_at' => Carbon::createFromDate(2020, 01, 01)->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
@@ -48,11 +60,130 @@ class ListWithFulltextSearchTest extends TestCase
             ['id' => 6, 'discussion_id' => 4, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>తెలుగు</p></t>'],
             ['id' => 7, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>支持中文吗</p></t>'],
         ]);
+    }
 
-        // We need to call these again, since we rolled back the transaction started by `::app()`.
-        $this->database()->beginTransaction();
+    private function populateRealDataForScoreTests(): void
+    {
+        // Disable forign key constraints temporarily
+        $this->database()->statement('SET FOREIGN_KEY_CHECKS=0');
 
-        $this->populateDatabase();
+        $this->database()->table('discussions')->insert([
+            ['id' => 7, 'title' => 'User should be able to promote the visible, foreground, non-saved window to a saved window', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1, 'first_post_id' => 8],
+            ['id' => 8, 'title' => 'Moving Tab in Saved Window to New Window Destroys Non-Saved Window', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1, 'first_post_id' => 16],
+            ['id' => 9, 'title' => 'Current saved window is renamed when moving normal window to saved window area', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1, 'first_post_id' => 18],
+            ['id' => 10, 'title' => 'Save bookmarks edit page window position is not saved', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1, 'first_post_id' => 19],
+            ['id' => 11, 'title' => 'Favicons in the saved bookmarks flash on and off', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1, 'first_post_id' => 20],
+            ['id' => 12, 'title' => 'User should be able to switch \'in-place\' between non-saved windows', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1, 'first_post_id' => 23],
+        ]);
+
+        $this->database()->table('posts')->insert([
+            ['id' => 8, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Unless I\'m missing something, currently there does not appear to be a way to promote a non-saved window to a saved window. A user must be click the \'+\' button in the window menu dropdown, then re-open all open tabs in the current window in the new saved window. That doesn\'t sound fun if one has multiple tabs open.</p>
+
+<p>This would be ameliorated if it was possible move tabs to saved windows without physical drag and drop but that doesn\'t seem possible as well, see User should be able to move tabs from visible window to non-visible saved windows</p></t>'],
+            ['id' => 9, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>open sidebar<br/>
+switch to either Tabs or Windows view in sidebar<br/>
+right click on window title in side bar (eg. "3 Tabs")<br/>
+click "Save..."<br/>
+OR<br/>
+click once on window title in sidebar (eg. "3 Tabs")<br/>
+rename window in-place<br/>
+I think this is how it is supposed to work.</p>
+
+<p>For me, at least, this funcionality doesn\'t work due to (I imagine) a bug...<br/>
+Unless I\'ve misunderstood you?</p></t>'],
+            ['id' => 10, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p>Are you refering to this?</p>
+
+<p><URL url="https://orionfeedback.org/d/4258-window-switcher-i-am-able-to-drag-the-unsaved-window-into-saved-windows-and-it-breaks-the-ui-until-restart">https://orionfeedback.org/d/4258-window-switcher-i-am-able-to-drag-the-unsaved-window-into-saved-windows-and-it-breaks-the-ui-until-restart</URL></p></r>'],
+            ['id' => 11, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>robrecord Yes! Wasn\'t apparent that was the trick. Thanks for pointing it out.<br/>
+Vlad My other logged issue seems related to that one</p></t>'],
+            ['id' => 12, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>b3noit Which one?</p>
+
+<p>Is there anything still being asked here?</p></t>'],
+            ['id' => 13, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p>Vlad This one <URL url="https://orionfeedback.org/d/4288-moving-tab-in-saved-window-to-new-window-destroys-non-saved-window">https://orionfeedback.org/d/4288-moving-tab-in-saved-window-to-new-window-destroys-non-saved-window</URL></p>
+
+<p>The post above yours clarified how the UI is supposed to be used here</p></r>'],
+            ['id' => 14, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t>
+<p>b3noit So is there an ask here or I can close this?</p></t>'],
+            ['id' => 15, 'discussion_id' => 7, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t>
+<p>b3noit ping</p></t>'],
+
+            ['id' => 26, 'discussion_id' => 12, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => "<t><p>Visible, non-saved windows cannot participate in 'in-place' window switching, they can only be switched via the OS window manager. Its unclear why only saved windows can participate, at the least non-saved windows should be able to opt-in so one window can switch between both saved and non-saved windows.</p></t>"],
+            ['id' => 25, 'discussion_id' => 12, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>@dino can you explain why we decided this?</p>
+
+</t>'],
+            ['id' => 24, 'discussion_id' => 12, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Vlad b3noit Because when anyone creates new Window (by New Window menu), user will always expect, there will be a separate Window as per any native app. So when having separate Window (for unsaved windows), why in-place switching needed. Lots of users still prefer working with Windows (as this term is very obvious for any OS), sometime side-by-side, sometime by using external display.</p>
+
+<p>Also any modern browser uses Tab-Groups for in-place switching, but they treat traditional Windows in same way. So instead of breaking Native terminology and flow of OS, we preferred to continue with Windows.</p>
+
+<p>Also if some user still feels to use all in-place switching, then that user can create new Windows as new in-place group by clicking "+" from window manager &#128578;</p></t>'],
+            ['id' => 23, 'discussion_id' => 12, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => "<t><p>dino Vlad My thing about the solution of 'well, make a new saved window that does participate in in-place switching' is that:</p>
+
+<p>there's no convenient affordance to move tabs from a visible, non-saved window to a saved window<br/>
+there's no convenient affordance to simply transform a non-saved, visible window to a saved window that can interact with in-place switching<br/>
+I don't see a reason why a user can't opt in a window into being able to be switched in-place<br/>
+From where I'm standing, unless I'm missing something, the abstraction of a window and a group of tabs are two different things; it appears that in the case of Orion, there's an assumption about the relationship between a collection of tabs and windows such that, just like in programming languages with different 'colored' functions (e.g. async in JS, C#, etc), here you have the case of 'colored' windows.</p></t>"],
+
+            ['id' => 22, 'discussion_id' => 11, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => "<t><p>No and actually it's OK I found it. It was some corrupted pref files. The ones relating to the web icons. I had to reestablish some of my preferences for the app but otherwise not much hassle!</p>
+
+</t>"],
+            ['id' => 21, 'discussion_id' => 11, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>can u provide a video?</p>
+
+</t>'],
+            ['id' => 20, 'discussion_id' => 11, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Steps to reproduce:<br/>
+&lt;Include steps to reproduce the bug; Did you try using Compatibility mode? If applicable, does Safari behave in the same way?&gt;</p>
+
+<p>Expected behavior:<br/>
+&lt;What you expected to happen?&gt;</p>
+
+<p>Orion, OS version; hardware type:<br/>
+Orion version Version 0.99.121-beta (WebKit 614.1.20)<br/>
+MacOS version 12.6 (21G115) Monterey<br/>
+M1 Mac mini (M1, 2020)<br/>
+Image/Video:<br/>
+&lt;Copy/paste or drag and drop to upload images or videos (up to 20MB)&gt;</p>
+
+<p>The bookmarks in my Orion usually show favicons of the sites after I visit them. Today even after clearing cache and restarting the browser several times they are still flashing. Any ideas?</p></t>'],
+
+            ['id' => 19, 'discussion_id' => 10, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Steps to reproduce:<br/>
+&lt;Include steps to reproduce the bug; Did you try using Compatibility mode? If applicable, does Safari behave in the same way?&gt;</p>
+
+<p>Expected behavior:<br/>
+Position is saved.</p>
+
+<p>Orion and macOS:<br/>
+&lt;Version&gt;</p>
+
+<p>Image/Video:</p></t>'],
+
+            ['id' => 18, 'discussion_id' => 9, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => "<t><p>Steps to reproduce:</p>
+
+<p>Have one open window.<br/>
+Have a saved window.<br/>
+Using the toolbar icon, move the regular window to the saved window<br/>
+Expected behavior:<br/>
+Window is moved to saved area, doesn't affect other saved windows.<br/>
+Orion, OS version; hardware type:<br/>
+Version 0.99.123.1-beta (WebKit 615.1.16.1)<br/>
+MacBook Pro (macOS Monterey 12.6.2 build 21G320)</p>
+
+<p>Image/Video:</p>
+
+</t>"],
+
+            ['id' => 17, 'discussion_id' => 8, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>b3noit Can you please record a video of this?</p></t>'],
+            ['id' => 16, 'discussion_id' => 8, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Steps to reproduce:</p>
+
+<p>Initialized a new non-saved window one tab<br/>
+Initialize a new saved window with one tab<br/>
+Switch in-place to saved window<br/>
+Right tab and select move tab to New Window<br/>
+Tab moves to non-saved window and replaces previously open tab in non-saved window<br/>
+Expected behavior:<br/>
+Tab should not replace non-saved window tab</p>
+
+<p>Orion, OS version; hardware type:<br/>
+0.99.123 on 12.6.3</p></t>'],
+        ]);
     }
 
     /**
@@ -85,6 +216,27 @@ class ListWithFulltextSearchTest extends TestCase
         }, $data['data']);
 
         $this->assertEqualsCanonicalizing(['2', '1', '3'], $ids, 'IDs do not match');
+    }
+
+    /**
+     * @test
+     */
+    public function search_prioritizes_title_search_score_over_post()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams([
+                    'filter' => ['q' => 'saved bookmarks'],
+                    'include' => 'mostRelevantPost',
+                ])
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        $ids = array_map(function ($row) {
+            return $row['id'];
+        }, $data['data']);
+
+        $this->assertEquals(['11', '10', '7', '8', '9', '12'], $ids, 'IDs do not match');
     }
 
     /**


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d087396</samp>

### Summary
:mag::bug::test_tube:

<!--
1.  :mag: - This emoji represents the fulltext search feature and the improvement of its functionality and accuracy.
2.  :bug: - This emoji represents the bug fix that was applied to the fulltext search feature, which was causing some discussions to be excluded from the results.
3.  :test_tube: - This emoji represents the addition of more test cases and the refactoring of the test data insertion code.
-->
This pull request improves the fulltext search feature for discussions by fixing a bug and using a subquery to calculate relevance scores. It also adds more test cases using real data and introduces the `symfony/var-dumper` package for debugging purposes. The changes affect the files `FulltextGambit.php`, `ListWithFulltextSearchTest.php`, and both `composer.json` files.

> _We're heaving on the ropes, me hearties, on the count of three_
> _We're adding `var-dumper` to the `composer.json` file, you see_
> _We're fixing bugs and boosting scores for the fulltext search_
> _We're testing with Orion data, so we don't end up in a lurch_

### Walkthrough
*  Add `symfony/var-dumper` package to `require-dev` section of `composer.json` files for debugging purposes ([link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L145-R146), [link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-6086cae05750eaed317e69cc3292058f773ccc00653ff2291693e0d7db3e59feL91-R92))
  *  Use `query` instead of `select` and alias `id` as `discussion_id` in `discussionSubquery` to avoid overriding query builder and enable joining with `posts_ft` subquery ([link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-e709afd23c29c588cfeab681e0367164658085f16dedc0721215a429906158f1L33-R34))
  *  Add `posts_ft.score` and `title_score` columns to `discussionSubquery` to store relevance scores of posts and titles for each discussion ([link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-e709afd23c29c588cfeab681e0367164658085f16dedc0721215a429906158f1R56-R57))
  *  Update `join` and `setDefaultSort` methods to use `posts_ft.discussion_id` and `title_score` columns and simplify sorting logic ([link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-e709afd23c29c588cfeab681e0367164658085f16dedc0721215a429906158f1L61-R68))
  *  Extract test data insertion into separate methods and call them after rolling back and starting new transaction ([link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-aa7c0819f7d36c442b946da158c0fe8c3545a2e817119b8fa771ea19bca8548fL30-R44))
  *  Insert real data from Orion feedback forum into discussions and posts tables with different search query matches ([link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-aa7c0819f7d36c442b946da158c0fe8c3545a2e817119b8fa771ea19bca8548fL51-R186))
  *  Test that title score is prioritized over post score when sorting results ([link](https://github.com/flarum/framework/pull/3775/files?diff=unified&w=0#diff-aa7c0819f7d36c442b946da158c0fe8c3545a2e817119b8fa771ea19bca8548fR224-R244))

