### PR TITLE
fix(testing): always clear cache in integration test's tearDown

### DIFF
--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -16,6 +16,7 @@ use Flarum\Foundation\Paths;
 use Flarum\Testing\integration\Extend\BeginTransactionAndSetDatabase;
 use Flarum\Testing\integration\Extend\OverrideExtensionManagerForTests;
 use Flarum\Testing\integration\Extend\SetSettingsBeforeBoot;
+use Illuminate\Contracts\Cache\Store;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\ServerRequest;
@@ -36,6 +37,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         parent::tearDown();
 
         $this->database()->rollBack();
+        $this->app()->getContainer()->make(Store::class)->flush();
     }
 
     /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->


**Changes proposed in this pull request:**

This prevent integration tests from interacting between each other through the cache. See https://github.com/flarum/framework/issues/3663#issuecomment-1531646474.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

