### PR TITLE
chore: drop usage of jquery in `install` and `update` interfaces

### DIFF
--- a/framework/core/views/install/install.php
+++ b/framework/core/views/install/install.php
@@ -67,37 +67,36 @@
 </form>
 
 <script>
-document.querySelector('form input').select();
+  window.onload = function() {
+    document.querySelector('form input').select();
 
-document.querySelector('form').addEventListener('submit', function(e) {
-  e.preventDefault();
+    document.querySelector('form').addEventListener('submit', function(e) {
+      e.preventDefault();
 
-  var button = this.querySelector('button');
-  button.textContent = 'Please Wait...';
-  button.disabled = true;
+      var button = this.querySelector('button');
+      button.textContent = 'Please Wait...';
+      button.disabled = true;
 
-  fetch('', {
-    method: 'POST',
-    body: new FormData(this)
-  })
-    .then(response => {
-      if (response.ok) {
-        window.location.reload();
-      } else {
-        response.text().then(errorMessage => {
-          var error = document.querySelector('#error');
-          error.style.display = 'block';
-          error.textContent = 'Something went wrong:\n\n' + errorMessage;
-          button.disabled = false;
-          button.textContent = 'Install Flarum';
+      fetch('', {
+        method: 'POST',
+        body: new FormData(this)
+      })
+        .then(response => {
+          if (response.ok) {
+            window.location.reload();
+          } else {
+            response.text().then(errorMessage => {
+              var error = document.querySelector('#error');
+              error.style.display = 'block';
+              error.textContent = 'Something went wrong:\n\n' + errorMessage;
+              button.disabled = false;
+              button.textContent = 'Install Flarum';
+            });
+          }
         });
-      }
-    })
-    .catch(error => {
-      console.error('Error:', error);
-    });
 
-  return false;
-});
+      return false;
+    });
+  }
 </script>
 

--- a/framework/core/views/install/install.php
+++ b/framework/core/views/install/install.php
@@ -67,7 +67,7 @@
 </form>
 
 <script>
-  window.onload = function() {
+  document.addEventListener('DOMContentLoaded', function() {
     document.querySelector('form input').select();
 
     document.querySelector('form').addEventListener('submit', function(e) {
@@ -97,6 +97,6 @@
 
       return false;
     });
-  }
+  });
 </script>
 

--- a/framework/core/views/install/install.php
+++ b/framework/core/views/install/install.php
@@ -66,29 +66,38 @@
   </div>
 </form>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
 <script>
-$(function() {
-  $('form :input:first').select();
+document.querySelector('form input').select();
 
-  $('form').on('submit', function(e) {
-    e.preventDefault();
+document.querySelector('form').addEventListener('submit', function(e) {
+  e.preventDefault();
 
-    var $button = $(this).find('button')
-      .text('Please Wait...')
-      .prop('disabled', true);
+  var button = this.querySelector('button');
+  button.textContent = 'Please Wait...';
+  button.disabled = true;
 
-    $.post('', $(this).serialize())
-      .done(function() {
+  fetch('', {
+    method: 'POST',
+    body: new FormData(this)
+  })
+    .then(response => {
+      if (response.ok) {
         window.location.reload();
-      })
-      .fail(function(data) {
-        $('#error').show().text('Something went wrong:\n\n' + data.responseText);
+      } else {
+        response.text().then(errorMessage => {
+          var error = document.querySelector('#error');
+          error.style.display = 'block';
+          error.textContent = 'Something went wrong:\n\n' + errorMessage;
+          button.disabled = false;
+          button.textContent = 'Install Flarum';
+        });
+      }
+    })
+    .catch(error => {
+      console.error('Error:', error);
+    });
 
-        $button.prop('disabled', false).text('Install Flarum');
-      });
-
-    return false;
-  });
+  return false;
 });
 </script>
+

--- a/framework/core/views/install/update.php
+++ b/framework/core/views/install/update.php
@@ -18,7 +18,7 @@
 </form>
 
 <script>
-  window.onload = function() {
+  document.addEventListener('DOMContentLoaded', function() {
     document.querySelector('form input').select();
 
     document.querySelector('form').addEventListener('submit', function(e) {
@@ -48,6 +48,6 @@
 
       return false;
     });
-  }
+  });
 </script>
 

--- a/framework/core/views/install/update.php
+++ b/framework/core/views/install/update.php
@@ -18,37 +18,36 @@
 </form>
 
 <script>
-  document.querySelector('form input').select();
+  window.onload = function() {
+    document.querySelector('form input').select();
 
-  document.querySelector('form').addEventListener('submit', function(e) {
-    e.preventDefault();
+    document.querySelector('form').addEventListener('submit', function(e) {
+      e.preventDefault();
 
-    var button = this.querySelector('button');
-    button.textContent = 'Please Wait...';
-    button.disabled = true;
+      var button = this.querySelector('button');
+      button.textContent = 'Please Wait...';
+      button.disabled = true;
 
-    fetch('', {
-      method: 'POST',
-      body: new FormData(this)
-    })
-      .then(response => {
-        if (response.ok) {
-          window.location.reload();
-        } else {
-          response.text().then(errorMessage => {
-            var error = document.querySelector('#error');
-            error.style.display = 'block';
-            error.textContent = 'Something went wrong:\n\n' + errorMessage;
-            button.disabled = false;
-            button.textContent = 'Update Flarum';
-          });
-        }
+      fetch('', {
+        method: 'POST',
+        body: new FormData(this)
       })
-      .catch(error => {
-        console.error('Error:', error);
-      });
+        .then(response => {
+          if (response.ok) {
+            window.location.reload();
+          } else {
+            response.text().then(errorMessage => {
+              var error = document.querySelector('#error');
+              error.style.display = 'block';
+              error.textContent = 'Something went wrong:\n\n' + errorMessage;
+              button.disabled = false;
+              button.textContent = 'Update Flarum';
+            });
+          }
+        });
 
-    return false;
-  });
+      return false;
+    });
+  }
 </script>
 

--- a/framework/core/views/install/update.php
+++ b/framework/core/views/install/update.php
@@ -17,29 +17,38 @@
   </div>
 </form>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
 <script>
-$(function() {
-  $('form :input:first').select();
+  document.querySelector('form input').select();
 
-  $('form').on('submit', function(e) {
+  document.querySelector('form').addEventListener('submit', function(e) {
     e.preventDefault();
 
-    var $button = $(this).find('button')
-      .text('Please Wait...')
-      .prop('disabled', true);
+    var button = this.querySelector('button');
+    button.textContent = 'Please Wait...';
+    button.disabled = true;
 
-    $.post('', $(this).serialize())
-      .done(function() {
-        window.location.reload();
+    fetch('', {
+      method: 'POST',
+      body: new FormData(this)
+    })
+      .then(response => {
+        if (response.ok) {
+          window.location.reload();
+        } else {
+          response.text().then(errorMessage => {
+            var error = document.querySelector('#error');
+            error.style.display = 'block';
+            error.textContent = 'Something went wrong:\n\n' + errorMessage;
+            button.disabled = false;
+            button.textContent = 'Update Flarum';
+          });
+        }
       })
-      .fail(function(data) {
-        $('#error').show().text('Something went wrong:\n\n' + data.responseText);
-
-        $button.prop('disabled', false).text('Update Flarum');
+      .catch(error => {
+        console.error('Error:', error);
       });
 
     return false;
   });
-});
 </script>
+


### PR DESCRIPTION
**Fixes #3457**

**Changes proposed in this pull request:**
* Just converts the JS code to vanilla JS.
* Tesed locally.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
