### PR TITLE
fix: notification subject discussion eager loading fails

### DIFF
--- a/framework/core/src/Api/Controller/ListNotificationsController.php
+++ b/framework/core/src/Api/Controller/ListNotificationsController.php
@@ -113,16 +113,16 @@ class ListNotificationsController extends AbstractListController
         $ids = [];
 
         foreach ($notifications as $notification) {
-            if ($notification->subject && $notification->subject->getAttribute('discussion_id')) {
-                $ids[] = $notification->subject->getAttribute('discussion_id');
+            if ($notification->subject && ($discussionId = $notification->subject->getAttribute('discussion_id'))) {
+                $ids[] = $discussionId;
             }
         }
 
         $discussions = Discussion::query()->find(array_unique($ids));
 
         foreach ($notifications as $notification) {
-            if ($notification->subject && $notification->subject->getAttribute('discussion_id')) {
-                $notification->subject->setRelation('discussion', $discussions->find($notification->subject->getAttribute('discussion_id')));
+            if ($notification->subject && ($discussionId = $notification->subject->getAttribute('discussion_id'))) {
+                $notification->subject->setRelation('discussion', $discussions->find($discussionId));
             }
         }
     }

--- a/framework/core/src/Api/Controller/ListNotificationsController.php
+++ b/framework/core/src/Api/Controller/ListNotificationsController.php
@@ -113,16 +113,16 @@ class ListNotificationsController extends AbstractListController
         $ids = [];
 
         foreach ($notifications as $notification) {
-            if ($notification->subject && property_exists($notification->subject, 'discussion_id')) {
-                $ids[] = $notification->subject->discussion_id;
+            if ($notification->subject && $notification->subject->getAttribute('discussion_id')) {
+                $ids[] = $notification->subject->getAttribute('discussion_id');
             }
         }
 
         $discussions = Discussion::query()->find(array_unique($ids));
 
         foreach ($notifications as $notification) {
-            if ($notification->subject && property_exists($notification->subject, 'discussion_id')) {
-                $notification->subject->setRelation('discussion', $discussions->find($notification->subject->discussion_id));
+            if ($notification->subject && $notification->subject->getAttribute('discussion_id')) {
+                $notification->subject->setRelation('discussion', $discussions->find($notification->subject->getAttribute('discussion_id')));
             }
         }
     }


### PR DESCRIPTION
**Closes #3778**

**Changes proposed in this pull request:**
In 1.7 the `property_exists` check was added to fix PHP 8.2 deprecations but missed the fact that dynamic properties cannot be checked like that.

I don't believe this is the problem described in the issue however, only 10 notifications are loaded at a time. So it could be a bad extension.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
