### PR TITLE
fix(tags): tag discussion modal filters with exact matches only after first index

### DIFF
--- a/extensions/tags/js/src/common/components/TagSelectionModal.tsx
+++ b/extensions/tags/js/src/common/components/TagSelectionModal.tsx
@@ -260,7 +260,7 @@ export default class TagSelectionModal<
     // If the user has entered text in the filter input, then filter by tags
     // whose name matches what they've entered.
     if (filter) {
-      tags = tags.filter((tag) => tag.name().substring(0, filter.length).toLowerCase() === filter);
+      tags = tags.filter((tag) => tag.name().includes(filter));
     }
 
     if (!this.indexTag || !tags.includes(this.indexTag)) this.indexTag = tags[0];

--- a/extensions/tags/js/src/common/components/TagSelectionModal.tsx
+++ b/extensions/tags/js/src/common/components/TagSelectionModal.tsx
@@ -260,7 +260,7 @@ export default class TagSelectionModal<
     // If the user has entered text in the filter input, then filter by tags
     // whose name matches what they've entered.
     if (filter) {
-      tags = tags.filter((tag) => tag.name().includes(filter));
+      tags = tags.filter((tag) => tag.name().toLowerCase().includes(filter));
     }
 
     if (!this.indexTag || !tags.includes(this.indexTag)) this.indexTag = tags[0];


### PR DESCRIPTION
**Changes proposed in this pull request:**
This pull request updates the tag filtering functionality to include partial matches when searching for tags. The previous implementation used `substring` method to match the tags with the filter string, which only matched tags starting from the beginning of the tag name.

The new implementation uses the `includes` method to match the filter string with any part of the tag name. This means that users can now search for tags based on partial matches, making it easier to find relevant tags.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Tag list:
![image](https://user-images.githubusercontent.com/25438601/230797178-c533d9bc-8a41-4f26-bba5-33fbbcfc6791.png)

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/25438601/230796566-414aacae-b4bd-4090-b1c4-a0bb26f5a0ab.png) | ![After](https://user-images.githubusercontent.com/25438601/230796570-06f83243-bd15-4c1e-a911-db2049fad0bf.png) |


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.