### PR TITLE
feat: customizable default footer component

### DIFF
--- a/framework/core/js/src/forum/ForumApplication.tsx
+++ b/framework/core/js/src/forum/ForumApplication.tsx
@@ -24,6 +24,7 @@ import type NotificationModel from '../common/models/Notification';
 import type PostModel from '../common/models/Post';
 import extractText from '../common/utils/extractText';
 import Notices from './components/Notices';
+import Footer from './components/Footer';
 
 export interface ForumApplicationData extends ApplicationData {}
 
@@ -118,6 +119,7 @@ export default class ForumApplication extends Application {
     m.mount(document.getElementById('header-primary')!, HeaderPrimary);
     m.mount(document.getElementById('header-secondary')!, HeaderSecondary);
     m.mount(document.getElementById('notices')!, Notices);
+    m.mount(document.getElementById('footer')!, Footer);
 
     // Route the home link back home when clicked. We do not want it to register
     // if the user is opening it in a new tab, however.

--- a/framework/core/js/src/forum/components/Footer.tsx
+++ b/framework/core/js/src/forum/components/Footer.tsx
@@ -1,0 +1,7 @@
+import Component from '../../common/Component';
+
+export default class Footer extends Component {
+  view() {
+    return null;
+  }
+}

--- a/framework/core/views/frontend/forum.blade.php
+++ b/framework/core/views/frontend/forum.blade.php
@@ -39,6 +39,8 @@
         </div>
     </main>
 
+    <footer class="App-footer" id="footer"></footer>
+
 </div>
 
 {!! $forum['footerHtml'] !!}


### PR DESCRIPTION
**Fixes https://github.com/flarum/issue-archive/issues/74**

* The footer alone by default is empty, but this provides a location for extensions/themes to hook into, as right now it's more work/inconvenient code to add this from outside.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
