### PR TITLE
chore: use flexbox for `App-header`

### DIFF
--- a/framework/core/less/admin/AdminNav.less
+++ b/framework/core/less/admin/AdminNav.less
@@ -17,6 +17,10 @@
   }
 }
 
+.Header-navigation {
+  position: relative;
+}
+
 @media @phone {
   .Dropdown-menu {
     height: 70vh;

--- a/framework/core/less/admin/ExtensionPage.less
+++ b/framework/core/less/admin/ExtensionPage.less
@@ -27,6 +27,10 @@
         }
       }
     }
+
+    .container {
+      .clearfix();
+    }
   }
 
   &-header,

--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -265,6 +265,7 @@
 
   .Header-controls {
     display: flex;
+    align-items: center;
   }
   .Header-primary {
     //

--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -169,6 +169,12 @@
 // ------------------------------------
 // Header
 
+.App-header {
+  display: flex;
+}
+.Header-navigation {
+  position: absolute;
+}
 .Header-controls {
   margin: 0;
   padding: 0;
@@ -176,7 +182,6 @@
 }
 .Header-logo {
   max-height: 30px;
-  vertical-align: middle;
 }
 
 // On phones, the header is displayed inside of the drawer. We lay its
@@ -239,6 +244,12 @@
     position: absolute;
     border-bottom: 0;
 
+    .container {
+      display: flex;
+      align-items: center;
+      gap: 15px;
+    }
+
     .affix & {
       position: fixed;
     }
@@ -252,29 +263,19 @@
     }
   }
 
-  .Header-navigation {
-    float: left;
-    margin-right: 25px;
-  }
   .Header-controls {
-    &, > li {
-      display: inline-block;
-      vertical-align: middle;
-    }
+    display: flex;
   }
   .Header-primary {
-    float: left;
+    //
   }
   .Header-title {
-    float: left;
-    vertical-align: top;
     font-size: 18px;
     font-weight: normal;
-    margin: 0 15px 0 0;
     line-height: 34px;
   }
   .Header-secondary {
-    float: right;
+    margin-left: auto;
 
     .Search {
       margin-right: 10px;
@@ -291,6 +292,22 @@
     &:not(.active) input {
       padding-right: 0;
     }
+  }
+}
+
+@media @desktop-hd {
+  .Header-navigation {
+    .hasPane.panePinned & {
+      position: relative;
+      width: ~"min(20%, var(--pane-width))";
+    }
+  }
+}
+
+@media (max-width: calc(@screen-desktop-hd + 80px)) {
+  .Header-navigation {
+    position: relative;
+    width: auto;
   }
 }
 

--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -61,18 +61,16 @@
   &:before {
     .fas();
     content: @fa-var-search;
-    float: left;
     margin-right: -36px;
     width: 36px;
     font-size: 14px;
     text-align: center;
-    position: relative;
+    position: absolute;
     padding: 8px 0;
     line-height: 1.5;
     pointer-events: none;
   }
   input {
-    float: left;
     width: 225px;
     padding-left: 32px;
     padding-right: 32px;
@@ -85,7 +83,9 @@
   }
 
   .Button {
-    float: left;
+    position: absolute;
+    right: 0;
+    top: 0;
     margin-left: -36px;
     width: 36px !important;
 

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -62,7 +62,6 @@ p {
   margin-left: auto;
   padding-left: 15px;
   padding-right: 15px;
-  .clearfix();
 
   @media @tablet {
     width: @screen-tablet;

--- a/framework/core/less/forum/DiscussionListPane.less
+++ b/framework/core/less/forum/DiscussionListPane.less
@@ -75,10 +75,6 @@
   }
   .App-header .container {
     transition: width 0.2s;
-
-    .hasPane.panePinned & {
-      width: 100%;
-    }
   }
 }
 


### PR DESCRIPTION
**Part of flarum/issue-archive#355**

**Changes proposed in this pull request:**
Drops floats and negative spacing for flexbox. This makes customizing the header layout a lot easier.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.