### PR TITLE
fix: discussion page showing horizontal scroll on iOS

### DIFF
--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -6,6 +6,7 @@
   }
 }
 
+// Fix to prevent horizontal scrolling bug on iOS
 @media @phone {
   html {
     overflow-x: hidden;

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -6,6 +6,10 @@
   }
 }
 
+html {
+  overflow-x: hidden;
+}
+
 body {
   background: var(--body-bg);
   color: var(--text-color);

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -6,8 +6,10 @@
   }
 }
 
-html {
-  overflow-x: hidden;
+@media @phone {
+  html {
+    overflow-x: hidden;
+  }
 }
 
 body {


### PR DESCRIPTION
**Fixes #3703**

**Changes proposed in this pull request:**
* Prevents horizontal scroll of the page.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
