### PR TITLE
fix: unreadable badge icon on certain colors

### DIFF
--- a/framework/core/js/src/common/components/Badge.tsx
+++ b/framework/core/js/src/common/components/Badge.tsx
@@ -2,6 +2,7 @@ import Tooltip from './Tooltip';
 import Component, { ComponentAttrs } from '../Component';
 import icon from '../helpers/icon';
 import classList from '../utils/classList';
+import textContrastClass from '../helpers/textContrastClass';
 
 export interface IBadgeAttrs extends ComponentAttrs {
   icon: string;
@@ -27,7 +28,7 @@ export default class Badge<CustomAttrs extends IBadgeAttrs = IBadgeAttrs> extend
   view() {
     const { type, icon: iconName, label, color, style = {}, ...attrs } = this.attrs;
 
-    const className = classList('Badge', [type && `Badge--${type}`], attrs.className);
+    const className = classList('Badge', [type && `Badge--${type}`], attrs.className, color && textContrastClass(color));
 
     const iconChild = iconName ? icon(iconName, { className: 'Badge-icon' }) : m.trust('&nbsp;');
 

--- a/framework/core/less/common/Badge.less
+++ b/framework/core/less/common/Badge.less
@@ -4,7 +4,7 @@
   height: var(--size);
   border-radius: calc(~"var(--size) / 2");
   background: var(--badge-bg);
-  color: var(--badge-color);
+  color: var(--contrast-color, var(--badge-color));
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
**Fixes #3805**

**Changes proposed in this pull request:**
* Uses the color contrast utility to fix badge icon color on colored backgrounds.

**Screenshot**
![Screenshot from 2023-04-27 19-42-35](https://user-images.githubusercontent.com/20267363/234987543-1d43a532-a73f-4de5-a76d-78cca6923a21.png)
![Screenshot from 2023-04-27 19-42-48](https://user-images.githubusercontent.com/20267363/234987584-4914e481-47c8-4561-bb94-d0e2c3b804b4.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
