### PR TITLE
feat: add a trait to flush the formatter cache in tests

### DIFF
--- a/framework/core/tests/integration/extenders/FormatterTest.php
+++ b/framework/core/tests/integration/extenders/FormatterTest.php
@@ -11,16 +11,16 @@ namespace Flarum\Tests\integration\extenders;
 
 use Flarum\Extend;
 use Flarum\Formatter\Formatter;
+use Flarum\Testing\integration\RefreshesFormatterCache;
 use Flarum\Testing\integration\TestCase;
 
 class FormatterTest extends TestCase
 {
+    use RefreshesFormatterCache;
+
     protected function getFormatter()
     {
-        $formatter = $this->app()->getContainer()->make(Formatter::class);
-        $formatter->flush();
-
-        return $formatter;
+        return $this->app()->getContainer()->make(Formatter::class);
     }
 
     /**

--- a/php-packages/testing/src/integration/RefreshesFormatterCache.php
+++ b/php-packages/testing/src/integration/RefreshesFormatterCache.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Testing\integration;
 
 use Flarum\Formatter\Formatter;

--- a/php-packages/testing/src/integration/RefreshesFormatterCache.php
+++ b/php-packages/testing/src/integration/RefreshesFormatterCache.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Flarum\Testing\integration;
+
+use Flarum\Formatter\Formatter;
+
+trait RefreshesFormatterCache
+{
+    protected function tearDown(): void
+    {
+        $this->app()->getContainer()->make(Formatter::class)->flush();
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
**Fixes #3663**

**Changes proposed in this pull request:**
* Adds a trait that can be used in tests to clear formatter cache when needed.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
