### PR TITLE
chore[tags]: Change some methods from private to protected, to be able to extend the affected classes

### DIFF
--- a/extensions/tags/src/Content/Tag.php
+++ b/extensions/tags/src/Content/Tag.php
@@ -113,7 +113,7 @@ class Tag
      *
      * @return array
      */
-    private function getSortMap()
+    protected function getSortMap()
     {
         return resolve('flarum.forum.discussions.sortmap');
     }
@@ -121,12 +121,12 @@ class Tag
     /**
      * Get the result of an API request to list discussions.
      */
-    private function getApiDocument(Request $request, array $params)
+    protected function getApiDocument(Request $request, array $params)
     {
         return json_decode($this->api->withParentRequest($request)->withQueryParams($params)->get('/discussions')->getBody());
     }
 
-    private function getTagsDocument(Request $request, string $slug)
+    protected function getTagsDocument(Request $request, string $slug)
     {
         return json_decode($this->api->withParentRequest($request)->withQueryParams([
             'include' => 'children,children.parent,parent,parent.children.parent,state'

--- a/extensions/tags/src/Content/Tags.php
+++ b/extensions/tags/src/Content/Tags.php
@@ -100,7 +100,7 @@ class Tags
         return $document;
     }
 
-    private function getTagsDocument(Request $request)
+    protected function getTagsDocument(Request $request)
     {
         return json_decode($this->api->withParentRequest($request)->withQueryParams([
             'include' => 'children,lastPostedDiscussion,parent'


### PR DESCRIPTION
**Changes proposed in this pull request:**
_see title_

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
