### PR TITLE
fix(mentions): missed post mentions UI changes

### DIFF
--- a/extensions/mentions/js/src/forum/addMentionedByList.js
+++ b/extensions/mentions/js/src/forum/addMentionedByList.js
@@ -118,7 +118,7 @@ export default function addMentionedByList() {
         });
 
       const limit = 4;
-      const overLimit = repliers.length > limit;
+      const overLimit = post.mentionedByCount() > limit;
 
       // Create a list of unique users who have replied. So even if a user has
       // replied twice, they will only be in this array once.
@@ -136,7 +136,7 @@ export default function addMentionedByList() {
       // others" name to the end of the list. Clicking on it will display a modal
       // with a full list of names.
       if (overLimit) {
-        const count = repliers.length - names.length;
+        const count = post.mentionedByCount() - names.length;
 
         names.push(app.translator.trans('flarum-mentions.forum.post.others_text', { count }));
       }

--- a/extensions/mentions/src/Api/LoadMentionedByRelationship.php
+++ b/extensions/mentions/src/Api/LoadMentionedByRelationship.php
@@ -50,6 +50,16 @@ class LoadMentionedByRelationship
             $loadable = $data->newCollection($data->posts)->filter(function ($post) {
                 return $post instanceof Post;
             });
+
+            // firstPost and lastPost might have been included in the API response,
+            // so we have to make sure counts are also loaded for them.
+            if ($data->firstPost) {
+                $loadable->push($data->firstPost);
+            }
+
+            if ($data->lastPost) {
+                $loadable->push($data->lastPost);
+            }
         } elseif ($data instanceof Collection) {
             $loadable = $data;
         } elseif ($data instanceof Post) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Patches https://github.com/flarum/framework/pull/3780**

**Changes proposed in this pull request:**
- Fix UI to actually use the new `mentionedByCount` instead of checking the length of the `repliers` array.
- Fix the API, so that it serializes the correct value of `mentionedByCount` instead of `0` (else the UI doesn't behave as expected)

**Reviewers should focus on:**
The issues are actually fixed, no new performance issue has been introduced.

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
