### PR TITLE
fix: unread count in post stream not visible

### DIFF
--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -41,6 +41,7 @@ export default class PostStreamScrubber extends Component {
       const newStyle = {
         top: 100 - unreadPercent * 100 + '%',
         height: unreadPercent * 100 + '%',
+        opacity: unreadPercent ? 1 : 0,
       };
 
       if (vnode.state.oldStyle) {

--- a/framework/core/less/forum/Scrubber.less
+++ b/framework/core/less/forum/Scrubber.less
@@ -36,7 +36,6 @@
   font-size: 11px;
   font-weight: bold;
   padding-left: 13px;
-  overflow: hidden;
 }
 .Scrubber-handle {
   position: relative;


### PR DESCRIPTION
**Fixes #3642**

**Changes proposed in this pull request:**
Removes the overflow hidden CSS rule. Applies a 0 opacity when the unread is 0.
Visually the unread label never seems to overlap with the text above it, so it seems fine.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
