### PR TITLE
feat: cli command for enabling or disabling an extension

### DIFF
--- a/framework/core/src/Console/ConsoleServiceProvider.php
+++ b/framework/core/src/Console/ConsoleServiceProvider.php
@@ -12,6 +12,7 @@ namespace Flarum\Console;
 use Flarum\Console\Cache\Factory;
 use Flarum\Database\Console\MigrateCommand;
 use Flarum\Database\Console\ResetCommand;
+use Flarum\Extension\Console\ToggleExtensionCommand;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Console\AssetsPublishCommand;
 use Flarum\Foundation\Console\CacheClearCommand;
@@ -63,7 +64,8 @@ class ConsoleServiceProvider extends AbstractServiceProvider
                 MigrateCommand::class,
                 ResetCommand::class,
                 ScheduleListCommand::class,
-                ScheduleRunCommand::class
+                ScheduleRunCommand::class,
+                ToggleExtensionCommand::class
                 // Used internally to create DB dumps before major releases.
                 // \Flarum\Database\Console\GenerateDumpCommand::class
             ];

--- a/framework/core/src/Extension/Console/ToggleExtensionCommand.php
+++ b/framework/core/src/Extension/Console/ToggleExtensionCommand.php
@@ -11,7 +11,6 @@ namespace Flarum\Extension\Console;
 
 use Flarum\Console\AbstractCommand;
 use Flarum\Extension\ExtensionManager;
-use Illuminate\Contracts\Container\Container;
 
 class ToggleExtensionCommand extends AbstractCommand
 {
@@ -26,7 +25,7 @@ class ToggleExtensionCommand extends AbstractCommand
 
         parent::__construct();
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/framework/core/src/Extension/Console/ToggleExtensionCommand.php
+++ b/framework/core/src/Extension/Console/ToggleExtensionCommand.php
@@ -43,16 +43,33 @@ class ToggleExtensionCommand extends AbstractCommand
      */
     protected function fire()
     {
-        $name = $this->input->getArgument('extension');
+        $name = $this->input->getArgument('extension-id');
+        $enabling = $this->input->getFirstArgument() === 'extension:enable';
 
-        if ($this->input->getOption('enable')) {
-            $this->info("Enabling $name extension...");
-            $this->extensionManager->enable($name);
-        } elseif ($this->input->getOption('disable')) {
-            $this->info("Disabling $name extension...");
-            $this->extensionManager->disable($name);
-        } else {
-            $this->error('You must specify --enable or --disable.');
+        if ($this->extensionManager->getExtension($name) === null) {
+            $this->error("There are no extensions by the ID of '$name'.");
+            return;
+        }
+
+        switch ($enabling) {
+            case true:
+                if ($this->extensionManager->isEnabled($name)) {
+                    $this->info("The '$name' extension is already enabled.");
+                    return;
+                } else {
+                    $this->info("Enabling '$name' extension...");
+                    $this->extensionManager->enable($name);
+                }
+                break;
+            case false:
+                if (! $this->extensionManager->isEnabled($name)) {
+                    $this->info("The '$name' extension is already disabled.");
+                    return;
+                } else {
+                    $this->info("Disabling '$name' extension...");
+                    $this->extensionManager->disable($name);
+                }
+                break;
         }
     }
 }

--- a/framework/core/src/Extension/Console/ToggleExtensionCommand.php
+++ b/framework/core/src/Extension/Console/ToggleExtensionCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension\Console;
+
+use Flarum\Console\AbstractCommand;
+use Flarum\Extension\ExtensionManager;
+use Illuminate\Contracts\Container\Container;
+
+class ToggleExtensionCommand extends AbstractCommand
+{
+    /**
+     * @var ExtensionManager
+     */
+    protected $extensionManager;
+
+    public function __construct(ExtensionManager $extensionManager)
+    {
+        $this->extensionManager = $extensionManager;
+
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('extension:toggle')
+            ->setDescription('Enable or disable an extension.')
+            ->addArgument('extension', null, 'The extension to enable or disable.')
+            ->addOption('enable', null, null, 'Enable the extension.')
+            ->addOption('disable', null, null, 'Disable the extension.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fire()
+    {
+        $name = $this->input->getArgument('extension');
+
+        if ($this->input->getOption('enable')) {
+            $this->info("Enabling $name extension...");
+            $this->extensionManager->enable($name);
+        } elseif ($this->input->getOption('disable')) {
+            $this->info("Disabling $name extension...");
+            $this->extensionManager->disable($name);
+        } else {
+            $this->error('You must specify --enable or --disable.');
+        }
+    }
+}

--- a/framework/core/src/Extension/Console/ToggleExtensionCommand.php
+++ b/framework/core/src/Extension/Console/ToggleExtensionCommand.php
@@ -32,11 +32,10 @@ class ToggleExtensionCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setName('extension:toggle')
+            ->setName('extension:enable')
+            ->setAliases(['extension:disable'])
             ->setDescription('Enable or disable an extension.')
-            ->addArgument('extension', null, 'The extension to enable or disable.')
-            ->addOption('enable', null, null, 'Enable the extension.')
-            ->addOption('disable', null, null, 'Disable the extension.');
+            ->addArgument('extension-id', null, 'The ID of the extension to enable or disable.');
     }
 
     /**

--- a/framework/core/src/Extension/Console/ToggleExtensionCommand.php
+++ b/framework/core/src/Extension/Console/ToggleExtensionCommand.php
@@ -48,6 +48,7 @@ class ToggleExtensionCommand extends AbstractCommand
 
         if ($this->extensionManager->getExtension($name) === null) {
             $this->error("There are no extensions by the ID of '$name'.");
+
             return;
         }
 
@@ -55,6 +56,7 @@ class ToggleExtensionCommand extends AbstractCommand
             case true:
                 if ($this->extensionManager->isEnabled($name)) {
                     $this->info("The '$name' extension is already enabled.");
+
                     return;
                 } else {
                     $this->info("Enabling '$name' extension...");
@@ -64,6 +66,7 @@ class ToggleExtensionCommand extends AbstractCommand
             case false:
                 if (! $this->extensionManager->isEnabled($name)) {
                     $this->info("The '$name' extension is already disabled.");
+
                     return;
                 } else {
                     $this->info("Disabling '$name' extension...");


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds a new CLI command to enable toggling of a given extension.

Usage:

```
 php flarum extension:enable blomstra-turnstile
```

```
 php flarum extension:disable blomstra-turnstile
```

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
![image](https://user-images.githubusercontent.com/16573496/235358093-00de6e10-6a16-47b6-88dd-1d70adc1a726.png)


![image](https://user-images.githubusercontent.com/16573496/235358080-898ef545-b3f3-4904-94e4-e938516519c9.png)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
