### PR TITLE
fix: deleting a discussion from the profile does not visually remove it

### DIFF
--- a/framework/core/js/src/common/compat.ts
+++ b/framework/core/js/src/common/compat.ts
@@ -4,6 +4,7 @@ import Session from './Session';
 import Store from './Store';
 import BasicEditorDriver from './utils/BasicEditorDriver';
 import evented from './utils/evented';
+import EventEmitter from './utils/EventEmitter';
 import KeyboardNavigatable from './utils/KeyboardNavigatable';
 import liveHumanTimes from './utils/liveHumanTimes';
 import ItemList from './utils/ItemList';
@@ -97,6 +98,7 @@ export default {
   Store: Store,
   'utils/BasicEditorDriver': BasicEditorDriver,
   'utils/evented': evented,
+  'utils/EventEmitter': EventEmitter,
   'utils/KeyboardNavigatable': KeyboardNavigatable,
   'utils/liveHumanTimes': liveHumanTimes,
   'utils/ItemList': ItemList,

--- a/framework/core/js/src/common/utils/EventEmitter.ts
+++ b/framework/core/js/src/common/utils/EventEmitter.ts
@@ -1,0 +1,23 @@
+export default class EventEmitter {
+  protected events: any = {};
+
+  public constructor() {
+    this.events = {};
+  }
+
+  public on(event: string, listener: Function): EventEmitter {
+    if (!this.events[event]) {
+      this.events[event] = [];
+    }
+
+    this.events[event].push(listener);
+
+    return this;
+  }
+
+  public emit(event: string, ...args: any[]): void {
+    if (this.events[event]) {
+      this.events[event].forEach((listener: Function) => listener(...args));
+    }
+  }
+}


### PR DESCRIPTION
**Fixes #2233**

**Changes proposed in this pull request:**
* Based on previous PRs, I think the best approach to this is as Clark suggested. An event-listener approach, so that any discussion list that deletes a discussion, affects all discussion list states.
* This is cleaner than previous PRs.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
