### PR TITLE
Sort extensions in console info output

### DIFF
--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -83,7 +83,9 @@ class InfoCommand extends AbstractCommand
         $this->output->writeln('<info>PHP version:</info> '.$this->appInfo->identifyPHPVersion());
         $this->output->writeln('<info>MySQL version:</info> '.$this->appInfo->identifyDatabaseVersion());
 
-        $phpExtensions = implode(', ', get_loaded_extensions());
+        $phpExtensions = get_loaded_extensions();
+        sort($phpExtensions, SORT_STRING | SORT_FLAG_CASE);
+        $phpExtensions = implode(', ', $phpExtensions);
         $this->output->writeln("<info>Loaded extensions:</info> $phpExtensions");
 
         $this->getExtensionTable()->render();
@@ -118,7 +120,15 @@ class InfoCommand extends AbstractCommand
                 (new TableStyle)->setCellHeaderFormat('<info>%s</info>')
             );
 
-        foreach ($this->extensions->getEnabledExtensions() as $extension) {
+        $extensions = [];
+        foreach (array_values($this->extensions->getEnabledExtensions()) as $i => $extension) {
+            // Sort by ID, use their position as tiebreaker to prevent any potential name collision
+            $sortKey = $extension->getId().'-'.$i;
+            $extensions[$sortKey] = $extension;
+        }
+        ksort($extensions, SORT_STRING | SORT_FLAG_CASE);
+
+        foreach ($extensions as $extension) {
             $table->addRow([
                 $extension->getId(),
                 $extension->getVersion(),


### PR DESCRIPTION
**Changes proposed in this pull request:**
Sort extensions in lexicographic order in the console `info` output. It makes it easier to visually parse when someone reports an issue. Has no other use or impact, does not change the order of the extensions as returned by the ExtensionManager.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
The output should look like this, with `zlib` at the end of the list rather than lost between `sqlite3` and `ctype`.
```
$ ./flarum info
Flarum core: 1.7.2
PHP version: 8.2.5
MySQL version: 10.6.12-MariaDB-log
Loaded extensions: Core, ctype, curl, date, dba, dom, fileinfo, filter, gd, hash, iconv, intl, json, libxml, mbstring, mysqli, mysqlnd, openssl, pcre, PDO, pdo_mysql, pdo_sqlite, Phar, random, readline, Reflection, session, SimpleXML, sodium, SPL, sqlite3, standard, tokenizer, xml, xmlwriter, xsl, zip, zlib
+----------------------+---------+--------+
| Flarum Extensions    |         |        |
+----------------------+---------+--------+
| ID                   | Version | Commit |
+----------------------+---------+--------+
| flarum-approval      | v1.7.0  |        |
| flarum-bbcode        | v1.7.0  |        |
| flarum-emoji         | v1.7.0  |        |
| flarum-flags         | v1.7.0  |        |
| flarum-lang-english  | v1.7.0  |        |
| flarum-likes         | v1.7.0  |        |
| flarum-lock          | v1.7.0  |        |
| flarum-markdown      | v1.7.0  |        |
| flarum-mentions      | v1.7.0  |        |
| flarum-statistics    | v1.7.0  |        |
| flarum-sticky        | v1.7.0  |        |
| flarum-subscriptions | v1.7.0  |        |
| flarum-suspend       | v1.7.0  |        |
| flarum-tags          | v1.7.1  |        |
+----------------------+---------+--------+
```

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
