### PR TITLE
fix(tags): not all tags are loaded in the permission grid

### DIFF
--- a/extensions/tags/js/src/admin/addTagsPermissionScope.tsx
+++ b/extensions/tags/js/src/admin/addTagsPermissionScope.tsx
@@ -19,7 +19,6 @@ export default function () {
   extend(PermissionGrid.prototype, 'oncreate', function () {
     app.tagList.load().then(() => {
       this.loading = false;
-
       m.redraw();
     });
   });

--- a/extensions/tags/js/src/common/states/TagListState.ts
+++ b/extensions/tags/js/src/common/states/TagListState.ts
@@ -2,17 +2,27 @@ import app from 'flarum/common/app';
 import type Tag from '../../common/models/Tag';
 
 export default class TagListState {
-  loadedIncludes = new Set();
+  loadedIncludes?: Set<string>;
 
   async load(includes: string[] = []): Promise<Tag[]> {
-    const unloadedIncludes = includes.filter((include) => !this.loadedIncludes.has(include));
+    if (!this.loadedIncludes) {
+      return this.query(includes);
+    }
+
+    const unloadedIncludes = includes.filter((include) => !this.loadedIncludes!.has(include));
 
     if (unloadedIncludes.length === 0) {
       return Promise.resolve(app.store.all<Tag>('tags'));
     }
 
-    return app.store.find<Tag[]>('tags', { include: unloadedIncludes.join(',') }).then((val) => {
-      unloadedIncludes.forEach((include) => this.loadedIncludes.add(include));
+    return this.query(unloadedIncludes);
+  }
+
+  async query(includes: string[] = []): Promise<Tag[]> {
+    this.loadedIncludes ??= new Set();
+
+    return app.store.find<Tag[]>('tags', { include: includes.join(',') }).then((val) => {
+      includes.forEach((include) => this.loadedIncludes!.add(include));
       return val;
     });
   }


### PR DESCRIPTION
**Fixes #3800**

**Changes proposed in this pull request:**
* The code was just getting all tags from the store, this PR changes the state to make sure to consider first load.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
