### PR TITLE
fix(bbcode): localize quote `wrote` string

### DIFF
--- a/extensions/bbcode/extend.php
+++ b/extensions/bbcode/extend.php
@@ -9,22 +9,34 @@
 
 use Flarum\Extend;
 use s9e\TextFormatter\Configurator;
+use s9e\TextFormatter\Renderer;
 
-return (new Extend\Formatter)
-    ->configure(function (Configurator $config) {
-        $config->BBCodes->addFromRepository('B');
-        $config->BBCodes->addFromRepository('I');
-        $config->BBCodes->addFromRepository('U');
-        $config->BBCodes->addFromRepository('S');
-        $config->BBCodes->addFromRepository('URL');
-        $config->BBCodes->addFromRepository('IMG');
-        $config->BBCodes->addFromRepository('EMAIL');
-        $config->BBCodes->addFromRepository('CODE');
-        $config->BBCodes->addFromRepository('QUOTE');
-        $config->BBCodes->addFromRepository('LIST');
-        $config->BBCodes->addFromRepository('DEL');
-        $config->BBCodes->addFromRepository('COLOR');
-        $config->BBCodes->addFromRepository('CENTER');
-        $config->BBCodes->addFromRepository('SIZE');
-        $config->BBCodes->addFromRepository('*');
-    });
+return [
+    new Extend\Locales(__DIR__.'/locale'),
+
+    (new Extend\Formatter)
+        ->render(function (Renderer $renderer, $context, string $xml) {
+            $renderer->setParameter('L_WROTE', resolve('translator')->trans('flarum-bbcode.forum.quote.wrote'));
+
+            return $xml;
+        })
+        ->configure(function (Configurator $config) {
+            $config->BBCodes->addFromRepository('B');
+            $config->BBCodes->addFromRepository('I');
+            $config->BBCodes->addFromRepository('U');
+            $config->BBCodes->addFromRepository('S');
+            $config->BBCodes->addFromRepository('URL');
+            $config->BBCodes->addFromRepository('IMG');
+            $config->BBCodes->addFromRepository('EMAIL');
+            $config->BBCodes->addFromRepository('CODE');
+            $config->BBCodes->addFromRepository('QUOTE', 'default', [
+                'authorStr' => '<xsl:value-of select="@author"/> <xsl:value-of select="$L_WROTE"/>'
+            ]);
+            $config->BBCodes->addFromRepository('LIST');
+            $config->BBCodes->addFromRepository('DEL');
+            $config->BBCodes->addFromRepository('COLOR');
+            $config->BBCodes->addFromRepository('CENTER');
+            $config->BBCodes->addFromRepository('SIZE');
+            $config->BBCodes->addFromRepository('*');
+        }),
+];

--- a/extensions/bbcode/locale/en.yml
+++ b/extensions/bbcode/locale/en.yml
@@ -1,0 +1,10 @@
+flarum-bbcode:
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
+  # Translations in this namespace are used by the forum user interface.
+  forum:
+    quote:
+      wrote: wrote


### PR DESCRIPTION
**Fixes #3807**

**Changes proposed in this pull request:**
* Allows localizing the `wrote` bit of the quote bbcode.
* This PR takes into consideration previous attempts. The translated string is not cached with the renderer cache. It is resolved on new renders.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
