### PR TITLE
chore: upgrade Wikimedia/less.php to 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,7 @@
         "symfony/postmark-mailer": "^6.3",
         "symfony/translation": "^6.3",
         "symfony/yaml": "^6.3",
-        "wikimedia/less.php": "^3.0"
+        "wikimedia/less.php": "^4.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -92,7 +92,7 @@
         "symfony/translation": "^6.3",
         "symfony/translation-contracts": "^2.5",
         "symfony/yaml": "^6.3",
-        "wikimedia/less.php": "^3.0"
+        "wikimedia/less.php": "^4.1"
     },
     "require-dev": {
         "flarum/testing": "^2.0",


### PR DESCRIPTION
Although the less.js version remains at `2.5.3` :( I still think it worthwhile to bump to `4.x` here, at least until we decide if `LESS` will be kept, or replaced with `SCSS`, etc.

Changes since `3.2.1`:

## 4.1.0

* Add support for `@supports` blocks. (Anne Tomasevich) [T332923](http://phabricator.wikimedia.org/T332923)
* Less_Parser: Returning a URI from `SetImportDirs()` callbacks is now optional. (Timo Tijhof)

## 4.0.0

* Remove support for PHP 7.2 and 7.3. Raise requirement to PHP 7.4+.
* Remove support for `cache_method=php` and `cache_method=var_export`, only the faster and more secure `cache_method=serialize` is now available. The built-in cache remains disabled by default.
* Fix `url(#myid)` to be treated as absolute URL. [T331649](https://phabricator.wikimedia.org/T331688)
* Fix "Undefined property" PHP 8.1 warning when `calc()` is used with CSS `var()`. [T331688](https://phabricator.wikimedia.org/T331688)
* Less_Parser: Improve performance by removing MatchFuncs and NewObj overhead. (Timo Tijhof)

https://github.com/wikimedia/less.php/compare/v3.2.1...v4.1.0