### PR TITLE
fix(bbcode): highlight.js does not work after changing post content

### DIFF
--- a/extensions/bbcode/composer.json
+++ b/extensions/bbcode/composer.json
@@ -21,6 +21,11 @@
     "require": {
         "flarum/core": "^1.7"
     },
+    "autoload": {
+        "psr-4": {
+            "Flarum\\BBCode\\": "src"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "1.x-dev"

--- a/extensions/bbcode/extend.php
+++ b/extensions/bbcode/extend.php
@@ -38,5 +38,15 @@ return [
             $config->BBCodes->addFromRepository('CENTER');
             $config->BBCodes->addFromRepository('SIZE');
             $config->BBCodes->addFromRepository('*');
+
+            // Fix for highlight JS not working after changing post content.
+            $codeTag = $config->tags->get('CODE');
+            $script = '
+                <script>
+                    if(window.hljsLoader && !document.currentScript.parentNode.hasAttribute(\'data-s9e-livepreview-onupdate\')) {
+                        window.hljsLoader.highlightBlocks(document.currentScript.parentNode);
+                    }
+                </script>';
+            $codeTag->template = str_replace('</pre>', $script.'</pre>', $codeTag->template);
         }),
 ];

--- a/extensions/bbcode/extend.php
+++ b/extensions/bbcode/extend.php
@@ -7,46 +7,14 @@
  * LICENSE file that was distributed with this source code.
  */
 
+namespace Flarum\BBCode;
+
 use Flarum\Extend;
-use s9e\TextFormatter\Configurator;
-use s9e\TextFormatter\Renderer;
 
 return [
     new Extend\Locales(__DIR__.'/locale'),
 
     (new Extend\Formatter)
-        ->render(function (Renderer $renderer, $context, string $xml) {
-            $renderer->setParameter('L_WROTE', resolve('translator')->trans('flarum-bbcode.forum.quote.wrote'));
-
-            return $xml;
-        })
-        ->configure(function (Configurator $config) {
-            $config->BBCodes->addFromRepository('B');
-            $config->BBCodes->addFromRepository('I');
-            $config->BBCodes->addFromRepository('U');
-            $config->BBCodes->addFromRepository('S');
-            $config->BBCodes->addFromRepository('URL');
-            $config->BBCodes->addFromRepository('IMG');
-            $config->BBCodes->addFromRepository('EMAIL');
-            $config->BBCodes->addFromRepository('CODE');
-            $config->BBCodes->addFromRepository('QUOTE', 'default', [
-                'authorStr' => '<xsl:value-of select="@author"/> <xsl:value-of select="$L_WROTE"/>'
-            ]);
-            $config->BBCodes->addFromRepository('LIST');
-            $config->BBCodes->addFromRepository('DEL');
-            $config->BBCodes->addFromRepository('COLOR');
-            $config->BBCodes->addFromRepository('CENTER');
-            $config->BBCodes->addFromRepository('SIZE');
-            $config->BBCodes->addFromRepository('*');
-
-            // Fix for highlight JS not working after changing post content.
-            $codeTag = $config->tags->get('CODE');
-            $script = '
-                <script>
-                    if(window.hljsLoader && !document.currentScript.parentNode.hasAttribute(\'data-s9e-livepreview-onupdate\')) {
-                        window.hljsLoader.highlightBlocks(document.currentScript.parentNode);
-                    }
-                </script>';
-            $codeTag->template = str_replace('</pre>', $script.'</pre>', $codeTag->template);
-        }),
+        ->render(Render::class)
+        ->configure(Configure::class),
 ];

--- a/extensions/bbcode/src/Configure.php
+++ b/extensions/bbcode/src/Configure.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Flarum\BBCode;
+
+use s9e\TextFormatter\Configurator;
+
+class Configure
+{
+    public function __invoke(Configurator $config)
+    {
+        $this->addTagsFromRepositories($config);
+        $this->adaptHighlightJs($config);
+    }
+
+    protected function addTagsFromRepositories(Configurator $config): void
+    {
+        $config->BBCodes->addFromRepository('B');
+        $config->BBCodes->addFromRepository('I');
+        $config->BBCodes->addFromRepository('U');
+        $config->BBCodes->addFromRepository('S');
+        $config->BBCodes->addFromRepository('URL');
+        $config->BBCodes->addFromRepository('IMG');
+        $config->BBCodes->addFromRepository('EMAIL');
+        $config->BBCodes->addFromRepository('CODE');
+        $config->BBCodes->addFromRepository('QUOTE', 'default', [
+            'authorStr' => '<xsl:value-of select="@author"/> <xsl:value-of select="$L_WROTE"/>'
+        ]);
+        $config->BBCodes->addFromRepository('LIST');
+        $config->BBCodes->addFromRepository('DEL');
+        $config->BBCodes->addFromRepository('COLOR');
+        $config->BBCodes->addFromRepository('CENTER');
+        $config->BBCodes->addFromRepository('SIZE');
+        $config->BBCodes->addFromRepository('*');
+    }
+
+    /**
+     * Fix for highlight JS not working after changing post content.
+     *
+     * @link https://github.com/flarum/framework/issues/3794
+     */
+    protected function adaptHighlightJs(Configurator $config): void
+    {
+        $codeTag = $config->tags->get('CODE');
+        $script = '
+                <script>
+                    if(window.hljsLoader && !document.currentScript.parentNode.hasAttribute(\'data-s9e-livepreview-onupdate\')) {
+                        window.hljsLoader.highlightBlocks(document.currentScript.parentNode);
+                    }
+                </script>';
+        $codeTag->template = str_replace('</pre>', $script.'</pre>', $codeTag->template);
+    }
+}

--- a/extensions/bbcode/src/Configure.php
+++ b/extensions/bbcode/src/Configure.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\BBCode;
 
 use s9e\TextFormatter\Configurator;

--- a/extensions/bbcode/src/Render.php
+++ b/extensions/bbcode/src/Render.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Flarum\BBCode;
+
+use s9e\TextFormatter\Renderer;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class Render
+{
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function __invoke(Renderer $renderer, $context, string $xml): string
+    {
+        $renderer->setParameter('L_WROTE', $this->translator->trans('flarum-bbcode.forum.quote.wrote'));
+
+        return $xml;
+    }
+}

--- a/extensions/bbcode/src/Render.php
+++ b/extensions/bbcode/src/Render.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\BBCode;
 
 use s9e\TextFormatter\Renderer;


### PR DESCRIPTION
**Fixes #3794**

**Changes proposed in this pull request:**
* Explicitly applies `hljs` after the post content has been updated.
* The relevant commit is https://github.com/flarum/framework/commit/8081e9b90ce34ea060bf9f051436c9cca63e2c8d the second one is just a re-organization of the code.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
