### PR TITLE
feat: provide old content to `Revised` event

### DIFF
--- a/framework/core/src/Post/CommentPost.php
+++ b/framework/core/src/Post/CommentPost.php
@@ -75,12 +75,14 @@ class CommentPost extends Post
     public function revise($content, User $actor)
     {
         if ($this->content !== $content) {
+            $oldContent = $this->content;
+
             $this->setContentAttribute($content, $actor);
 
             $this->edited_at = Carbon::now();
             $this->edited_user_id = $actor->id;
 
-            $this->raise(new Revised($this));
+            $this->raise(new Revised($this, $actor, $oldContent));
         }
 
         return $this;

--- a/framework/core/src/Post/Event/Revised.php
+++ b/framework/core/src/Post/Event/Revised.php
@@ -15,7 +15,7 @@ use Flarum\User\User;
 class Revised
 {
     /**
-     * @var \Flarum\Post\CommentPost
+     * @var CommentPost
      */
     public $post;
 
@@ -25,11 +25,18 @@ class Revised
     public $actor;
 
     /**
-     * @param \Flarum\Post\CommentPost $post
+     * We manually set the old content because at this stage the post
+     * has already been updated with the new content. So the original
+     * content is not available anymore.
+     *
+     * @var string
      */
-    public function __construct(CommentPost $post, User $actor = null)
+    public $oldContent;
+
+    public function __construct(CommentPost $post, User $actor, string $oldContent)
     {
         $this->post = $post;
         $this->actor = $actor;
+        $this->oldContent = $oldContent;
     }
 }


### PR DESCRIPTION
**Fixes #3715**

**Changes proposed in this pull request:**
We manually set the old content because at this stage the post has already been updated with the new content. So the original content is not available anymore.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
