### PR TITLE
chore: use `str_contains` instead of `strpos`

### DIFF
--- a/extensions/mentions/src/Formatter/UnparsePostMentions.php
+++ b/extensions/mentions/src/Formatter/UnparsePostMentions.php
@@ -47,7 +47,7 @@ class UnparsePostMentions
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
-            if (strpos($attributes['displayname'], '"#') !== false) {
+            if (str_contains($attributes['displayname'], '"#')) {
                 $attributes['displayname'] = preg_replace('/"#[a-z]{0,3}[0-9]+/', '_', $attributes['displayname']);
             }
 
@@ -62,7 +62,7 @@ class UnparsePostMentions
     {
         $tagName = 'POSTMENTION';
 
-        if (strpos($xml, $tagName) === false) {
+        if (! str_contains($xml, $tagName)) {
             return $xml;
         }
 

--- a/extensions/mentions/src/Formatter/UnparseTagMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseTagMentions.php
@@ -49,7 +49,7 @@ class UnparseTagMentions
     {
         $tagName = 'TAGMENTION';
 
-        if (strpos($xml, $tagName) === false) {
+        if (! str_contains($xml, $tagName)) {
             return $xml;
         }
 

--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -44,7 +44,7 @@ class UnparseUserMentions
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
-            if (strpos($attributes['displayname'], '"#') !== false) {
+            if (str_contains($attributes['displayname'], '"#')) {
                 $attributes['displayname'] = preg_replace('/"#[a-z]{0,3}[0-9]+/', '_', $attributes['displayname']);
             }
 
@@ -59,7 +59,7 @@ class UnparseUserMentions
     {
         $tagName = 'USERMENTION';
 
-        if (strpos($xml, $tagName) === false) {
+        if (! str_contains($xml, $tagName)) {
             return $xml;
         }
 

--- a/extensions/package-manager/src/Command/RequireExtensionHandler.php
+++ b/extensions/package-manager/src/Command/RequireExtensionHandler.php
@@ -45,7 +45,7 @@ class RequireExtensionHandler
         $packageName = $command->package;
 
         // Auto append :* if not requiring a specific version.
-        if (strpos($packageName, ':') === false) {
+        if (! str_contains($packageName, ':')) {
             $packageName .= ':*';
         }
 


### PR DESCRIPTION
chore: use `str_contains` instead of `strpos`

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
