### PR TITLE
feat: reusable `UploadImageButton` component

### DIFF
--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -12,6 +12,8 @@ import AdminHeader from './AdminHeader';
 import generateElementId from '../utils/generateElementId';
 import ColorPreviewInput from '../../common/components/ColorPreviewInput';
 import ItemList from '../../common/utils/ItemList';
+import type { IUploadImageButtonAttrs } from './UploadImageButton';
+import UploadImageButton from './UploadImageButton';
 
 export interface AdminHeaderOptions {
   title: Mithril.Children;
@@ -79,6 +81,7 @@ const BooleanSettingTypes = ['bool', 'checkbox', 'switch', 'boolean'] as const;
 const SelectSettingTypes = ['select', 'dropdown', 'selectdropdown'] as const;
 const TextareaSettingTypes = ['textarea'] as const;
 const ColorPreviewSettingType = 'color-preview' as const;
+const ImageUploadSettingType = 'image-upload' as const;
 
 /**
  * Valid options for the setting component builder to generate a Switch.
@@ -113,6 +116,10 @@ export interface ColorPreviewSettingComponentOptions extends CommonSettingsItemO
   type: typeof ColorPreviewSettingType;
 }
 
+export interface ImageUploadSettingComponentOptions extends CommonSettingsItemOptions, IUploadImageButtonAttrs {
+  type: typeof ImageUploadSettingType;
+}
+
 export interface CustomSettingComponentOptions extends CommonSettingsItemOptions {
   type: string;
   [key: string]: unknown;
@@ -127,6 +134,7 @@ export type SettingsComponentOptions =
   | SelectSettingComponentOptions
   | TextareaSettingComponentOptions
   | ColorPreviewSettingComponentOptions
+  | ImageUploadSettingComponentOptions
   | CustomSettingComponentOptions;
 
 /**
@@ -311,6 +319,10 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
           {...otherAttrs}
         />
       );
+    } else if (type === ImageUploadSettingType) {
+      const { value, ...otherAttrs } = componentAttrs;
+
+      settingElement = <UploadImageButton value={this.settings[setting]} {...otherAttrs} />;
     } else if (customSettingComponents.has(type)) {
       return customSettingComponents.get(type)({ setting, help, label, ...componentAttrs });
     } else {

--- a/framework/core/js/src/admin/components/AppearancePage.tsx
+++ b/framework/core/js/src/admin/components/AppearancePage.tsx
@@ -37,13 +37,13 @@ export default class AppearancePage extends AdminPage {
           <div className="Form-group">
             <label>{app.translator.trans('core.admin.appearance.logo_heading')}</label>
             <div className="helpText">{app.translator.trans('core.admin.appearance.logo_text')}</div>
-            <UploadImageButton name="logo" />
+            <UploadImageButton name="logo" routePath="logo" value={app.data.settings.logo_path} url={app.forum.attribute('logoUrl')} />
           </div>
 
           <div className="Form-group">
             <label>{app.translator.trans('core.admin.appearance.favicon_heading')}</label>
             <div className="helpText">{app.translator.trans('core.admin.appearance.favicon_text')}</div>
-            <UploadImageButton name="favicon" />
+            <UploadImageButton name="favicon" routePath="favicon" value={app.data.settings.favicon_path} url={app.forum.attribute('faviconUrl')} />
           </div>
 
           <div className="Form-group">

--- a/framework/core/js/src/admin/components/UploadImageButton.tsx
+++ b/framework/core/js/src/admin/components/UploadImageButton.tsx
@@ -1,35 +1,45 @@
 import app from '../../admin/app';
 import Button from '../../common/components/Button';
+import type { IButtonAttrs } from '../../common/components/Button';
 import classList from '../../common/utils/classList';
+import type Mithril from 'mithril';
+import Component from '../../common/Component';
 
-export default class UploadImageButton extends Button {
+export interface IUploadImageButtonAttrs extends IButtonAttrs {
+  name: string;
+}
+
+export default class UploadImageButton<CustomAttrs extends IUploadImageButtonAttrs = IUploadImageButtonAttrs> extends Component<CustomAttrs> {
   loading = false;
 
-  view(vnode) {
-    this.attrs.loading = this.loading;
-    this.attrs.className = classList(this.attrs.className, 'Button');
+  view(vnode: Mithril.Vnode<CustomAttrs, this>) {
+    const { name, ...attrs } = vnode.attrs as IButtonAttrs;
 
-    if (app.data.settings[this.attrs.name + '_path']) {
-      this.attrs.onclick = this.remove.bind(this);
+    attrs.loading = this.loading;
+    attrs.className = classList(attrs.className, 'Button');
 
+    if (app.data.settings[name + '_path']) {
       return (
         <div>
           <p>
-            <img src={app.forum.attribute(this.attrs.name + 'Url')} alt="" />
+            <img src={app.forum.attribute(name + 'Url')} alt="" />
           </p>
-          <p>{super.view({ ...vnode, children: app.translator.trans('core.admin.upload_image.remove_button') })}</p>
+          <p>
+            <Button onclick={this.remove.bind(this)} {...attrs}>
+              {app.translator.trans('core.admin.upload_image.remove_button')}
+            </Button>
+          </p>
         </div>
       );
-    } else {
-      this.attrs.onclick = this.upload.bind(this);
     }
 
-    return super.view({ ...vnode, children: app.translator.trans('core.admin.upload_image.upload_button') });
+    return (
+      <Button onclick={this.upload.bind(this)} {...attrs}>
+        {app.translator.trans('core.admin.upload_image.upload_button')}
+      </Button>
+    );
   }
 
-  /**
-   * Prompt the user to upload an image.
-   */
   upload() {
     if (this.loading) return;
 
@@ -41,6 +51,7 @@ export default class UploadImageButton extends Button {
       .trigger('click')
       .on('change', (e) => {
         const body = new FormData();
+        // @ts-ignore
         body.append(this.attrs.name, $(e.target)[0].files[0]);
 
         this.loading = true;
@@ -57,9 +68,6 @@ export default class UploadImageButton extends Button {
       });
   }
 
-  /**
-   * Remove the logo.
-   */
   remove() {
     this.loading = true;
     m.redraw();
@@ -78,21 +86,15 @@ export default class UploadImageButton extends Button {
 
   /**
    * After a successful upload/removal, reload the page.
-   *
-   * @param {object} response
-   * @protected
    */
-  success(response) {
+  protected success(response: any) {
     window.location.reload();
   }
 
   /**
    * If upload/removal fails, stop loading.
-   *
-   * @param {object} response
-   * @protected
    */
-  failure(response) {
+  protected failure(response: any) {
     this.loading = false;
     m.redraw();
   }

--- a/framework/core/js/src/admin/components/UploadImageButton.tsx
+++ b/framework/core/js/src/admin/components/UploadImageButton.tsx
@@ -8,18 +8,26 @@ import Component from '../../common/Component';
 export interface IUploadImageButtonAttrs extends IButtonAttrs {
   name: string;
   routePath: string;
-  value?: string | null;
-  url?: string | null;
+  value?: string | null | (() => string | null);
+  url?: string | null | (() => string | null);
 }
 
 export default class UploadImageButton<CustomAttrs extends IUploadImageButtonAttrs = IUploadImageButtonAttrs> extends Component<CustomAttrs> {
   loading = false;
 
   view(vnode: Mithril.Vnode<CustomAttrs, this>) {
-    const { name, value, url, ...attrs } = vnode.attrs as IButtonAttrs;
+    let { name, value, url, ...attrs } = vnode.attrs as IButtonAttrs;
 
     attrs.loading = this.loading;
     attrs.className = classList(attrs.className, 'Button');
+
+    if (typeof value === 'function') {
+      value = value();
+    }
+
+    if (typeof url === 'function') {
+      url = url();
+    }
 
     return (
       <div className="UploadImageButton">

--- a/framework/core/js/src/admin/components/UploadImageButton.tsx
+++ b/framework/core/js/src/admin/components/UploadImageButton.tsx
@@ -7,36 +7,37 @@ import Component from '../../common/Component';
 
 export interface IUploadImageButtonAttrs extends IButtonAttrs {
   name: string;
+  routePath: string;
+  value?: string | null;
+  url?: string | null;
 }
 
 export default class UploadImageButton<CustomAttrs extends IUploadImageButtonAttrs = IUploadImageButtonAttrs> extends Component<CustomAttrs> {
   loading = false;
 
   view(vnode: Mithril.Vnode<CustomAttrs, this>) {
-    const { name, ...attrs } = vnode.attrs as IButtonAttrs;
+    const { name, value, url, ...attrs } = vnode.attrs as IButtonAttrs;
 
     attrs.loading = this.loading;
     attrs.className = classList(attrs.className, 'Button');
 
-    if (app.data.settings[name + '_path']) {
-      return (
-        <div>
-          <p>
-            <img src={app.forum.attribute(name + 'Url')} alt="" />
-          </p>
-          <p>
+    return (
+      <div className="UploadImageButton">
+        {value ? (
+          <>
+            <div className="UploadImageButton-image">
+              <img src={url} alt={name} />
+            </div>
             <Button onclick={this.remove.bind(this)} {...attrs}>
               {app.translator.trans('core.admin.upload_image.remove_button')}
             </Button>
-          </p>
-        </div>
-      );
-    }
-
-    return (
-      <Button onclick={this.upload.bind(this)} {...attrs}>
-        {app.translator.trans('core.admin.upload_image.upload_button')}
-      </Button>
+          </>
+        ) : (
+          <Button onclick={this.upload.bind(this)} {...attrs}>
+            {app.translator.trans('core.admin.upload_image.upload_button')}
+          </Button>
+        )}
+      </div>
     );
   }
 
@@ -81,7 +82,7 @@ export default class UploadImageButton<CustomAttrs extends IUploadImageButtonAtt
   }
 
   resourceUrl() {
-    return app.forum.attribute('apiUrl') + '/' + this.attrs.name;
+    return app.forum.attribute('apiUrl') + '/' + this.attrs.routePath;
   }
 
   /**


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Converts the components to TypeScript.
* Refactors the `UploadImgeButton` component to allow reusing it in different contexts/other extensions.
* Adds a new setting type `image-upload` that auto uses the refactored component.

**Screenshot**
![Screenshot from 2023-09-13 18-53-51](https://github.com/flarum/framework/assets/20267363/2b149818-7b99-4df4-af68-5230d85a6548)

![Screenshot from 2023-09-13 18-53-58](https://github.com/flarum/framework/assets/20267363/1ce749c4-e51a-4adc-980b-11fa776d79f6)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
