### PR TITLE
fix: deleting a discussion from the profile does not visually remove it

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionList.js
+++ b/framework/core/js/src/forum/components/DiscussionList.js
@@ -50,7 +50,7 @@ export default class DiscussionList extends Component {
           {state.getPages().map((pg, pageNum) => {
             return pg.items.map((discussion, itemNum) => (
               <li key={discussion.id()} data-id={discussion.id()} role="article" aria-setsize="-1" aria-posinset={pageNum * pageSize + itemNum}>
-                <DiscussionListItem discussion={discussion} params={params} />
+                <DiscussionListItem discussion={discussion} params={params} state={state} />
               </li>
             ));
           })}

--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -20,10 +20,12 @@ import Tooltip from '../../common/components/Tooltip';
 import type Discussion from '../../common/models/Discussion';
 import type Mithril from 'mithril';
 import type { DiscussionListParams } from '../states/DiscussionListState';
+import DiscussionListState from '../states/DiscussionListState';
 
 export interface IDiscussionListItemAttrs extends ComponentAttrs {
   discussion: Discussion;
   params: DiscussionListParams;
+  state?: DiscussionListState;
 }
 
 /**

--- a/framework/core/js/src/forum/utils/DiscussionControls.js
+++ b/framework/core/js/src/forum/utils/DiscussionControls.js
@@ -121,7 +121,7 @@ export default {
    * @return {ItemList<import('mithril').Children>}
    * @protected
    */
-  destructiveControls(discussion) {
+  destructiveControls(discussion, context) {
     const items = new ItemList();
 
     if (!discussion.isHidden()) {
@@ -157,7 +157,7 @@ export default {
           Button.component(
             {
               icon: 'fas fa-times',
-              onclick: this.deleteAction.bind(discussion),
+              onclick: this.deleteAction.bind(discussion, context),
             },
             app.translator.trans('core.forum.discussion_controls.delete_forever_button')
           )
@@ -232,9 +232,11 @@ export default {
   /**
    * Delete the discussion after confirming with the user.
    *
+   * @param {import('../../common/Component').default<any, any>} context The parent component under which the controls menu will be displayed.
+   *
    * @return {Promise<void>}
    */
-  deleteAction() {
+  deleteAction(context) {
     if (confirm(extractText(app.translator.trans('core.forum.discussion_controls.delete_confirmation')))) {
       // If we're currently viewing the discussion that was deleted, go back
       // to the previous page.
@@ -242,7 +244,14 @@ export default {
         app.history.back();
       }
 
-      return this.delete().then(() => app.discussions.removeDiscussion(this));
+      return this.delete().then(() => {
+        if (context.attrs?.state) {
+          // Delete from the local state.
+          context.attrs.state.removeDiscussion(this);
+          // And the global state if it isn't the global state.
+          if (context.attrs.state !== app.discussions) app.discussions.removeDiscussion(this);
+        }
+      });
     }
   },
 


### PR DESCRIPTION
**Fixes #2233**

**Changes proposed in this pull request:**
Changes the discussion controls to always use the correct state instead of assuming only global discussion list state.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
