### PR TITLE
chore: Test using MySQL 8.1 also

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -95,6 +95,11 @@ jobs:
             db: MariaDB
             prefix: flarum_
             prefixStr: (prefix)
+          - php: ${{ fromJSON(inputs.php_versions)[0] }}
+            service: 'mysql:8.1.0'
+            db: MySQL 8.1
+            prefix: flarum_
+            prefixStr: (prefix)
 
         # To reduce number of actions, we exclude some PHP versions from running with some DB versions.
         exclude:

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -43,7 +43,7 @@ on:
         description: Versions of databases to test with. Should be array of strings encoded as JSON array
         type: string
         required: false
-        default: '["mysql:5.7", "mysql:8.0.30", "mariadb"]'
+        default: '["mysql:5.7", "mysql:8.0.30", "mysql:8.1.0", "mariadb"]'
 
       php_ini_values:
         description: PHP ini values

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -76,6 +76,8 @@ jobs:
             db: MySQL 8.0
           - service: mariadb
             db: MariaDB
+          - service: 'mysql:8.1.0'
+            db: MySQL 8.1
 
           # Include Database prefix tests with only one PHP version.
           - php: ${{ fromJSON(inputs.php_versions)[0] }}


### PR DESCRIPTION
As title, adds MySQL 8.1.0 to the DBs tested.

Q: I think this should probably be run against the `1.x` branch too, what do others think?