### PR TITLE
fix: styling regressions

### DIFF
--- a/extensions/flags/less/forum.less
+++ b/extensions/flags/less/forum.less
@@ -1,6 +1,9 @@
 .Post--flagged {
+  --border-width: 2px;
   padding-top: 0 !important;
-  border: 2px solid @primary-color;
+  padding-left: var(--post-padding);
+  margin-left: calc(~"0px - var(--post-padding)");
+  border: var(--border-width) solid @primary-color;
 }
 
 .Post-header .item-flagged {
@@ -9,10 +12,10 @@
 }
 .Post-flagged {
   background: @primary-color;
-  margin-top: -2px;
-  margin-bottom: 20px;
-  margin-left: -22px;
-  margin-right: -22px;
+  margin-top: calc(~"0px - var(--border-width)");
+  margin-bottom: var(--post-padding);
+  margin-left: calc(~"0px - var(--border-width) - var(--post-padding)");
+  margin-right: calc(~"0px - var(--border-width) - var(--post-padding)");
   padding: 10px;
   border-radius: @border-radius @border-radius 0 0;
   overflow: hidden;

--- a/framework/core/js/src/forum/components/PostUser.js
+++ b/framework/core/js/src/forum/components/PostUser.js
@@ -22,7 +22,9 @@ export default class PostUser extends Component {
     if (!user) {
       return (
         <div className="PostUser">
-          <h3 className="PostUser-name">{username(user)}</h3>
+          <h3 className="PostUser-name">
+            {avatar(user, { className: 'Post-avatar' })} {username(user)}
+          </h3>
         </div>
       );
     }
@@ -31,6 +33,7 @@ export default class PostUser extends Component {
       <div className="PostUser">
         <h3 className="PostUser-name">
           <Link href={app.route.user(user)}>
+            {avatar(user, { className: 'Post-avatar' })}
             {userOnline(user)}
             {username(user)}
           </Link>

--- a/framework/core/js/src/forum/components/ReplyPlaceholder.js
+++ b/framework/core/js/src/forum/components/ReplyPlaceholder.js
@@ -19,16 +19,20 @@ export default class ReplyPlaceholder extends Component {
     if (app.composer.composingReplyTo(this.attrs.discussion)) {
       return (
         <article className="Post CommentPost editing" aria-busy="true">
-          <header className="Post-header">
-            <div className="PostUser">
-              <h3 className="PostUser-name">
-                {avatar(app.session.user, { className: 'PostUser-avatar' })}
-                {username(app.session.user)}
-              </h3>
-              <ul className="PostUser-badges badges">{listItems(app.session.user.badges().toArray())}</ul>
+          <div className="Post-container">
+            <div className="Post-side">{avatar(app.session.user, { className: 'Post-avatar' })}</div>
+            <div className="Post-main">
+              <header className="Post-header">
+                <div className="PostUser">
+                  <h3 className="PostUser-name">{username(app.session.user)}</h3>
+                  <ul className="PostUser-badges badges">{listItems(app.session.user.badges().toArray())}</ul>
+                </div>
+              </header>
+              <div className="Post-body">
+                <ComposerPostPreview className="Post-body" composer={app.composer} surround={this.anchorPreview.bind(this)} />
+              </div>
             </div>
-          </header>
-          <ComposerPostPreview className="Post-body" composer={app.composer} surround={this.anchorPreview.bind(this)} />
+          </div>
         </article>
       );
     }
@@ -39,9 +43,12 @@ export default class ReplyPlaceholder extends Component {
 
     return (
       <button className="Post ReplyPlaceholder" onclick={reply}>
-        <span className="Post-header">
-          {avatar(app.session.user, { className: 'PostUser-avatar' })} {app.translator.trans('core.forum.post_stream.reply_placeholder')}
-        </span>
+        <div className="Post-container">
+          <div className="Post-side">{avatar(app.session.user, { className: 'Post-avatar' })}</div>
+          <div className="Post-main">
+            <span className="Post-header">{app.translator.trans('core.forum.post_stream.reply_placeholder')}</span>
+          </div>
+        </div>
       </button>
     );
   }

--- a/framework/core/less/common/root.less
+++ b/framework/core/less/common/root.less
@@ -44,7 +44,7 @@
   }
 
   // ---------------------------------
-  // COMPONENTS
+  // COMPONENT COLORS
 
   --header-bg:                     @header-bg;
   --header-color:                  @header-color;
@@ -131,4 +131,10 @@
   @media @tablet { --flarum-screen: tablet; }
   @media @desktop { --flarum-screen: desktop; }
   @media @desktop-hd { --flarum-screen: desktop-hd; }
+
+  // ---------------------------------
+  // COMPONENT LAYOUTS
+
+  --avatar-column-width: 85px;
+  --post-padding: 20px;
 }

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -28,6 +28,8 @@
     --gap: 55px;
 
     .Page {
+      .Page--cols();
+
       &-container {
         flex-direction: row-reverse;
       }

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -34,7 +34,6 @@
 
       &-content {
         margin-top: 10px;
-        margin-inline-start: -20px;
       }
 
       &-sidebar {

--- a/framework/core/less/forum/PageStructure.less
+++ b/framework/core/less/forum/PageStructure.less
@@ -3,33 +3,36 @@
   --sidebar-width: 190px;
   --gap: 50px;
 
+  &-container {
+    gap: var(--gap);
+  }
+
   @media @desktop-up {
-    &-container {
-      display: flex;
-      gap: var(--gap);
-
-      &::before, &::after {
-        content: none;
-      }
-    }
-
-    &-content {
-      width: var(--content-width);
-    }
-
-    &-sidebar {
-      width: var(--sidebar-width);
-      flex-shrink: 0;
-    }
-
-    &-content, &-sidebar {
-      margin-top: 30px;
-    }
+    .Page--cols()
   }
 
   @media @phone, @tablet {
     &-content {
       margin-top: 15px;
     }
+  }
+}
+
+.Page--cols {
+  &-container {
+    display: flex;
+  }
+
+  &-content {
+    width: var(--content-width);
+  }
+
+  &-sidebar {
+    width: var(--sidebar-width);
+    flex-shrink: 0;
+  }
+
+  &-content, &-sidebar {
+    margin-top: 30px;
   }
 }

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -47,6 +47,12 @@
       opacity: 1;
     }
   }
+
+  .Avatar {
+    .Avatar--size(32px);
+    vertical-align: middle;
+    margin-right: 5px;
+  }
 }
 .PostUser {
   margin: 0;
@@ -363,11 +369,9 @@
 }
 
 @media @phone {
-  .Post-header {
-    .Avatar {
-      .Avatar--size(32px);
-      vertical-align: middle;
-      margin-right: 5px;
+  .Post-side {
+    .Post-avatar {
+      display: none;
     }
   }
   .PostUser-badges {
@@ -402,6 +406,9 @@
   .Post-avatar {
     .Avatar--size(64px);
   }
+  .Post-header .Post-avatar {
+    display: none;
+  }
   .PostUser-badges {
     float: left;
     position: relative;
@@ -421,16 +428,41 @@
   cursor: text;
   overflow: hidden;
   margin-top: 50px;
+  margin-left: calc(0px - var(--post-padding));
+  padding-left: var(--post-padding);
   border: 2px dashed var(--control-bg);
   color: var(--muted-color);
   border-radius: 10px;
   background-color: transparent;
-  width: calc(~"100% + 20px * 2");
-  display: flex;
+  display: block;
+  appearance: none;
+  -webkit-appearance: none;
+  text-align: left;
+  width: calc(100% + var(--post-padding));
+
+  .Post-container {
+    display: grid;
+    grid-template-columns: var(--avatar-column-width) 1fr;
+
+    @media @phone {
+      grid-template-columns: auto 1fr;
+      gap: 10px;
+    }
+  }
 
   .Post-header {
     margin: 0;
     color: inherit;
+  }
+
+  .Post-avatar {
+    .Avatar--size(32px);
+    display: block;
+  }
+
+  .Post-main {
+    display: flex;
+    align-items: center;
   }
 }
 @media @tablet-up {
@@ -439,14 +471,13 @@
     transition: border-color 0.2s;
 
     .Post-header {
-      padding-top: 18px;
       position: relative;
-    }
-    .Avatar {
-      margin-top: -18px;
     }
     &:hover {
       border-color: var(--control-bg);
+    }
+    .Post-avatar {
+      .Avatar--size(64px);
     }
   }
   .LoadingPost .Post-header {

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -2,7 +2,7 @@
 // Posts
 
 .Post {
-  padding: 20px;
+  padding: var(--post-padding) var(--post-padding) var(--post-padding) 0;
   transition: 0.2s box-shadow, top 0.2s, opacity 0.2s;
   position: relative;
   top: 0;
@@ -391,11 +391,8 @@
   }
 }
 
-@avatar-column-width: 85px;
-
 @media @tablet-up {
   .Post-container {
-    --avatar-column-width: 85px;
     display: grid;
     grid-template-columns: var(--avatar-column-width) 1fr;
   }

--- a/framework/core/less/forum/PostStream.less
+++ b/framework/core/less/forum/PostStream.less
@@ -6,10 +6,10 @@
     &::after {
       content: "";
       display: block;
-      width: calc(~"100% - 40px");
+      width: calc(~"100% - var(--post-padding)");
       height: 1px;
       background-color: var(--control-bg);
-      margin: 0 auto;
+      margin-right: auto;
     }
 
     @media @phone {
@@ -50,7 +50,7 @@
   text-transform: uppercase;
   font-weight: bold;
   color: var(--muted-color);
-  padding: 20px 20px 20px @avatar-column-width;
+  padding: 20px 20px 20px calc(~"var(--avatar-column-width) + 20px");
   font-size: 12px;
 
   @media @phone {


### PR DESCRIPTION
**Fixes regressions in styling from the previous PRs**

**Changes proposed in this pull request:**
* Post avatar is rendered twice, one to display on mobile and one on tablet-up. This removes the need for hacky code to display the avatar where wanted.
* Fixes the spacing of the post element, so that styling introduced by flags works as expected.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.