### PR TITLE
feat: make page structure customizable across different pages

### DIFF
--- a/extensions/subscriptions/js/src/forum/addSubscriptionFilter.js
+++ b/extensions/subscriptions/js/src/forum/addSubscriptionFilter.js
@@ -2,11 +2,12 @@ import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
 import LinkButton from 'flarum/common/components/LinkButton';
 import IndexPage from 'flarum/forum/components/IndexPage';
+import IndexSidebar from 'flarum/forum/components/IndexSidebar';
 import DiscussionListState from 'flarum/forum/states/DiscussionListState';
 import GlobalSearchState from 'flarum/forum/states/GlobalSearchState';
 
 export default function addSubscriptionFilter() {
-  extend(IndexPage.prototype, 'navItems', function (items) {
+  extend(IndexSidebar.prototype, 'navItems', function (items) {
     if (app.session.user) {
       const params = app.search.stickyParams();
 

--- a/extensions/tags/js/src/@types/shims.d.ts
+++ b/extensions/tags/js/src/@types/shims.d.ts
@@ -20,11 +20,11 @@ declare module 'flarum/common/models/Discussion' {
   }
 }
 
-declare module 'flarum/forum/components/IndexPage' {
-  export default interface IndexPage {
+declare module 'flarum/forum/ForumApplication' {
+  export default interface ForumApplication {
     currentActiveTag?: Tag;
     currentTagLoading?: boolean;
-    currentTag: () => Tag | undefined;
+    currentTag: (reload?: boolean) => Tag | undefined;
   }
 }
 

--- a/extensions/tags/js/src/forum/addTagComposer.js
+++ b/extensions/tags/js/src/forum/addTagComposer.js
@@ -1,14 +1,15 @@
+import app from 'flarum/forum/app';
 import { extend, override } from 'flarum/common/extend';
-import IndexPage from 'flarum/forum/components/IndexPage';
+import IndexSidebar from 'flarum/forum/components/IndexSidebar';
 import classList from 'flarum/common/utils/classList';
 
 import tagsLabel from '../common/helpers/tagsLabel';
 import getSelectableTags from './utils/getSelectableTags';
 
 export default function addTagComposer() {
-  extend(IndexPage.prototype, 'newDiscussionAction', function (promise) {
+  extend(IndexSidebar.prototype, 'newDiscussionAction', function (promise) {
     // From `addTagFilter
-    const tag = this.currentTag();
+    const tag = app.currentTag();
 
     if (tag) {
       const parent = tag.parent();

--- a/extensions/tags/js/src/forum/addTagList.js
+++ b/extensions/tags/js/src/forum/addTagList.js
@@ -1,17 +1,17 @@
+import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
-import IndexPage from 'flarum/forum/components/IndexPage';
+import IndexSidebar from 'flarum/forum/components/IndexSidebar';
 import Separator from 'flarum/common/components/Separator';
 import LinkButton from 'flarum/common/components/LinkButton';
 
 import TagLinkButton from './components/TagLinkButton';
 import TagsPage from './components/TagsPage';
-import app from 'flarum/forum/app';
 import sortTags from '../common/utils/sortTags';
 
 export default function addTagList() {
   // Add a link to the tags page, as well as a list of all the tags,
   // to the index page's sidebar.
-  extend(IndexPage.prototype, 'navItems', function (items) {
+  extend(IndexSidebar.prototype, 'navItems', function (items) {
     items.add(
       'tags',
       <LinkButton icon="fas fa-th-large" href={app.route('tags')}>
@@ -26,7 +26,7 @@ export default function addTagList() {
 
     const params = app.search.stickyParams();
     const tags = app.store.all('tags');
-    const currentTag = this.currentTag();
+    const currentTag = app.currentTag();
 
     const addTag = (tag) => {
       let active = currentTag === tag;

--- a/extensions/tags/js/src/forum/components/TagsPage.js
+++ b/extensions/tags/js/src/forum/components/TagsPage.js
@@ -1,12 +1,15 @@
+import app from 'flarum/forum/app';
 import Page from 'flarum/common/components/Page';
-import IndexPage from 'flarum/forum/components/IndexPage';
+import PageStructure from 'flarum/forum/components/PageStructure';
+import WelcomeHero from 'flarum/forum/components/WelcomeHero';
+import IndexSidebar from 'flarum/forum/components/IndexSidebar';
 import Link from 'flarum/common/components/Link';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
-import listItems from 'flarum/common/helpers/listItems';
 import ItemList from 'flarum/common/utils/ItemList';
 import humanTime from 'flarum/common/helpers/humanTime';
 import textContrastClass from 'flarum/common/helpers/textContrastClass';
 import classList from 'flarum/common/utils/classList';
+import extractText from 'flarum/common/utils/extractText';
 
 import tagIcon from '../../common/helpers/tagIcon';
 import tagLabel from '../../common/helpers/tagLabel';
@@ -16,7 +19,7 @@ export default class TagsPage extends Page {
   oninit(vnode) {
     super.oninit(vnode);
 
-    app.history.push('tags', app.translator.trans('flarum-tags.forum.header.back_to_tags_tooltip'));
+    app.history.push('tags', extractText(app.translator.trans('flarum-tags.forum.header.back_to_tags_tooltip')));
 
     this.tags = [];
 
@@ -46,29 +49,11 @@ export default class TagsPage extends Page {
   }
 
   view() {
-    return <div className="TagsPage">{this.pageContent().toArray()}</div>;
-  }
-
-  pageContent() {
-    const items = new ItemList();
-
-    items.add('hero', this.hero(), 100);
-    items.add('main', <div className="container">{this.mainContent().toArray()}</div>, 10);
-
-    return items;
-  }
-
-  mainContent() {
-    const items = new ItemList();
-
-    items.add('sidebar', this.sidebar(), 100);
-    items.add('content', this.content(), 10);
-
-    return items;
-  }
-
-  content() {
-    return <div className="TagsPage-content sideNavOffset">{this.contentItems().toArray()}</div>;
+    return (
+      <PageStructure className="TagsPage" hero={this.hero.bind(this)} sidebar={this.sidebar.bind(this)}>
+        {this.contentItems().toArray()}
+      </PageStructure>
+    );
   }
 
   contentItems() {
@@ -91,19 +76,11 @@ export default class TagsPage extends Page {
   }
 
   hero() {
-    return IndexPage.prototype.hero();
+    return <WelcomeHero />;
   }
 
   sidebar() {
-    return (
-      <nav className="TagsPage-nav IndexPage-nav sideNav">
-        <ul>{listItems(this.sidebarItems().toArray())}</ul>
-      </nav>
-    );
-  }
-
-  sidebarItems() {
-    return IndexPage.prototype.sidebarItems();
+    return <IndexSidebar />;
   }
 
   tagTileListView(pinned) {

--- a/extensions/tags/less/forum.less
+++ b/extensions/tags/less/forum.less
@@ -72,11 +72,13 @@
 }
 @media @desktop-up {
   .TagsPage {
+    --sidebar-width: 100%;
+    --gap: 30px;
+
     .sideNav {
       .sideNav--horizontal();
-      float: none;
       width: auto;
-      padding-top: 0;
+      padding: 0;
 
       &:after {
         display: none;
@@ -86,8 +88,13 @@
         width: 190px;
       }
     }
-    .sideNavOffset {
-      margin: 15px 0 0;
+
+    .Page-container {
+      flex-direction: column;
+    }
+
+    .Page-content {
+      margin-top: 0;
     }
   }
 }

--- a/framework/core/js/src/forum/components/DiscussionPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionPage.tsx
@@ -13,6 +13,7 @@ import PostStreamState from '../states/PostStreamState';
 import Discussion from '../../common/models/Discussion';
 import Post from '../../common/models/Post';
 import { ApiResponseSingle } from '../../common/Store';
+import PageStructure from './PageStructure';
 
 export interface IDiscussionPageAttrs extends IPageAttrs {
   id: string;
@@ -84,22 +85,20 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
 
   view() {
     return (
-      <div className="DiscussionPage">
-        <DiscussionListPane state={app.discussions} />
-        <div className="DiscussionPage-discussion">{!this.loading ? this.pageContent().toArray() : this.loadingItems().toArray()}</div>
-      </div>
+      <PageStructure
+        className="DiscussionPage"
+        loading={this.loading}
+        hero={this.hero.bind(this)}
+        sidebar={this.sidebar.bind(this)}
+        pane={() => <DiscussionListPane state={app.discussions} />}
+      >
+        {this.loading || (
+          <div className="DiscussionPage-stream">
+            <this.PostStream discussion={this.discussion} stream={this.stream} onPositionChange={this.positionChanged.bind(this)} />
+          </div>
+        )}
+      </PageStructure>
     );
-  }
-
-  /**
-   * List of components shown while the discussion is loading.
-   */
-  loadingItems(): ItemList<Mithril.Children> {
-    const items = new ItemList<Mithril.Children>();
-
-    items.add('spinner', <LoadingIndicator />, 100);
-
-    return items;
   }
 
   /**
@@ -118,37 +117,6 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
    */
   hero(): Mithril.Children {
     return <DiscussionHero discussion={this.discussion} />;
-  }
-
-  /**
-   * List of items rendered as the main page content.
-   */
-  pageContent(): ItemList<Mithril.Children> {
-    const items = new ItemList<Mithril.Children>();
-
-    items.add('hero', this.hero(), 100);
-    items.add('main', <div className="container">{this.mainContent().toArray()}</div>, 10);
-
-    return items;
-  }
-
-  /**
-   * List of items rendered inside the main page content container.
-   */
-  mainContent(): ItemList<Mithril.Children> {
-    const items = new ItemList<Mithril.Children>();
-
-    items.add('sidebar', this.sidebar(), 100);
-
-    items.add(
-      'poststream',
-      <div className="DiscussionPage-stream">
-        <this.PostStream discussion={this.discussion} stream={this.stream} onPositionChange={this.positionChanged.bind(this)} />
-      </div>,
-      10
-    );
-
-    return items;
   }
 
   /**

--- a/framework/core/js/src/forum/components/IndexPage.tsx
+++ b/framework/core/js/src/forum/components/IndexPage.tsx
@@ -12,6 +12,7 @@ import SelectDropdown from '../../common/components/SelectDropdown';
 import extractText from '../../common/utils/extractText';
 import type Mithril from 'mithril';
 import type Discussion from '../../common/models/Discussion';
+import PageStructure from './PageStructure';
 
 export interface IIndexPageAttrs extends IPageAttrs {}
 
@@ -51,23 +52,13 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
 
   view() {
     return (
-      <div className="IndexPage">
-        {this.hero()}
-        <div className="container">
-          <div className="sideNavContainer">
-            <nav className="IndexPage-nav sideNav">
-              <ul>{listItems(this.sidebarItems().toArray())}</ul>
-            </nav>
-            <div className="IndexPage-results sideNavOffset">
-              <div className="IndexPage-toolbar">
-                <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
-                <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>
-              </div>
-              <DiscussionList state={app.discussions} />
-            </div>
-          </div>
+      <PageStructure className="IndexPage" hero={this.hero()} sidebar={this.sidebar()}>
+        <div className="IndexPage-toolbar">
+          <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
+          <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>
         </div>
-      </div>
+        <DiscussionList state={app.discussions} />
+      </PageStructure>
     );
   }
 
@@ -180,6 +171,14 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
     );
 
     return items;
+  }
+
+  sidebar() {
+    return (
+      <nav className="IndexPage-nav sideNav">
+        <ul>{listItems(this.sidebarItems().toArray())}</ul>
+      </nav>
+    );
   }
 
   /**

--- a/framework/core/js/src/forum/components/IndexPage.tsx
+++ b/framework/core/js/src/forum/components/IndexPage.tsx
@@ -13,6 +13,7 @@ import extractText from '../../common/utils/extractText';
 import type Mithril from 'mithril';
 import type Discussion from '../../common/models/Discussion';
 import PageStructure from './PageStructure';
+import IndexSidebar from './IndexSidebar';
 
 export interface IIndexPageAttrs extends IPageAttrs {}
 
@@ -133,71 +134,8 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
     return <WelcomeHero />;
   }
 
-  /**
-   * Build an item list for the sidebar of the index page. By default this is a
-   * "New Discussion" button, and then a DropdownSelect component containing a
-   * list of navigation items.
-   */
-  sidebarItems() {
-    const items = new ItemList<Mithril.Children>();
-    const canStartDiscussion = app.forum.attribute('canStartDiscussion') || !app.session.user;
-
-    items.add(
-      'newDiscussion',
-      <Button
-        icon="fas fa-edit"
-        className="Button Button--primary IndexPage-newDiscussion"
-        itemClassName="App-primaryControl"
-        onclick={() => {
-          // If the user is not logged in, the promise rejects, and a login modal shows up.
-          // Since that's already handled, we dont need to show an error message in the console.
-          return this.newDiscussionAction().catch(() => {});
-        }}
-        disabled={!canStartDiscussion}
-      >
-        {app.translator.trans(`core.forum.index.${canStartDiscussion ? 'start_discussion_button' : 'cannot_start_discussion_button'}`)}
-      </Button>
-    );
-
-    items.add(
-      'nav',
-      <SelectDropdown
-        buttonClassName="Button"
-        className="App-titleControl"
-        accessibleToggleLabel={app.translator.trans('core.forum.index.toggle_sidenav_dropdown_accessible_label')}
-      >
-        {this.navItems().toArray()}
-      </SelectDropdown>
-    );
-
-    return items;
-  }
-
   sidebar() {
-    return (
-      <nav className="IndexPage-nav sideNav">
-        <ul>{listItems(this.sidebarItems().toArray())}</ul>
-      </nav>
-    );
-  }
-
-  /**
-   * Build an item list for the navigation in the sidebar of the index page. By
-   * default this is just the 'All Discussions' link.
-   */
-  navItems() {
-    const items = new ItemList<Mithril.Children>();
-    const params = app.search.stickyParams();
-
-    items.add(
-      'allDiscussions',
-      <LinkButton href={app.route('index', params)} icon="far fa-comments">
-        {app.translator.trans('core.forum.index.all_discussions_link')}
-      </LinkButton>,
-      100
-    );
-
-    return items;
+    return <IndexSidebar />;
   }
 
   /**
@@ -273,23 +211,6 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
     }
 
     return items;
-  }
-
-  /**
-   * Open the composer for a new discussion or prompt the user to login.
-   */
-  newDiscussionAction(): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      if (app.session.user) {
-        app.composer.load(() => import('./DiscussionComposer'), { user: app.session.user }).then(() => app.composer.show());
-
-        return resolve(app.composer);
-      } else {
-        app.modal.show(() => import('./LogInModal'));
-
-        return reject();
-      }
-    });
   }
 
   /**

--- a/framework/core/js/src/forum/components/IndexPage.tsx
+++ b/framework/core/js/src/forum/components/IndexPage.tsx
@@ -7,8 +7,6 @@ import WelcomeHero from './WelcomeHero';
 import DiscussionPage from './DiscussionPage';
 import Dropdown from '../../common/components/Dropdown';
 import Button from '../../common/components/Button';
-import LinkButton from '../../common/components/LinkButton';
-import SelectDropdown from '../../common/components/SelectDropdown';
 import extractText from '../../common/utils/extractText';
 import type Mithril from 'mithril';
 import type Discussion from '../../common/models/Discussion';

--- a/framework/core/js/src/forum/components/IndexPage.tsx
+++ b/framework/core/js/src/forum/components/IndexPage.tsx
@@ -52,7 +52,7 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
 
   view() {
     return (
-      <PageStructure className="IndexPage" hero={this.hero()} sidebar={this.sidebar()}>
+      <PageStructure className="IndexPage" hero={this.hero.bind(this)} sidebar={this.sidebar.bind(this)}>
         <div className="IndexPage-toolbar">
           <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
           <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>

--- a/framework/core/js/src/forum/components/IndexSidebar.tsx
+++ b/framework/core/js/src/forum/components/IndexSidebar.tsx
@@ -1,0 +1,97 @@
+import Component from '../../common/Component';
+import type { ComponentAttrs } from '../../common/Component';
+import type Mithril from 'mithril';
+import ItemList from '../../common/utils/ItemList';
+import app from '../app';
+import Button from '../../common/components/Button';
+import SelectDropdown from '../../common/components/SelectDropdown';
+import listItems from '../../common/helpers/listItems';
+import LinkButton from '../../common/components/LinkButton';
+
+export interface IndexSidebarAttrs extends ComponentAttrs {}
+
+export default class IndexSidebar<CustomAttrs extends IndexSidebarAttrs = IndexSidebarAttrs> extends Component<CustomAttrs> {
+  view(vnode: Mithril.Vnode<CustomAttrs, this>): Mithril.Children {
+    return (
+      <nav className="IndexPage-nav sideNav">
+        <ul>{listItems(this.items().toArray())}</ul>
+      </nav>
+    );
+  }
+
+  /**
+   * Build an item list for the sidebar of the index page. By default this is a
+   * "New Discussion" button, and then a DropdownSelect component containing a
+   * list of navigation items.
+   */
+  items() {
+    const items = new ItemList<Mithril.Children>();
+    const canStartDiscussion = app.forum.attribute('canStartDiscussion') || !app.session.user;
+
+    items.add(
+      'newDiscussion',
+      <Button
+        icon="fas fa-edit"
+        className="Button Button--primary IndexPage-newDiscussion"
+        itemClassName="App-primaryControl"
+        onclick={() => {
+          // If the user is not logged in, the promise rejects, and a login modal shows up.
+          // Since that's already handled, we dont need to show an error message in the console.
+          return this.newDiscussionAction().catch(() => {});
+        }}
+        disabled={!canStartDiscussion}
+      >
+        {app.translator.trans(`core.forum.index.${canStartDiscussion ? 'start_discussion_button' : 'cannot_start_discussion_button'}`)}
+      </Button>
+    );
+
+    items.add(
+      'nav',
+      <SelectDropdown
+        buttonClassName="Button"
+        className="App-titleControl"
+        accessibleToggleLabel={app.translator.trans('core.forum.index.toggle_sidenav_dropdown_accessible_label')}
+      >
+        {this.navItems().toArray()}
+      </SelectDropdown>
+    );
+
+    return items;
+  }
+
+  /**
+   * Build an item list for the navigation in the sidebar of the index page. By
+   * default this is just the 'All Discussions' link.
+   */
+  navItems() {
+    const items = new ItemList<Mithril.Children>();
+    const params = app.search.stickyParams();
+
+    items.add(
+      'allDiscussions',
+      <LinkButton href={app.route('index', params)} icon="far fa-comments">
+        {app.translator.trans('core.forum.index.all_discussions_link')}
+      </LinkButton>,
+      100
+    );
+
+    return items;
+  }
+
+  /**
+   * Open the composer for a new discussion or prompt the user to login.
+   */
+  newDiscussionAction(): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (app.session.user) {
+        app.composer.load(() => import('./DiscussionComposer'), { user: app.session.user }).then(() => app.composer.show());
+
+        return resolve(app.composer);
+      } else {
+        app.modal.show(() => import('./LogInModal'));
+
+        return reject();
+      }
+    });
+  }
+}

--- a/framework/core/js/src/forum/components/PageStructure.tsx
+++ b/framework/core/js/src/forum/components/PageStructure.tsx
@@ -45,7 +45,7 @@ export default class PageStructure<CustomAttrs extends PageStructureAttrs = Page
   loadingItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
-    items.add('spinner', <LoadingIndicator />, 100);
+    items.add('spinner', <LoadingIndicator display="block" />, 100);
 
     return items;
   }

--- a/framework/core/js/src/forum/components/PageStructure.tsx
+++ b/framework/core/js/src/forum/components/PageStructure.tsx
@@ -1,0 +1,81 @@
+import Component from '../../common/Component';
+import type { ComponentAttrs } from '../../common/Component';
+import type Mithril from 'mithril';
+import classList from '../../common/utils/classList';
+import ItemList from '../../common/utils/ItemList';
+
+export interface PageStructureAttrs extends ComponentAttrs {
+  hero?: Mithril.Children;
+  sidebar?: Mithril.Children;
+  rootItems?: (items: ItemList<Mithril.Children>) => void;
+}
+
+export default class PageStructure<CustomAttrs extends PageStructureAttrs = PageStructureAttrs> extends Component<CustomAttrs> {
+  private content?: Mithril.Children;
+
+  view(vnode: Mithril.Vnode<CustomAttrs, this>): Mithril.Children {
+    const { className } = vnode.attrs;
+
+    this.content = vnode.children;
+
+    return <div className={classList('Page', className)}>{this.rootItems().toArray()}</div>;
+  }
+
+  rootItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('main', this.main(), 100);
+
+    if (this.attrs.rootItems) {
+      this.attrs.rootItems(items);
+    }
+
+    return items;
+  }
+
+  mainItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('hero', this.providedHero(), 100);
+    items.add('container', this.container(), 10);
+
+    return items;
+  }
+
+  main(): Mithril.Children {
+    return <div className="Page-main">{this.mainItems().toArray()}</div>;
+  }
+
+  containerItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('sidebar', this.sidebar(), 100);
+    items.add('content', this.providedContent(), 10);
+
+    return items;
+  }
+
+  container(): Mithril.Children {
+    return <div className="Page-container container">{this.containerItems().toArray()}</div>;
+  }
+
+  sidebarItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('sidebar', this.attrs.sidebar, 100);
+
+    return items;
+  }
+
+  sidebar(): Mithril.Children {
+    return <div className="Page-sidebar">{this.sidebarItems().toArray()}</div>;
+  }
+
+  providedHero(): Mithril.Children {
+    return <div className="Page-hero">{this.attrs.hero}</div>;
+  }
+
+  providedContent(): Mithril.Children {
+    return <div className="Page-content">{this.content}</div>;
+  }
+}

--- a/framework/core/js/src/forum/components/PageStructure.tsx
+++ b/framework/core/js/src/forum/components/PageStructure.tsx
@@ -3,11 +3,14 @@ import type { ComponentAttrs } from '../../common/Component';
 import type Mithril from 'mithril';
 import classList from '../../common/utils/classList';
 import ItemList from '../../common/utils/ItemList';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 export interface PageStructureAttrs extends ComponentAttrs {
-  hero?: Mithril.Children;
-  sidebar?: Mithril.Children;
-  rootItems?: (items: ItemList<Mithril.Children>) => void;
+  hero?: () => Mithril.Children;
+  sidebar?: () => Mithril.Children;
+  pane?: () => Mithril.Children;
+  loading?: boolean;
+  className: string;
 }
 
 export default class PageStructure<CustomAttrs extends PageStructureAttrs = PageStructureAttrs> extends Component<CustomAttrs> {
@@ -24,11 +27,8 @@ export default class PageStructure<CustomAttrs extends PageStructureAttrs = Page
   rootItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
-    items.add('main', this.main(), 100);
-
-    if (this.attrs.rootItems) {
-      this.attrs.rootItems(items);
-    }
+    items.add('pane', this.providedPane(), 100);
+    items.add('main', this.main(), 10);
 
     return items;
   }
@@ -42,8 +42,16 @@ export default class PageStructure<CustomAttrs extends PageStructureAttrs = Page
     return items;
   }
 
+  loadingItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('spinner', <LoadingIndicator />, 100);
+
+    return items;
+  }
+
   main(): Mithril.Children {
-    return <div className="Page-main">{this.mainItems().toArray()}</div>;
+    return <div className="Page-main">{this.attrs.loading ? this.loadingItems().toArray() : this.mainItems().toArray()}</div>;
   }
 
   containerItems(): ItemList<Mithril.Children> {
@@ -62,7 +70,7 @@ export default class PageStructure<CustomAttrs extends PageStructureAttrs = Page
   sidebarItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
-    items.add('sidebar', this.attrs.sidebar, 100);
+    items.add('sidebar', (this.attrs.sidebar && this.attrs.sidebar()) || null, 100);
 
     return items;
   }
@@ -71,8 +79,12 @@ export default class PageStructure<CustomAttrs extends PageStructureAttrs = Page
     return <div className="Page-sidebar">{this.sidebarItems().toArray()}</div>;
   }
 
+  providedPane(): Mithril.Children {
+    return <div className="Page-pane">{(this.attrs.pane && this.attrs.pane()) || null}</div>;
+  }
+
   providedHero(): Mithril.Children {
-    return <div className="Page-hero">{this.attrs.hero}</div>;
+    return <div className="Page-hero">{(this.attrs.hero && this.attrs.hero()) || null}</div>;
   }
 
   providedContent(): Mithril.Children {

--- a/framework/core/js/src/forum/components/UserPage.tsx
+++ b/framework/core/js/src/forum/components/UserPage.tsx
@@ -2,7 +2,6 @@ import app from '../../forum/app';
 import Page, { IPageAttrs } from '../../common/components/Page';
 import ItemList from '../../common/utils/ItemList';
 import UserCard from './UserCard';
-import LoadingIndicator from '../../common/components/LoadingIndicator';
 import SelectDropdown from '../../common/components/SelectDropdown';
 import LinkButton from '../../common/components/LinkButton';
 import Separator from '../../common/components/Separator';

--- a/framework/core/js/src/forum/components/UserPage.tsx
+++ b/framework/core/js/src/forum/components/UserPage.tsx
@@ -10,6 +10,7 @@ import listItems from '../../common/helpers/listItems';
 import AffixedSidebar from './AffixedSidebar';
 import type User from '../../common/models/User';
 import type Mithril from 'mithril';
+import PageStructure from './PageStructure';
 
 export interface IUserPageAttrs extends IPageAttrs {}
 
@@ -37,28 +38,30 @@ export default class UserPage<CustomAttrs extends IUserPageAttrs = IUserPageAttr
    */
   view() {
     return (
-      <div className="UserPage">
-        {this.user
-          ? [
-              <UserCard
-                user={this.user}
-                className="Hero UserHero"
-                editable={this.user.canEdit() || this.user === app.session.user}
-                controlsButtonClassName="Button"
-              />,
-              <div className="container">
-                <div className="sideNavContainer">
-                  <AffixedSidebar>
-                    <nav className="sideNav UserPage-nav">
-                      <ul>{listItems(this.sidebarItems().toArray())}</ul>
-                    </nav>
-                  </AffixedSidebar>
-                  <div className="sideNavOffset UserPage-content">{this.content()}</div>
-                </div>
-              </div>,
-            ]
-          : [<LoadingIndicator display="block" />]}
-      </div>
+      <PageStructure className="UserPage" hero={this.hero.bind(this)} sidebar={this.sidebar.bind(this)} loading={!this.user}>
+        {this.user && this.content()}
+      </PageStructure>
+    );
+  }
+
+  hero() {
+    return (
+      <UserCard
+        user={this.user}
+        className="Hero UserHero"
+        editable={this.user!.canEdit() || this.user === app.session.user}
+        controlsButtonClassName="Button"
+      />
+    );
+  }
+
+  sidebar() {
+    return (
+      <AffixedSidebar>
+        <nav className="sideNav UserPage-nav">
+          <ul>{listItems(this.sidebarItems().toArray())}</ul>
+        </nav>
+      </AffixedSidebar>
     );
   }
 

--- a/framework/core/less/common/sideNav.less
+++ b/framework/core/less/common/sideNav.less
@@ -58,14 +58,11 @@
   }
   .sideNav {
     flex-shrink: 0;
-    margin-right: 50px;
 
     &, > ul {
       width: 190px;
     }
     > ul {
-      margin-top: 30px;
-
       &.affix {
         top: var(--header-height);
       }

--- a/framework/core/less/forum.less
+++ b/framework/core/less/forum.less
@@ -1,5 +1,6 @@
 @import "common/common";
 
+@import "forum/PageStructure";
 @import "forum/ActivityPage";
 @import "forum/AvatarEditor";
 @import "forum/Composer";
@@ -14,7 +15,6 @@
 @import "forum/NotificationGrid";
 @import "forum/NotificationList";
 @import "forum/NotificationsDropdown";
-@import "forum/PageStructure";
 @import "forum/Post";
 @import "forum/PostStream";
 @import "forum/Scrubber";

--- a/framework/core/less/forum.less
+++ b/framework/core/less/forum.less
@@ -14,6 +14,7 @@
 @import "forum/NotificationGrid";
 @import "forum/NotificationList";
 @import "forum/NotificationsDropdown";
+@import "forum/PageStructure";
 @import "forum/Post";
 @import "forum/PostStream";
 @import "forum/Scrubber";

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -35,6 +35,10 @@
       &-content {
         margin-top: 10px;
       }
+
+      &-sidebar {
+        margin-top: 0;
+      }
     }
   }
 

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -23,15 +23,17 @@
   }
 }
 @media @tablet-up {
-  .DiscussionPage-discussion {
-    > .container {
-      display: grid;
-      grid-gap: 75px;
-      grid-template-columns: 1fr 150px;
-      grid-template-areas: 'stream nav';
+  .DiscussionPage {
+    --sidebar-width: 150px;
+    --gap: 75px;
 
-      &::before, &::after {
-        content: none;
+    .Page {
+      &-container {
+        flex-direction: row-reverse;
+      }
+
+      &-content {
+        margin-top: 10px;
       }
     }
   }
@@ -39,7 +41,6 @@
   .DiscussionPage-nav {
     align-self: start;
     position: sticky;
-    grid-area: nav;
     top: var(--header-height);
     padding-top: 32px;
     z-index: 1;
@@ -60,12 +61,6 @@
         width: 22%;
       }
     }
-  }
-
-  .DiscussionPage-stream {
-    grid-area: stream;
-    max-width: 100%;
-    min-width: 0;
   }
 }
 

--- a/framework/core/less/forum/PageStructure.less
+++ b/framework/core/less/forum/PageStructure.less
@@ -1,17 +1,26 @@
 .Page {
+  --content-width: 100%;
+  --sidebar-width: 190px;
+  --gap: 50px;
+
   @media @desktop-up {
     &-container {
       display: flex;
+      gap: var(--gap);
 
       &::before, &::after {
-        display: none;
+        content: none;
       }
     }
 
     &-content {
       margin-top: 30px;
-      flex: 1;
-      min-width: 0;
+      width: var(--content-width);
+    }
+
+    &-sidebar {
+      width: var(--sidebar-width);
+      flex-shrink: 0;
     }
   }
 

--- a/framework/core/less/forum/PageStructure.less
+++ b/framework/core/less/forum/PageStructure.less
@@ -14,13 +14,16 @@
     }
 
     &-content {
-      margin-top: 30px;
       width: var(--content-width);
     }
 
     &-sidebar {
       width: var(--sidebar-width);
       flex-shrink: 0;
+    }
+
+    &-content, &-sidebar {
+      margin-top: 30px;
     }
   }
 

--- a/framework/core/less/forum/PageStructure.less
+++ b/framework/core/less/forum/PageStructure.less
@@ -1,0 +1,23 @@
+.Page {
+  @media @desktop-up {
+    &-container {
+      display: flex;
+
+      &::before, &::after {
+        display: none;
+      }
+    }
+
+    &-content {
+      margin-top: 30px;
+      flex: 1;
+      min-width: 0;
+    }
+  }
+
+  @media @phone, @tablet {
+    &-content {
+      margin-top: 15px;
+    }
+  }
+}

--- a/framework/core/less/forum/PostStream.less
+++ b/framework/core/less/forum/PostStream.less
@@ -1,11 +1,6 @@
 // ------------------------------------
 // Stream
 
-.PostStream {
-  @media @tablet-up {
-    margin-top: 10px;
-  }
-}
 .PostStream-item {
   &:not(:last-child) {
     border-bottom: 1px solid var(--control-bg);


### PR DESCRIPTION
**Closes #3866**

**Changes proposed in this pull request:**
* Introduces a new forum `PageStructure` component that can be used from within a page component.
* Changes all our current forum pages to use said component.
* The new component will allow easier customization of the page structure (as long as extensions also use this component).

**Some before and afters**
| Before | After |
| ---------- | -------- |
| ![carbon (4)](https://github.com/flarum/framework/assets/20267363/f4e12325-50f6-4b13-98b1-c7b6fe98a5ab) | ![carbon (5)](https://github.com/flarum/framework/assets/20267363/d1ee045a-4e45-40dc-9cd7-b0494f8fb11e) |
| ![carbon (6)](https://github.com/flarum/framework/assets/20267363/eb134a0e-f7a0-4960-bbf2-47a9ae0f0ed8) | ![carbon (7)](https://github.com/flarum/framework/assets/20267363/2ba3b9f3-0a2a-41b5-af2b-8ad8d31184cc) |

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.


https://github.com/flarum/docs/pull/462