### PR TITLE
fix: circular dependencies disable all involved extensions

### DIFF
--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -605,6 +605,7 @@ core:
 
     # These translations are displayed as error messages.
     error:
+      circular_dependencies_message: "Circular dependencies detected: {extensions}. Aborting. Please disable one of the extensions and try again."
       dependent_extensions_message: "Cannot disable {extension} until the following dependent extensions are disabled: {extensions}"
       extension_initialiation_failed_message: "{extension} failed to initialize, check the browser console for further information."
       generic_message: "Oops! Something went wrong. Please reload the page and try again."

--- a/framework/core/src/Extension/Exception/CircularDependenciesException.php
+++ b/framework/core/src/Extension/Exception/CircularDependenciesException.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Extension\Exception;
 
 use Exception;

--- a/framework/core/src/Extension/Exception/CircularDependenciesException.php
+++ b/framework/core/src/Extension/Exception/CircularDependenciesException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Flarum\Extension\Exception;
+
+use Exception;
+use Flarum\Extension\ExtensionManager;
+
+class CircularDependenciesException extends Exception
+{
+    public $circular_dependencies;
+
+    public function __construct(array $circularDependencies)
+    {
+        $this->circular_dependencies = $circularDependencies;
+
+        parent::__construct('Circular dependencies detected: '.implode(', ', ExtensionManager::pluckTitles($circularDependencies)).' - aborting. Please fix this by disabling the extensions that are causing the circular dependencies.');
+    }
+}

--- a/framework/core/src/Extension/Exception/CircularDependenciesExceptionHandler.php
+++ b/framework/core/src/Extension/Exception/CircularDependenciesExceptionHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension\Exception;
+
+use Flarum\Extension\ExtensionManager;
+use Flarum\Foundation\ErrorHandling\HandledError;
+
+class CircularDependenciesExceptionHandler
+{
+    public function handle(CircularDependenciesException $e): HandledError
+    {
+        return (new HandledError(
+            $e,
+            'circular_dependencies',
+            409
+        ))->withDetails($this->errorDetails($e));
+    }
+
+    protected function errorDetails(CircularDependenciesException $e): array
+    {
+        return [[
+            'extensions' => ExtensionManager::pluckTitles($e->circular_dependencies),
+        ]];
+    }
+}

--- a/framework/core/src/Foundation/ErrorServiceProvider.php
+++ b/framework/core/src/Foundation/ErrorServiceProvider.php
@@ -58,6 +58,7 @@ class ErrorServiceProvider extends AbstractServiceProvider
             return [
                 IlluminateValidationException::class => Handling\ExceptionHandler\IlluminateValidationExceptionHandler::class,
                 ValidationException::class => Handling\ExceptionHandler\ValidationExceptionHandler::class,
+                ExtensionException\CircularDependenciesException::class => ExtensionException\CircularDependenciesExceptionHandler::class,
                 ExtensionException\DependentExtensionsException::class => ExtensionException\DependentExtensionsExceptionHandler::class,
                 ExtensionException\MissingDependenciesException::class => ExtensionException\MissingDependenciesExceptionHandler::class,
             ];


### PR DESCRIPTION
**Changes proposed in this pull request:**
Throws an exception wen circular dependencies are found, which prevents the extensions within the circular depdencies fro getting all disabled.

**Screenshot**
This is an example where I created a circular dependency with emoji, suspend, and likes:
![image](https://user-images.githubusercontent.com/20267363/230922686-4443eb7c-33f3-4178-b13d-55812d02c6c7.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
