### PR TITLE
fix(regression): Webpack not working on Windows with new export registry

### DIFF
--- a/js-packages/webpack-config/src/autoExportLoader.cjs
+++ b/js-packages/webpack-config/src/autoExportLoader.cjs
@@ -179,7 +179,9 @@ module.exports = function autoExportLoader(source) {
   // Get the path of the module to be exported
   // relative to the src directory.
   // Example: src/forum/components/UserCard.js => forum/components
-  const pathToModule = this.resourcePath.replace(path.resolve(this.rootContext, 'src') + '/', '').replace(/[A-Za-z_]+\.[A-Za-z_]+$/, '');
+  const pathToModule = path.relative(path.resolve(this.rootContext, 'src'), this.resourcePath)
+    .replaceAll(path.sep, '/')
+    .replace(/[A-Za-z_]+\.[A-Za-z_]+$/, '');
 
   return addAutoExports(source, pathToModule, moduleName);
 };


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

Caused by #3842.

**Changes proposed in this pull request:**
- Use `path.relative` for module path
- Replace system path separators with `/`

Initially, since `.replace()` was hardcoding `/`, the entire absolute path was being added to `flarum.reg.add()`.
Then, building still errored because it was using `\` as path separators, and the following characters weren't valid escape sequences.

```js
ERROR in ./src/common/utils/styleSelectedText.ts 354:32
Module parse failed: Bad character escape sequence (354:32)
File was processed with these loaders:
 * ../../../js-packages/webpack-config/src/autoExportLoader.cjs
 * ../../../node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
|   };
| }
> flarum.reg.add('core', 'common\utils\styleSelectedText', styleSelectedText)
```

Tried to use `path.posix`, but it can't normalize win32 paths into unix. There's a package for that ([slash](https://github.com/sindresorhus/slash)), but it basically just replaces `\` with `/` - I don't think this implementation should cause any issues.

**QA**
Build JS. Dist remains the exact same.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
