### PR TITLE
fix: approving a post does not bump user `comment_count`

### DIFF
--- a/extensions/approval/src/Listener/UpdateDiscussionAfterPostApproval.php
+++ b/extensions/approval/src/Listener/UpdateDiscussionAfterPostApproval.php
@@ -36,5 +36,10 @@ class UpdateDiscussionAfterPostApproval
             $user->refreshCommentCount();
             $user->save();
         }
+
+        if ($post->user) {
+            $post->user->refreshCommentCount();
+            $post->user->save();
+        }
     }
 }


### PR DESCRIPTION
**Fixes #3714**

**Changes proposed in this pull request:**
Bumps post author's `comment_count` when approving a post.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
