### PR TITLE
Fixed str_getcsv() on php 8.x

### DIFF
--- a/framework/core/src/Search/GambitManager.php
+++ b/framework/core/src/Search/GambitManager.php
@@ -45,7 +45,12 @@ class GambitManager
      */
     protected function explode(string $query): array
     {
-        return str_getcsv($query, ' ');
+        // Fixed Deprecated: str_getcsv(): Passing null to parameter #1 ($string) of type string is deprecated on php 8.x
+        if ($query !== null && is_string($query)) {
+            return str_getcsv($query, ' ');
+        } else {
+            return [];
+        }
     }
 
     protected function applyGambits(SearchState $search, string $query): string


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
