### PR TITLE
feat(permission): add delete own posts permission

### DIFF
--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -399,7 +399,6 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
       },
       60
     );
-    
 
     items.add(
       'userEditCredentials',

--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -367,6 +367,30 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
     );
 
     items.add(
+      'hideOwnPosts',
+      {
+        icon: 'far fa-trash-alt',
+        label: app.translator.trans('core.admin.permissions.allow_delete_own_posts_label'),
+        setting: () => {
+          const minutes = parseInt(app.data.settings.allow_hide_own_posts, 10);
+
+          return SettingDropdown.component({
+            defaultLabel: minutes
+              ? app.translator.trans('core.admin.permissions_controls.allow_some_minutes_button', { count: minutes })
+              : app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button'),
+            key: 'allow_hide_own_posts',
+            options: [
+              { value: '-1', label: app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button') },
+              { value: '10', label: app.translator.trans('core.admin.permissions_controls.allow_ten_minutes_button') },
+              { value: 'reply', label: app.translator.trans('core.admin.permissions_controls.allow_until_reply_button') },
+            ],
+          });
+        },
+      },
+      60
+    );
+
+    items.add(
       'deletePosts',
       {
         icon: 'fas fa-times',
@@ -375,6 +399,7 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
       },
       60
     );
+    
 
     items.add(
       'userEditCredentials',

--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -288,6 +288,31 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
       90
     );
 
+    items.add(
+      'hideOwnPosts',
+      {
+        icon: 'far fa-trash-alt',
+        label: app.translator.trans('core.admin.permissions.allow_hide_own_posts_label'),
+        setting: () => {
+          const minutes = parseInt(app.data.settings.allow_hide_own_posts, 10);
+
+          return SettingDropdown.component({
+            defaultLabel: minutes
+              ? app.translator.trans('core.admin.permissions_controls.allow_some_minutes_button', { count: minutes })
+              : app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button'),
+            key: 'allow_hide_own_posts',
+            options: [
+              { value: '-1', label: app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button') },
+              { value: '10', label: app.translator.trans('core.admin.permissions_controls.allow_ten_minutes_button') },
+              { value: 'reply', label: app.translator.trans('core.admin.permissions_controls.allow_until_reply_button') },
+              { value: '0', label: app.translator.trans('core.admin.permissions_controls.allow_never_button') },
+            ],
+          });
+        },
+      },
+      80
+    );
+
     items.merge(app.extensionData.getAllExtensionPermissions('reply'));
 
     return items;
@@ -362,31 +387,6 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
         icon: 'far fa-trash-alt',
         label: app.translator.trans('core.admin.permissions.delete_posts_label'),
         permission: 'discussion.hidePosts',
-      },
-      60
-    );
-
-    items.add(
-      'hideOwnPosts',
-      {
-        icon: 'far fa-trash-alt',
-        label: app.translator.trans('core.admin.permissions.allow_delete_own_posts_label'),
-        setting: () => {
-          const minutes = parseInt(app.data.settings.allow_hide_own_posts, 10);
-
-          return SettingDropdown.component({
-            defaultLabel: minutes
-              ? app.translator.trans('core.admin.permissions_controls.allow_some_minutes_button', { count: minutes })
-              : app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button'),
-            key: 'allow_hide_own_posts',
-            options: [
-              { value: '-1', label: app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button') },
-              { value: '10', label: app.translator.trans('core.admin.permissions_controls.allow_ten_minutes_button') },
-              { value: 'reply', label: app.translator.trans('core.admin.permissions_controls.allow_until_reply_button') },
-              { value: '0', label: app.translator.trans('core.admin.permissions_controls.allow_never_button') },
-            ],
-          });
-        },
       },
       60
     );

--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -383,7 +383,7 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
               { value: '-1', label: app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button') },
               { value: '10', label: app.translator.trans('core.admin.permissions_controls.allow_ten_minutes_button') },
               { value: 'reply', label: app.translator.trans('core.admin.permissions_controls.allow_until_reply_button') },
-              { value: '0', label: app.translator.trans('core.admin.permissions_controls.allow_never_button') }
+              { value: '0', label: app.translator.trans('core.admin.permissions_controls.allow_never_button') },
             ],
           });
         },

--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -383,6 +383,7 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
               { value: '-1', label: app.translator.trans('core.admin.permissions_controls.allow_indefinitely_button') },
               { value: '10', label: app.translator.trans('core.admin.permissions_controls.allow_ten_minutes_button') },
               { value: 'reply', label: app.translator.trans('core.admin.permissions_controls.allow_until_reply_button') },
+              { value: '0', label: app.translator.trans('core.admin.permissions_controls.allow_never_button') }
             ],
           });
         },

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -194,13 +194,13 @@ core:
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:
+      allow_delete_own_posts_label: Allow deleting own posts
       allow_post_editing_label: Allow post editing
       allow_renaming_label: Allow renaming
       create_access_token_label: Create access token
       create_heading: Create
       delete_discussions_forever_label: Delete discussions forever
       delete_discussions_label: Delete discussions
-      allow_delete_own_posts_label: Allow deleting own posts
       delete_posts_forever_label: Delete posts forever
       delete_posts_label: Delete posts
       description: Configure who can see and do what.

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -194,7 +194,7 @@ core:
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:
-      allow_delete_own_posts_label: Allow deleting own posts
+      allow_hide_own_posts_label: Allow deleting own posts
       allow_post_editing_label: Allow post editing
       allow_renaming_label: Allow renaming
       create_access_token_label: Create access token

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -229,6 +229,7 @@ core:
     # These translations are used in the dropdown menus on the Permissions page.
     permissions_controls:
       allow_indefinitely_button: Indefinitely
+      allow_never_button: => core.ref.never
       allow_some_minutes_button: "{count, plural, one {For # minute} other {For # minutes}}"
       allow_ten_minutes_button: For 10 minutes
       allow_until_reply_button: Until next reply
@@ -490,7 +491,7 @@ core:
         log_out_button: => core.ref.log_out
       hide_access_token: Hide Token
       last_activity: Last activity
-      never: Never
+      never: => core.ref.never
       new_access_token_button: => core.ref.new_token
       new_access_token_modal:
         submit_button: Create Token
@@ -802,6 +803,7 @@ core:
     log_in: Log In
     log_out: Log Out
     mark_all_as_read: Mark All as Read
+    never: Never
     new_token: New Token
     next_page: Next Page
     notifications: Notifications

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -200,6 +200,7 @@ core:
       create_heading: Create
       delete_discussions_forever_label: Delete discussions forever
       delete_discussions_label: Delete discussions
+      allow_delete_own_posts_label: Allow deleting own posts
       delete_posts_forever_label: Delete posts forever
       delete_posts_label: Delete posts
       description: Configure who can see and do what.

--- a/framework/core/src/Install/Steps/WriteSettings.php
+++ b/framework/core/src/Install/Steps/WriteSettings.php
@@ -56,6 +56,7 @@ class WriteSettings implements Step
     private function getDefaults()
     {
         return [
+            'allow_delete_own_posts' => 'reply',
             'allow_post_editing' => 'reply',
             'allow_renaming' => '10',
             'allow_sign_up' => '1',

--- a/framework/core/src/Install/Steps/WriteSettings.php
+++ b/framework/core/src/Install/Steps/WriteSettings.php
@@ -56,7 +56,7 @@ class WriteSettings implements Step
     private function getDefaults()
     {
         return [
-            'allow_delete_own_posts' => 'reply',
+            'allow_hide_own_posts' => 'reply',
             'allow_post_editing' => 'reply',
             'allow_renaming' => '10',
             'allow_sign_up' => '1',

--- a/framework/core/src/Post/Access/PostPolicy.php
+++ b/framework/core/src/Post/Access/PostPolicy.php
@@ -71,6 +71,14 @@ class PostPolicy extends AbstractPolicy
      */
     public function hide(User $actor, Post $post)
     {
-        return $this->edit($actor, $post);
+        if ($post->user_id == $actor->id && (! $post->hidden_at || $post->hidden_user_id == $actor->id) && $actor->can('reply', $post->discussion)) {
+            $allowHiding = $this->settings->get('allow_hide_own_posts');
+
+            if ($allowHiding === '-1'
+                || ($allowHiding === 'reply' && $post->number >= $post->discussion->last_post_number)
+                || (is_numeric($allowHiding) && $post->created_at->diffInMinutes(new Carbon) < $allowHiding)) {
+                return $this->allow();
+            }
+        }
     }
 }

--- a/framework/core/tests/integration/policy/PostPolicyTest.php
+++ b/framework/core/tests/integration/policy/PostPolicyTest.php
@@ -121,4 +121,79 @@ class PostPolicyTest extends TestCase
         $this->assertFalse($user->can('edit', $earlierPost));
         $this->assertFalse($user->can('edit', $lastPost));
     }
+
+    /**
+     * @test
+     */
+    public function hide_indefinitely()
+    {
+        $this->setting('allow_hide_own_posts', '-1');
+        $this->app();
+
+        $user = User::findOrFail(2);
+        $earlierPost = Post::findOrFail(1);
+        $lastPost = Post::findOrFail(2);
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertTrue($user->can('hide', $earlierPost));
+        $this->assertTrue($user->can('hide', $lastPost));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertTrue($user->can('hide', $earlierPost));
+        $this->assertTrue($user->can('hide', $lastPost));
+    }
+
+    /**
+     * @test
+     */
+    public function hide_until_reply()
+    {
+        $this->setting('allow_hide_own_posts', 'reply');
+        $this->app();
+
+        $user = User::findOrFail(2);
+        $earlierPost = Post::findOrFail(1);
+        $lastPost = Post::findOrFail(2);
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertFalse($user->can('hide', $earlierPost));
+        $this->assertTrue($user->can('hide', $lastPost));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertFalse($user->can('hide', $earlierPost));
+        $this->assertTrue($user->can('hide', $lastPost));
+    }
+
+    /**
+     * @test
+     */
+    public function hide_10_minutes()
+    {
+        $this->setting('allow_hide_own_posts', '10');
+        $this->app();
+
+        $user = User::findOrFail(2);
+        $earlierPost = Post::findOrFail(1);
+        $lastPost = Post::findOrFail(2);
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertTrue($user->can('hide', $earlierPost));
+        $this->assertTrue($user->can('hide', $lastPost));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertFalse($user->can('hide', $earlierPost));
+        $this->assertFalse($user->can('hide', $lastPost));
+    }
 }

--- a/framework/core/tests/integration/policy/PostPolicyTest.php
+++ b/framework/core/tests/integration/policy/PostPolicyTest.php
@@ -196,4 +196,29 @@ class PostPolicyTest extends TestCase
         $this->assertFalse($user->can('hide', $earlierPost));
         $this->assertFalse($user->can('hide', $lastPost));
     }
+
+    /**
+     * @test
+     */
+    public function hide_never()
+    {
+        $this->setting('allow_hide_own_posts', '0');
+        $this->app();
+
+        $user = User::findOrFail(2);
+        $earlierPost = Post::findOrFail(1);
+        $lastPost = Post::findOrFail(2);
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertFalse($user->can('hide', $earlierPost));
+        $this->assertFalse($user->can('hide', $lastPost));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertFalse($user->can('hide', $earlierPost));
+        $this->assertFalse($user->can('hide', $lastPost));
+    }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://discuss.flarum.org/d/31993-adding-permission-to-delete-own-posts**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
* Add permission for users to delete their own posts as a time-based permission

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
* Does the permission work properly?
* Is it in the right spot on the permission grid?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/33029517/230517484-a5a846f8-3f36-436f-bfc2-9d88be0e8178.png)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [X] Tests have been added, or are not appropriate here.

**Required changes:**

None
