### PR TITLE
feat: add `whenExtensionDisabled` to `Conditional` extender

### DIFF
--- a/framework/core/src/Extend/Conditional.php
+++ b/framework/core/src/Extend/Conditional.php
@@ -36,7 +36,7 @@ class Conditional implements ExtenderInterface
     public function whenExtensionDisabled(string $extensionId, array $extenders): self
     {
         return $this->when(function (ExtensionManager $extensions) use ($extensionId) {
-            return !$extensions->isEnabled($extensionId);
+            return ! $extensions->isEnabled($extensionId);
         }, $extenders);
     }
 

--- a/framework/core/src/Extend/Conditional.php
+++ b/framework/core/src/Extend/Conditional.php
@@ -30,6 +30,16 @@ class Conditional implements ExtenderInterface
         }, $extenders);
     }
 
+    /**
+     * @param ExtenderInterface[] $extenders
+     */
+    public function whenExtensionDisabled(string $extensionId, array $extenders): self
+    {
+        return $this->when(function (ExtensionManager $extensions) use ($extensionId) {
+            return !$extensions->isEnabled($extensionId);
+        }, $extenders);
+    }
+
     public function when(callable|bool $condition, array $extenders): self
     {
         $this->conditions[] = [

--- a/framework/core/tests/integration/extenders/ConditionalTest.php
+++ b/framework/core/tests/integration/extenders/ConditionalTest.php
@@ -159,4 +159,119 @@ class ConditionalTest extends TestCase
 
         $this->app();
     }
+
+    /** @test */
+    public function conditional_disabled_extension_not_enabled_applies_extender_array()
+    {
+        $this->extend(
+            (new Extend\Conditional())
+                ->whenExtensionDisabled('flarum-dummy-extension', [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
+
+    /** @test */
+    public function conditional_disabled_extension_enabled_does_not_apply_extender_array()
+    {
+        $this->extension('flarum-tags');
+
+        $this->extend(
+            (new Extend\Conditional())
+                ->whenExtensionDisabled('flarum-tags', [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
+
+    /** @test */
+    public function conditional_enabled_extension_disabled_does_not_apply_extender_array()
+    {
+        $this->extend(
+            (new Extend\Conditional())
+                ->whenExtensionEnabled('flarum-dummy-extension', [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
+
+    /** @test */
+    public function conditional_enabled_extension_enabled_applies_extender_array()
+    {
+        $this->extension('flarum-tags');
+        $this->extend(
+            (new Extend\Conditional())
+                ->whenExtensionEnabled('flarum-tags', [
+                    (new Extend\ApiSerializer(ForumSerializer::class))
+                        ->attributes(function () {
+                            return [
+                                'customConditionalAttribute' => true
+                            ];
+                        })
+                ])
+        );
+
+        $this->app();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('customConditionalAttribute', $payload['data']['attributes']);
+    }
 }


### PR DESCRIPTION
Follow up to #3759 

Adds `whenExtensionDisabled` condition to the `Conditional` extender. Enables developers to provide extend items when a given extension is not installed/enabled.

Usage example:

```php
return [
    (new Extend\Conditional)
        ->whenExtensionDisabled('flarum-tags', [
                ...
        ]),
]
```