### PR TITLE
fix(a11y): reply placeholder not accessible

### DIFF
--- a/framework/core/js/src/forum/components/ReplyPlaceholder.js
+++ b/framework/core/js/src/forum/components/ReplyPlaceholder.js
@@ -38,11 +38,11 @@ export default class ReplyPlaceholder extends Component {
     };
 
     return (
-      <article className="Post ReplyPlaceholder" onclick={reply}>
-        <header className="Post-header">
+      <button className="Post ReplyPlaceholder" onclick={reply}>
+        <span className="Post-header">
           {avatar(app.session.user, { className: 'PostUser-avatar' })} {app.translator.trans('core.forum.post_stream.reply_placeholder')}
-        </header>
-      </article>
+        </span>
+      </button>
     );
   }
 

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -437,6 +437,9 @@
   border: 2px dashed var(--control-bg);
   color: var(--muted-color);
   border-radius: 10px;
+  background-color: transparent;
+  width: 100%;
+  display: flex;
 
   .Post-header {
     margin: 0;


### PR DESCRIPTION
**Fixes #3659**

**Changes proposed in this pull request:**
* Makes the placeholder into a button.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
