### PR TITLE
fix(mentions): mentions XHR fired even after mentioning is done

### DIFF
--- a/extensions/mentions/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/mentions/js/src/forum/addComposerAutocomplete.js
@@ -73,56 +73,59 @@ export default function addComposerAutocomplete() {
       dropdown.hide();
       dropdown.active = false;
 
-      if (absMentionStart) {
-        const typed = lastChunk.substring(relMentionStart).toLowerCase();
-        matchTyped = activeFormat.queryFromTyped(typed);
-        mentionables.typed = matchTyped || typed;
+      if (!absMentionStart) return;
 
-        const buildSuggestions = () => {
-          // If the user has started to type a mention,
-          // then suggest models matching.
-          const suggestions = mentionables.buildSuggestions();
+      const typed = lastChunk.substring(relMentionStart).toLowerCase();
+      matchTyped = activeFormat.queryFromTyped(typed);
 
-          if (suggestions.length) {
-            dropdown.items = suggestions;
-            m.render($container[0], dropdown.render());
+      if (!matchTyped) return;
 
-            dropdown.show();
-            const coordinates = this.attrs.composer.editor.getCaretCoordinates(absMentionStart);
-            const width = dropdown.$().outerWidth();
-            const height = dropdown.$().outerHeight();
-            const parent = dropdown.$().offsetParent();
-            let left = coordinates.left;
-            let top = coordinates.top + 15;
+      mentionables.typed = matchTyped;
 
-            // Keep the dropdown inside the editor.
-            if (top + height > parent.height()) {
-              top = coordinates.top - height - 15;
-            }
-            if (left + width > parent.width()) {
-              left = parent.width() - width;
-            }
+      const buildSuggestions = () => {
+        // If the user has started to type a mention,
+        // then suggest models matching.
+        const suggestions = mentionables.buildSuggestions();
 
-            // Prevent the dropdown from going off screen on mobile
-            top = Math.max(-(parent.offset().top - $(document).scrollTop()), top);
-            left = Math.max(-parent.offset().left, left);
+        if (suggestions.length) {
+          dropdown.items = suggestions;
+          m.render($container[0], dropdown.render());
 
-            dropdown.show(left, top);
-          } else {
-            dropdown.active = false;
-            dropdown.hide();
+          dropdown.show();
+          const coordinates = this.attrs.composer.editor.getCaretCoordinates(absMentionStart);
+          const width = dropdown.$().outerWidth();
+          const height = dropdown.$().outerHeight();
+          const parent = dropdown.$().offsetParent();
+          let left = coordinates.left;
+          let top = coordinates.top + 15;
+
+          // Keep the dropdown inside the editor.
+          if (top + height > parent.height()) {
+            top = coordinates.top - height - 15;
           }
-        };
+          if (left + width > parent.width()) {
+            left = parent.width() - width;
+          }
 
-        dropdown.active = true;
+          // Prevent the dropdown from going off screen on mobile
+          top = Math.max(-(parent.offset().top - $(document).scrollTop()), top);
+          left = Math.max(-parent.offset().left, left);
 
-        buildSuggestions();
+          dropdown.show(left, top);
+        } else {
+          dropdown.active = false;
+          dropdown.hide();
+        }
+      };
 
-        dropdown.setIndex(0);
-        dropdown.$().scrollTop(0);
+      dropdown.active = true;
 
-        mentionables.search()?.then(buildSuggestions);
-      }
+      buildSuggestions();
+
+      dropdown.setIndex(0);
+      dropdown.$().scrollTop(0);
+
+      mentionables.search()?.then(buildSuggestions);
     };
 
     params.inputListeners.push(suggestionsInputListener);

--- a/extensions/mentions/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/mentions/js/src/forum/addComposerAutocomplete.js
@@ -73,59 +73,59 @@ export default function addComposerAutocomplete() {
       dropdown.hide();
       dropdown.active = false;
 
-      if (!absMentionStart) return;
+      if (absMentionStart) {
+        const typed = lastChunk.substring(relMentionStart).toLowerCase();
+        matchTyped = activeFormat.queryFromTyped(typed);
 
-      const typed = lastChunk.substring(relMentionStart).toLowerCase();
-      matchTyped = activeFormat.queryFromTyped(typed);
+        if (!matchTyped) return;
 
-      if (!matchTyped) return;
+        mentionables.typed = matchTyped;
 
-      mentionables.typed = matchTyped;
+        const buildSuggestions = () => {
+          // If the user has started to type a mention,
+          // then suggest models matching.
+          const suggestions = mentionables.buildSuggestions();
 
-      const buildSuggestions = () => {
-        // If the user has started to type a mention,
-        // then suggest models matching.
-        const suggestions = mentionables.buildSuggestions();
+          if (suggestions.length) {
+            dropdown.items = suggestions;
+            m.render($container[0], dropdown.render());
 
-        if (suggestions.length) {
-          dropdown.items = suggestions;
-          m.render($container[0], dropdown.render());
+            dropdown.show();
+            const coordinates = this.attrs.composer.editor.getCaretCoordinates(absMentionStart);
+            const width = dropdown.$().outerWidth();
+            const height = dropdown.$().outerHeight();
+            const parent = dropdown.$().offsetParent();
+            let left = coordinates.left;
+            let top = coordinates.top + 15;
 
-          dropdown.show();
-          const coordinates = this.attrs.composer.editor.getCaretCoordinates(absMentionStart);
-          const width = dropdown.$().outerWidth();
-          const height = dropdown.$().outerHeight();
-          const parent = dropdown.$().offsetParent();
-          let left = coordinates.left;
-          let top = coordinates.top + 15;
+            // Keep the dropdown inside the editor.
+            if (top + height > parent.height()) {
+              top = coordinates.top - height - 15;
+            }
+            if (left + width > parent.width()) {
+              left = parent.width() - width;
+            }
 
-          // Keep the dropdown inside the editor.
-          if (top + height > parent.height()) {
-            top = coordinates.top - height - 15;
+            // Prevent the dropdown from going off screen on mobile
+            top = Math.max(-(parent.offset().top - $(document).scrollTop()), top);
+            left = Math.max(-parent.offset().left, left);
+
+            dropdown.show(left, top);
+          } else {
+            dropdown.active = false;
+            dropdown.hide();
           }
-          if (left + width > parent.width()) {
-            left = parent.width() - width;
-          }
+        };
 
-          // Prevent the dropdown from going off screen on mobile
-          top = Math.max(-(parent.offset().top - $(document).scrollTop()), top);
-          left = Math.max(-parent.offset().left, left);
+        dropdown.active = true;
 
-          dropdown.show(left, top);
-        } else {
-          dropdown.active = false;
-          dropdown.hide();
-        }
-      };
+        buildSuggestions();
 
-      dropdown.active = true;
+        dropdown.setIndex(0);
+        dropdown.$().scrollTop(0);
 
-      buildSuggestions();
-
-      dropdown.setIndex(0);
-      dropdown.$().scrollTop(0);
-
-      mentionables.search()?.then(buildSuggestions);
+        mentionables.search()?.then(buildSuggestions);
+      }
     };
 
     params.inputListeners.push(suggestionsInputListener);

--- a/extensions/mentions/js/src/forum/mentionables/MentionableModels.tsx
+++ b/extensions/mentions/js/src/forum/mentionables/MentionableModels.tsx
@@ -1,4 +1,3 @@
-import MentionFormats from './MentionFormats';
 import type MentionableModel from './MentionableModel';
 import type Model from 'flarum/common/Model';
 import type Mithril from 'mithril';

--- a/extensions/mentions/js/src/forum/mentionables/formats/AtMentionFormat.ts
+++ b/extensions/mentions/js/src/forum/mentionables/formats/AtMentionFormat.ts
@@ -13,7 +13,7 @@ export default class AtMentionFormat extends MentionFormat {
   }
 
   public queryFromTyped(typed: string): string | null {
-    const matchTyped = typed.match(/^["“]((?:(?!"#).)+)$/);
+    const matchTyped = typed.match(/^["“]?((?:(?!"#).)+)$/);
 
     return matchTyped ? matchTyped[1] : null;
   }

--- a/extensions/mentions/js/src/forum/mentionables/formats/HashMentionFormat.ts
+++ b/extensions/mentions/js/src/forum/mentionables/formats/HashMentionFormat.ts
@@ -13,7 +13,7 @@ export default class HashMentionFormat extends MentionFormat {
   public queryFromTyped(typed: string): string | null {
     const matchTyped = typed.match(/^[-_\p{L}\p{N}\p{M}]+$/giu);
 
-    return matchTyped ? matchTyped[1] : null;
+    return matchTyped ? matchTyped[0] : null;
   }
 
   public format(slug: string): string {

--- a/extensions/mentions/js/src/forum/mentionables/formats/MentionFormat.ts
+++ b/extensions/mentions/js/src/forum/mentionables/formats/MentionFormat.ts
@@ -19,8 +19,19 @@ export default abstract class MentionFormat {
   }
 
   abstract mentionables: (new (...args: any[]) => MentionableModel)[];
+
   protected abstract extendable: boolean;
+
   abstract trigger(): string;
+
+  /**
+   * Picks the term to search in the API from the typed text.
+   * @example:
+   *  * Full text = `Hello @"John D`
+   *  * Typed text = `"John D`
+   *  * Query = `John D`
+   */
   abstract queryFromTyped(typed: string): string | null;
+
   abstract format(...args: any): string;
 }


### PR DESCRIPTION
**Fixes #3766**

**Changes proposed in this pull request:**
* Only executes logic if the typed content so far has an ongoing mention format typing.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.