### PR TITLE
chore: remove unused vars in catch

### DIFF
--- a/extensions/tags/src/Query/TagFilterGambit.php
+++ b/extensions/tags/src/Query/TagFilterGambit.php
@@ -64,7 +64,7 @@ class TagFilterGambit extends AbstractRegexGambit implements FilterInterface
                     // @TODO: grab all IDs first instead of multiple queries.
                     try {
                         $id = $this->slugger->forResource(Tag::class)->fromSlug($slug, $actor)->id;
-                    } catch (ModelNotFoundException $e) {
+                    } catch (ModelNotFoundException) {
                         $id = null;
                     }
 

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -92,7 +92,7 @@ class ApplicationInfoProvider
             // Try to get the configured driver instance.
             // Driver instances are created on demand.
             $this->session->driver($configuredDriver);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             // An exception is thrown if the configured driver is not a valid driver.
             // So we fallback to the default driver.
             $driver = $defaultDriver;

--- a/framework/core/src/User/AvatarValidator.php
+++ b/framework/core/src/User/AvatarValidator.php
@@ -77,7 +77,7 @@ class AvatarValidator extends AbstractValidator
 
         try {
             $this->imageManager->make($file->getStream()->getMetadata('uri'));
-        } catch (NotReadableException $_e) {
+        } catch (NotReadableException) {
             $this->raise('image');
         }
     }

--- a/framework/core/src/User/SessionManager.php
+++ b/framework/core/src/User/SessionManager.php
@@ -31,7 +31,7 @@ class SessionManager extends IlluminateSessionManager
 
         try {
             $driverInstance = parent::driver($driverName);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $defaultDriverName = $this->getDefaultDriver();
             $driverInstance = parent::driver($defaultDriverName);
 

--- a/framework/core/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/framework/core/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -163,7 +163,7 @@ class SimpleFlarumSearchTest extends TestCase
 
         try {
             $this->app()->getContainer()->make(CustomSearcher::class);
-        } catch (BindingResolutionException $e) {
+        } catch (BindingResolutionException) {
             $anExceptionWasThrown = true;
         }
 

--- a/framework/core/tests/unit/Foundation/ConfigTest.php
+++ b/framework/core/tests/unit/Foundation/ConfigTest.php
@@ -129,7 +129,7 @@ class ConfigTest extends TestCase
 
         try {
             $config['custom_a'] = 'c';
-        } catch (RuntimeException $_) {
+        } catch (RuntimeException) {
         }
 
         // Ensure the value was not changed
@@ -146,7 +146,7 @@ class ConfigTest extends TestCase
 
         try {
             unset($config['custom_a']);
-        } catch (RuntimeException $_) {
+        } catch (RuntimeException) {
         }
 
         // Ensure the value was not changed


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

Remove unused vars in catch.

As of PHP 8.0.0, the variable name for a caught exception is optional. If not specified, the [catch](https://www.php.net/manual/en/language.exceptions.php) block will still execute but will not have access to the thrown object.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
