### PR TITLE
fix: null as 2nd param in `preg_match` is deprecated

### DIFF
--- a/framework/core/src/Locale/Translator.php
+++ b/framework/core/src/Locale/Translator.php
@@ -62,7 +62,7 @@ class Translator extends BaseTranslator implements TranslatorContract
     {
         foreach ($catalogue->all() as $domain => $messages) {
             foreach ($messages as $id => $translation) {
-                if (preg_match(self::REFERENCE_REGEX, $translation, $matches)) {
+                if (! empty($translation) && preg_match(self::REFERENCE_REGEX, $translation, $matches)) {
                     $catalogue->set($id, $this->getTranslation($catalogue, $id, $domain), $domain);
                 }
             }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Replaces #3783 **

**Changes proposed in this pull request:**
`Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /var/www/framework/framework/core/src/Locale/Translator.php on line 65`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
