### PR TITLE
chore: upgrade to mithril 2.2

### DIFF
--- a/extensions/mentions/js/src/forum/mentionables/PostMention.tsx
+++ b/extensions/mentions/js/src/forum/mentionables/PostMention.tsx
@@ -58,12 +58,7 @@ export default class PostMention extends MentionableModel<Post, AtMentionFormat>
 
   suggestion(model: Post, typed: string): Mithril.Children {
     const user = model.user() || null;
-    const username = usernameHelper(user);
-
-    if (typed) {
-      username.children = [highlight((username.text ?? '') as string, typed)];
-      delete username.text;
-    }
+    const username = usernameHelper(user, (name: string) => highlight(name, typed));
 
     return (
       <>

--- a/extensions/mentions/js/src/forum/mentionables/UserMention.tsx
+++ b/extensions/mentions/js/src/forum/mentionables/UserMention.tsx
@@ -42,12 +42,7 @@ export default class UserMention extends MentionableModel<User, AtMentionFormat>
   }
 
   suggestion(model: User, typed: string): Mithril.Children {
-    const username = usernameHelper(model);
-
-    if (typed) {
-      username.children = [highlight((username.text ?? '') as string, typed)];
-      delete username.text;
-    }
+    const username = usernameHelper(model, (name: string) => highlight(name, typed));
 
     return (
       <>

--- a/framework/core/js/package.json
+++ b/framework/core/js/package.json
@@ -15,7 +15,7 @@
         "focus-trap": "^6.7.1",
         "jquery": "^3.6.0",
         "jquery.hotkeys": "^0.1.0",
-        "mithril": "~2.0.4",
+        "mithril": "^2.2",
         "nanoid": "^3.1.30",
         "punycode": "^2.1.1",
         "textarea-caret": "^3.1.0",

--- a/framework/core/js/src/common/components/Link.js
+++ b/framework/core/js/src/common/components/Link.js
@@ -15,9 +15,7 @@ export default class Link extends Component {
 
     attrs.href ||= '';
 
-    // For some reason, m.route.Link does not like vnode.text, so if present, we
-    // need to convert it to text vnodes and store it in children.
-    const children = vnode.children || { tag: '#', children: vnode.text };
+    const children = vnode.children;
 
     if (attrs.external) {
       return <a {...attrs}>{children}</a>;

--- a/framework/core/js/src/common/helpers/username.tsx
+++ b/framework/core/js/src/common/helpers/username.tsx
@@ -1,13 +1,15 @@
 import app from '../../common/app';
 import type Mithril from 'mithril';
 import User from '../models/User';
+import extractText from '../utils/extractText';
 
 /**
  * The `username` helper displays a user's username in a <span className="username">
  * tag. If the user doesn't exist, the username will be displayed as [deleted].
  */
-export default function username(user: User | null | undefined | false): Mithril.Vnode {
-  const name = (user && user.displayName()) || app.translator.trans('core.lib.username.deleted_text');
+export default function username(user: User | null | undefined | false, transformer?: (name: string) => Mithril.Children): Mithril.Vnode {
+  const name = (user && user.displayName()) || extractText(app.translator.trans('core.lib.username.deleted_text'));
+  const children = transformer ? transformer(name) : name;
 
-  return <span className="username">{name}</span>;
+  return <span className="username">{children}</span>;
 }

--- a/framework/core/js/src/common/utils/extractText.ts
+++ b/framework/core/js/src/common/utils/extractText.ts
@@ -7,7 +7,7 @@ export default function extractText(vdom: Mithril.Children): string {
   if (vdom instanceof Array) {
     return vdom.map((element) => extractText(element)).join('');
   } else if (typeof vdom === 'object' && vdom !== null) {
-    return vdom.children ? extractText(vdom.children) : String(vdom.text);
+    return extractText(vdom.children);
   } else {
     return String(vdom);
   }

--- a/framework/core/js/src/forum/components/UsersSearchSource.tsx
+++ b/framework/core/js/src/forum/components/UsersSearchSource.tsx
@@ -44,15 +44,13 @@ export default class UsersSearchResults implements SearchSource {
     return [
       <li className="Dropdown-header">{app.translator.trans('core.forum.search.users_heading')}</li>,
       ...results.map((user) => {
-        const name = username(user);
-
-        const children = [highlight(name.text as string, query)];
+        const name = username(user, (name: string) => highlight(name, query));
 
         return (
           <li className="UserSearchResult" data-index={'users' + user.id()}>
             <Link href={app.route.user(user)}>
               {avatar(user)}
-              {{ ...name, text: undefined, children }}
+              {name}
             </Link>
           </li>
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,10 +3665,12 @@ mithril-query@^4.0.1:
     pretty-html-log "1.1.1"
     yields-keycode "1.1.0"
 
-mithril@~2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/mithril/-/mithril-2.0.4.tgz#d125969d992b924c7185d24ff92d997e5c00116b"
-  integrity sha512-mgw+DMZlhMS4PpprF6dl7ZoeZq5GGcAuWnrg5e12MvaGauc4jzWsDZtVGRCktsiQczOEUr2K5teKbE5k44RlOg==
+mithril@^2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mithril/-/mithril-2.2.2.tgz#5a0743bd04726cc1efa6e91477f995d80fc6c539"
+  integrity sha512-YRm6eLv2UUaWaWHdH8L+desW9+DN7+oM34CxJv6tT2e1lNVue8bxQlknQeDRn9aKlO8sIujm2wqUHwM+Hb1wGQ==
+  dependencies:
+    ospec "4.0.0"
 
 mrmime@^1.0.0:
   version "1.0.1"
@@ -3785,6 +3787,13 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
+
+ospec@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ospec/-/ospec-4.0.0.tgz#7aaf8cb6d352a3f22e879460eebbc5f12df99779"
+  integrity sha512-MpDtkpscOxHYb4w71v7GB4LBsRuzxZnM+HdwjhzJQzu+5EJvA80yxTaKw+wp5Dmf5RV2/Bg3Uvz2vlI/PhW9Ow==
+  dependencies:
+    glob "^7.1.3"
 
 p-limit@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
**Changes proposed in this pull request:**
Upgrades to mithril 2.2

**Reviewers should focus on:**
* Found one breaking change, a vnode with simple text no longer has the text in `vnode.text`, it is now a child node with the `#` tag. Any direct access to `vnode.text` should be replaced in extensions with using the `extractText` utility.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**References**

- https://github.com/MithrilJS/mithril.js/pull/2670