### PR TITLE
fix:(1.x) missing compat exports

### DIFF
--- a/framework/core/js/src/common/compat.ts
+++ b/framework/core/js/src/common/compat.ts
@@ -90,6 +90,7 @@ import isObject from './utils/isObject';
 import AlertManagerState from './states/AlertManagerState';
 import ModalManagerState from './states/ModalManagerState';
 import PageState from './states/PageState';
+import LabelValue from './components/LabelValue';
 
 export default {
   extenders,
@@ -167,6 +168,7 @@ export default {
   'components/TextEditorButton': TextEditorButton,
   'components/Tooltip': Tooltip,
   'components/EditUserModal': EditUserModal,
+  'components/LabelValue': LabelValue,
   Model: Model,
   Application: Application,
   'helpers/fullTime': fullTime,

--- a/framework/core/js/src/forum/compat.ts
+++ b/framework/core/js/src/forum/compat.ts
@@ -75,6 +75,7 @@ import BasicEditorDriver from '../common/utils/BasicEditorDriver';
 import routes from './routes';
 import ForumApplication from './ForumApplication';
 import isSafariMobile from './utils/isSafariMobile';
+import AccessTokensList from './components/AccessTokensList';
 
 export default Object.assign(compat, {
   'utils/PostControls': PostControls,
@@ -150,6 +151,7 @@ export default Object.assign(compat, {
   'components/DiscussionListItem': DiscussionListItem,
   'components/LoadingPost': LoadingPost,
   'components/PostsUserPage': PostsUserPage,
+  'components/AccessTokensList': AccessTokensList,
   'resolvers/DiscussionPageResolver': DiscussionPageResolver,
   routes: routes,
   ForumApplication: ForumApplication,


### PR DESCRIPTION
**Fixes #3887 **

I propose this to form a patch release on `1.8.x`, so that the intended functionality is available to extension developers as soon as possible.

**Changes proposed in this pull request:**
Add the missing exports to `compat`.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
