### PR TITLE
fix(tags): `DiscussionTaggedPost` shows tags as `deleted`

### DIFF
--- a/extensions/mentions/extend.php
+++ b/extensions/mentions/extend.php
@@ -128,9 +128,6 @@ return [
                 ->render(Formatter\FormatTagMentions::class)
                 ->unparse(Formatter\UnparseTagMentions::class),
 
-            (new Extend\Model(Post::class))
-                ->belongsToMany('mentionsTags', Tag::class, 'post_mentions_tag', 'post_id', 'mentions_tag_id'),
-
             (new Extend\ApiSerializer(BasicPostSerializer::class))
                 ->hasMany('mentionsTags', TagSerializer::class),
 

--- a/extensions/tags/src/Post/DiscussionTaggedPost.php
+++ b/extensions/tags/src/Post/DiscussionTaggedPost.php
@@ -45,6 +45,11 @@ class DiscussionTaggedPost extends AbstractEventPost implements MergeableInterfa
 
         $this->save();
 
+        // Create mentions of the tags so that we can load them when rendering.
+        $this->mentionsTags()->sync(
+            array_merge($this->content[0], $this->content[1])
+        );
+
         return $this;
     }
 

--- a/extensions/tags/tests/integration/api/posts/ListTest.php
+++ b/extensions/tags/tests/integration/api/posts/ListTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Tests\integration\api\posts;
+
+use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class ListTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use RetrievesRepresentativeTags;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            'tags' => $this->tags(),
+            'users' => [
+                $this->normalUser(),
+                [
+                    'id' => 3,
+                    'username' => 'normal3',
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', // BCrypt hash for "too-obscure"
+                    'email' => 'normal3@machine.local',
+                    'is_email_confirmed' => 1,
+                ]
+            ],
+            'groups' => [
+                ['id' => 100, 'name_singular' => 'acme', 'name_plural' => 'acme']
+            ],
+            'group_user' => [
+                ['group_id' => 100, 'user_id' => 2]
+            ],
+            'group_permission' => [
+                ['group_id' => 100, 'permission' => 'tag5.viewForum'],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'no tags', 'user_id' => 1, 'comment_count' => 1],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>', 'number' => 1],
+                ['id' => 2, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'discussionTagged', 'content' => '[[1,5],[5]]', 'number' => 2],
+                ['id' => 3, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>', 'number' => 3],
+                ['id' => 4, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'discussionTagged', 'content' => '[[1,5],[5]]', 'number' => 4],
+           ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+            ],
+            'post_mentions_tag' => [
+                ['post_id' => 2, 'mentions_tag_id' => 1],
+                ['post_id' => 2, 'mentions_tag_id' => 5],
+                ['post_id' => 4, 'mentions_tag_id' => 1],
+                ['post_id' => 4, 'mentions_tag_id' => 5],
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider authorizedUsers
+     * @test
+     */
+    public function event_mentioned_tags_are_included_in_response_for_authorized_users(int $userId)
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts', [
+                'authenticatedAs' => $userId
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $tagIds = array_map(function ($tag) {
+            return $tag['id'];
+        }, array_filter($data['included'], function ($item) {
+            return $item['type'] === 'tags';
+        }));
+
+        $this->assertEqualsCanonicalizing([1, 5], $tagIds);
+    }
+
+    /**
+     * @dataProvider unauthorizedUsers
+     * @test
+     */
+    public function event_mentioned_tags_are_not_included_in_response_for_unauthorized_users(?int $userId)
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts', [
+                'authenticatedAs' => $userId
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $tagIds = array_map(function ($tag) {
+            return $tag['id'];
+        }, array_filter($data['included'], function ($item) {
+            return $item['type'] === 'tags';
+        }));
+
+        $this->assertEqualsCanonicalizing([1], $tagIds);
+    }
+
+    public function authorizedUsers()
+    {
+        return [
+            'admin' => [1],
+            'normal user with permission' => [2],
+        ];
+    }
+
+    public function unauthorizedUsers()
+    {
+        return [
+            'normal user without permission' => [3],
+            'guest' => [null],
+        ];
+    }
+}

--- a/extensions/tags/tests/integration/api/posts/ListTest.php
+++ b/extensions/tags/tests/integration/api/posts/ListTest.php
@@ -56,7 +56,7 @@ class ListTest extends TestCase
                 ['id' => 2, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'discussionTagged', 'content' => '[[1,5],[5]]', 'number' => 2],
                 ['id' => 3, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>', 'number' => 3],
                 ['id' => 4, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'discussionTagged', 'content' => '[[1,5],[5]]', 'number' => 4],
-           ],
+            ],
             'discussion_tag' => [
                 ['discussion_id' => 1, 'tag_id' => 1],
             ],


### PR DESCRIPTION
**Fixes #3620**

**Changes proposed in this pull request:**
* Uses tag mentions table (which is already in the tags extension) to include tags used in a `discussionTagged` post event, so that they are present in the frontend store and properly rendered.
* This will not fix older event posts, but will work for new ones.

**Screenshot**
| Before | After (new event post) (authorized users to see the tag) | unauthorized users from seeing the tag |
| -- | -- | -- |
| ![Screenshot from 2023-04-28 11-32-54](https://user-images.githubusercontent.com/20267363/235227088-c698bf90-7b29-4281-aa10-a8dca6e4c0d6.png) | ![Screenshot from 2023-04-28 15-53-18](https://user-images.githubusercontent.com/20267363/235227082-ee6eadd9-a738-4c14-8edd-b9b7e4b98d3f.png) | ![Screenshot from 2023-04-28 16-01-46](https://user-images.githubusercontent.com/20267363/235227078-e8f03579-a877-48c7-bc72-91740cca43d7.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
