### PR TITLE
fix(mentions): cannot use mentionables extender

### DIFF
--- a/extensions/mentions/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/mentions/js/src/forum/addComposerAutocomplete.js
@@ -5,12 +5,9 @@ import TextEditorButton from 'flarum/common/components/TextEditorButton';
 import KeyboardNavigatable from 'flarum/common/utils/KeyboardNavigatable';
 
 import AutocompleteDropdown from './fragments/AutocompleteDropdown';
-import MentionFormats from './mentionables/formats/MentionFormats';
 import MentionableModels from './mentionables/MentionableModels';
 
 export default function addComposerAutocomplete() {
-  app.mentionFormats = new MentionFormats();
-
   const $container = $('<div class="ComposerBody-mentionsDropdownContainer"></div>');
   const dropdown = new AutocompleteDropdown();
 

--- a/extensions/mentions/js/src/forum/extend.ts
+++ b/extensions/mentions/js/src/forum/extend.ts
@@ -2,6 +2,8 @@ import Extend from 'flarum/common/extenders';
 import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
 import MentionsUserPage from './components/MentionsUserPage';
+import Mentionables from "./extenders/Mentionables";
+import TagMention from "./mentionables/TagMention";
 
 export default [
   new Extend.Routes() //
@@ -13,4 +15,7 @@ export default [
 
   new Extend.Model(User) //
     .attribute<boolean>('canMentionGroups'),
+
+  new Mentionables()
+    .mentionable('#', TagMention),
 ];

--- a/extensions/mentions/js/src/forum/extend.ts
+++ b/extensions/mentions/js/src/forum/extend.ts
@@ -2,8 +2,6 @@ import Extend from 'flarum/common/extenders';
 import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
 import MentionsUserPage from './components/MentionsUserPage';
-import Mentionables from "./extenders/Mentionables";
-import TagMention from "./mentionables/TagMention";
 
 export default [
   new Extend.Routes() //
@@ -15,7 +13,4 @@ export default [
 
   new Extend.Model(User) //
     .attribute<boolean>('canMentionGroups'),
-
-  new Mentionables()
-    .mentionable('#', TagMention),
 ];

--- a/extensions/mentions/js/src/forum/extenders/Mentionables.ts
+++ b/extensions/mentions/js/src/forum/extenders/Mentionables.ts
@@ -5,7 +5,7 @@ import type MentionFormat from '../mentionables/formats/MentionFormat';
 
 export default class Mentionables implements IExtender<ForumApplication> {
   protected formats: (new () => MentionFormat)[] = [];
-  protected mentionables: Record<string, (new () => MentionableModel)[]> = {};
+  protected mentionables: Record<string, (new (...args: any[]) => MentionableModel)[]> = {};
 
   /**
    * Register a new mention format.
@@ -26,7 +26,7 @@ export default class Mentionables implements IExtender<ForumApplication> {
    * @param mentionable The mentionable instance to register.
    *                    Must extend MentionableModel.
    */
-  mentionable(symbol: string, mentionable: new () => MentionableModel): this {
+  mentionable(symbol: string, mentionable: new (...args: any[]) => MentionableModel): this {
     if (!this.mentionables[symbol]) {
       this.mentionables[symbol] = [];
     }

--- a/extensions/mentions/js/src/forum/index.js
+++ b/extensions/mentions/js/src/forum/index.js
@@ -13,10 +13,13 @@ import addComposerAutocomplete from './addComposerAutocomplete';
 import PostMentionedNotification from './components/PostMentionedNotification';
 import UserMentionedNotification from './components/UserMentionedNotification';
 import GroupMentionedNotification from './components/GroupMentionedNotification';
+import MentionFormats from './mentionables/formats/MentionFormats';
 import UserPage from 'flarum/forum/components/UserPage';
 import LinkButton from 'flarum/common/components/LinkButton';
 import User from 'flarum/common/models/User';
 import Model from 'flarum/common/Model';
+
+app.mentionFormats = new MentionFormats();
 
 export { default as extend } from './extend';
 

--- a/extensions/mentions/js/src/forum/mentionables/formats/HashMentionFormat.ts
+++ b/extensions/mentions/js/src/forum/mentionables/formats/HashMentionFormat.ts
@@ -4,7 +4,7 @@ import TagMention from '../TagMention';
 
 export default class HashMentionFormat extends MentionFormat {
   public mentionables: (new (...args: any[]) => MentionableModel)[] = [TagMention];
-  protected extendable: boolean = false;
+  protected extendable: boolean = true;
 
   public trigger(): string {
     return '#';

--- a/framework/core/src/Queue/ExceptionHandler.php
+++ b/framework/core/src/Queue/ExceptionHandler.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Queue;
 
-use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandling;
 use Psr\Log\LoggerInterface;
 use Throwable;


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Fixes the fact you can't use the newly introduced mentionables frontend extender in 1.8

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.