### PR TITLE
Update Translator.php

### DIFF
--- a/framework/core/src/Locale/Translator.php
+++ b/framework/core/src/Locale/Translator.php
@@ -62,7 +62,7 @@ class Translator extends BaseTranslator implements TranslatorContract
     {
         foreach ($catalogue->all() as $domain => $messages) {
             foreach ($messages as $id => $translation) {
-                if (preg_match(self::REFERENCE_REGEX, $translation, $matches)) {
+                if (@preg_match(self::REFERENCE_REGEX, $translation, $matches)) {
                     $catalogue->set($id, $this->getTranslation($catalogue, $id, $domain), $domain);
                 }
             }


### PR DESCRIPTION
**Changes proposed in this pull request:**

- Suppress error thrown in PHP 8.2

**Reviewers should focus on:**

Added `@` before `preg_match` to fix issues with several extensions which pass `null` to it.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.