### PR TITLE
fix: default labels with `SettingDropdown` and `SelectDropdown`

### DIFF
--- a/framework/core/js/src/admin/components/SettingDropdown.tsx
+++ b/framework/core/js/src/admin/components/SettingDropdown.tsx
@@ -21,7 +21,7 @@ export default class SettingDropdown<CustomAttrs extends ISettingDropdownAttrs =
     attrs.className = 'SettingDropdown';
     attrs.buttonClassName = 'Button Button--text';
     attrs.caretIcon = 'fas fa-caret-down';
-    attrs.defaultLabel = 'Custom';
+    attrs.defaultLabel ||= app.translator.trans('core.admin.settings.select_dropdown_custom_label');
 
     if ('key' in attrs) {
       attrs.setting = attrs.key?.toString();

--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -28,7 +28,7 @@ function isActive(vnode: Mithril.Children): boolean {
 }
 
 export interface ISelectDropdownAttrs extends IDropdownAttrs {
-  defaultLabel: string;
+  defaultLabel: Mithril.Children;
 }
 
 /**
@@ -48,9 +48,6 @@ export default class SelectDropdown<CustomAttrs extends ISelectDropdownAttrs = I
   getButtonContent(children: Mithril.ChildArray): Mithril.ChildArray {
     const activeChild = children.find(isActive);
     let label = (activeChild && typeof activeChild === 'object' && 'children' in activeChild && activeChild.children) || this.attrs.defaultLabel;
-
-    // @ts-ignore
-    if (Array.isArray(label)) label = label[0];
 
     return [<span className="Button-label">{label}</span>, this.attrs.caretIcon ? icon(this.attrs.caretIcon, { className: 'Button-caret' }) : null];
   }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -252,6 +252,7 @@ core:
     # These translations are used generically in setting fields.
     settings:
       saved_message: Your changes were saved.
+      select_dropdown_custom_label: Custom
       submit_button: => core.ref.save_changes
 
     # These translations are used in image upload buttons.


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- I've removed the array check that was reverted to in #3773. The code `if (Array.isArray(label)) label = label[0];` is from *2015*. I don't think either that or `extractText` is needed here -- I tested this in `v1` first with no issues in the same examples provided in that PR.

  https://github.com/flarum/framework/blame/f7dd609b264d4266151efa3b8a4c5775526346fc/framework/core/js/src/common/components/SelectDropdown.js#L48
  ![image](https://github.com/flarum/framework/assets/6401250/0efb838b-2e90-409a-92ac-36c94cb5d7de)

- Made the `defaultLabel` not override custom ones set by vnode attrs. This fixes the fallbacks in PermissionGrid for eg. discussion & tag renaming. They're currently broken in v1 as well.

  The previous change was needed because otherwise it'd only show "For" (since `trans` returns an array). Mithril can handle arrays just fine - the `label[0]` looks to me to be from when Mithril perhaps would join with commas (I vaguely remember that?)

- Also translated the "Custom" fallback. Wasn't sure what key to give the translation, since `SettingDropdown` is only used in `PermissionGrid` (but technically could be used anywhere in admin, I believe).


**Screenshot**
| Before | After |
|--------|--------|
| ![image](https://github.com/flarum/framework/assets/6401250/1048a874-7163-4a0c-9c19-6c8d58207d2f)| ![image](https://github.com/flarum/framework/assets/6401250/07dd7ace-cd12-44ad-b03d-7308b224a9ce)  | 

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
