### PR TITLE
chore: simplify if else conditions

### DIFF
--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -38,11 +38,7 @@ class UnparseUserMentions
                 ? $context->mentionsUsers->find($attributes['id'])
                 : User::find($attributes['id']);
 
-            if ($user) {
-                $attributes['displayname'] = $user->display_name;
-            } else {
-                $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
-            }
+            $attributes['displayname'] = $user ? $user->display_name : $this->translator->trans('core.lib.username.deleted_text');
 
             if (strpos($attributes['displayname'], '"#') !== false) {
                 $attributes['displayname'] = preg_replace('/"#[a-z]{0,3}[0-9]+/', '_', $attributes['displayname']);

--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -38,7 +38,7 @@ class UnparseUserMentions
                 ? $context->mentionsUsers->find($attributes['id'])
                 : User::find($attributes['id']);
 
-            $attributes['displayname'] = $user ? $user->display_name : $this->translator->trans('core.lib.username.deleted_text');
+            $attributes['displayname'] = $user?->display_name ?? $this->translator->trans('core.lib.username.deleted_text');
 
             if (strpos($attributes['displayname'], '"#') !== false) {
                 $attributes['displayname'] = preg_replace('/"#[a-z]{0,3}[0-9]+/', '_', $attributes['displayname']);

--- a/extensions/nicknames/src/SaveNicknameToDatabase.php
+++ b/extensions/nicknames/src/SaveNicknameToDatabase.php
@@ -34,11 +34,7 @@ class SaveNicknameToDatabase
 
             // If the user sets their nickname back to the username
             // set the nickname to null so that it just falls back to the username
-            if ($user->username === $nickname) {
-                $user->nickname = null;
-            } else {
-                $user->nickname = $nickname;
-            }
+            $user->nickname = $user->username === $nickname ? null : $nickname;
         }
     }
 }

--- a/framework/core/src/Extend/LanguagePack.php
+++ b/framework/core/src/Extend/LanguagePack.php
@@ -115,7 +115,7 @@ class LanguagePack implements ExtenderInterface, LifecycleInterface
 
         /** @var ExtensionManager|null $extensions */
         static $extensions;
-        $extensions = $extensions ?? $container->make(ExtensionManager::class);
+        $extensions ??= $container->make(ExtensionManager::class);
 
         return $extensions->isEnabled($slug);
     }

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -199,7 +199,7 @@ class Formatter
     protected function configureDefaultsOnLinks(string $xml): string
     {
         return Utils::replaceAttributes($xml, 'URL', function ($attributes) {
-            $attributes['rel'] = $attributes['rel'] ?? 'ugc nofollow';
+            $attributes['rel'] ??= 'ugc nofollow';
 
             return $attributes;
         });

--- a/framework/core/src/Http/RouteHandlerFactory.php
+++ b/framework/core/src/Http/RouteHandlerFactory.php
@@ -62,11 +62,9 @@ class RouteHandlerFactory
 
     private function resolveController(callable|string $controller): Handler
     {
-        if (is_callable($controller)) {
-            $controller = $this->container->call($controller);
-        } else {
-            $controller = $this->container->make($controller);
-        }
+        $controller = is_callable($controller)
+            ? $this->container->call($controller)
+            : $this->container->make($controller);
 
         if (! $controller instanceof Handler) {
             throw new InvalidArgumentException('Controller must be an instance of '.Handler::class);


### PR DESCRIPTION
simplify if else conditions with modern php syntax :sunglasses:

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
