### PR TITLE
chore: leftover gambit references on the backend

### DIFF
--- a/extensions/nicknames/extend.php
+++ b/extensions/nicknames/extend.php
@@ -52,7 +52,7 @@ return [
         ->configure(AddNicknameValidation::class),
 
     (new Extend\SimpleFlarumSearch(UserSearcher::class))
-        ->setFullTextFilter(NicknameFullTextGambit::class),
+        ->setFullTextFilter(NicknameFullTextFilter::class),
 
     (new Extend\Policy())
         ->modelPolicy(User::class, UserPolicy::class),

--- a/extensions/nicknames/src/NicknameFullTextFilter.php
+++ b/extensions/nicknames/src/NicknameFullTextFilter.php
@@ -14,7 +14,7 @@ use Flarum\Search\SearchState;
 use Flarum\User\UserRepository;
 use Illuminate\Database\Eloquent\Builder;
 
-class NicknameFullTextGambit extends AbstractFulltextFilter
+class NicknameFullTextFilter extends AbstractFulltextFilter
 {
     public function __construct(
         protected UserRepository $users

--- a/extensions/sticky/src/PinStickiedDiscussionsToTop.php
+++ b/extensions/sticky/src/PinStickiedDiscussionsToTop.php
@@ -11,7 +11,7 @@ namespace Flarum\Sticky;
 
 use Flarum\Search\SearchCriteria;
 use Flarum\Search\SearchState;
-use Flarum\Tags\Filter\TagFilter;
+use Flarum\Tags\Search\Filter\TagFilter;
 
 class PinStickiedDiscussionsToTop
 {

--- a/extensions/tags/extend.php
+++ b/extensions/tags/extend.php
@@ -24,13 +24,13 @@ use Flarum\Tags\Api\Controller;
 use Flarum\Tags\Api\Serializer\TagSerializer;
 use Flarum\Tags\Content;
 use Flarum\Tags\Event\DiscussionWasTagged;
-use Flarum\Tags\Filter\HideHiddenTagsFromAllDiscussionsPage;
-use Flarum\Tags\Filter\PostTagFilter;
-use Flarum\Tags\Filter\TagFilter;
 use Flarum\Tags\Listener;
 use Flarum\Tags\LoadForumTagsRelationship;
 use Flarum\Tags\Post\DiscussionTaggedPost;
-use Flarum\Tags\Search\Gambit\FulltextGambit;
+use Flarum\Tags\Search\Filter\PostTagFilter;
+use Flarum\Tags\Search\Filter\TagFilter;
+use Flarum\Tags\Search\FulltextFilter;
+use Flarum\Tags\Search\HideHiddenTagsFromAllDiscussionsPage;
 use Flarum\Tags\Search\TagSearcher;
 use Flarum\Tags\Tag;
 use Flarum\Tags\Utf8SlugDriver;
@@ -142,7 +142,7 @@ return [
         ->addSearchMutator(HideHiddenTagsFromAllDiscussionsPage::class),
 
     (new Extend\SimpleFlarumSearch(TagSearcher::class))
-        ->setFullTextFilter(FullTextGambit::class),
+        ->setFullTextFilter(FulltextFilter::class),
 
     (new Extend\ModelUrl(Tag::class))
         ->addSlugDriver('default', Utf8SlugDriver::class),

--- a/extensions/tags/src/Search/Filter/PostTagFilter.php
+++ b/extensions/tags/src/Search/Filter/PostTagFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Tags\Filter;
+namespace Flarum\Tags\Search\Filter;
 
 use Flarum\Search\FilterInterface;
 use Flarum\Search\SearchState;

--- a/extensions/tags/src/Search/Filter/TagFilter.php
+++ b/extensions/tags/src/Search/Filter/TagFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Tags\Filter;
+namespace Flarum\Tags\Search\Filter;
 
 use Flarum\Http\SlugManager;
 use Flarum\Search\FilterInterface;

--- a/extensions/tags/src/Search/FulltextFilter.php
+++ b/extensions/tags/src/Search/FulltextFilter.php
@@ -7,30 +7,27 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\User\Search\Gambit;
+namespace Flarum\Tags\Search;
 
 use Flarum\Search\AbstractFulltextFilter;
 use Flarum\Search\SearchState;
-use Flarum\User\User;
-use Flarum\User\UserRepository;
+use Flarum\Tags\TagRepository;
 use Illuminate\Database\Eloquent\Builder;
 
-class FulltextGambit extends AbstractFulltextFilter
+class FulltextFilter extends AbstractFulltextFilter
 {
     public function __construct(
-        protected UserRepository $users
+        protected TagRepository $tags
     ) {
     }
 
-    /**
-     * @return Builder<User>
-     */
-    private function getUserSearchSubQuery(string $searchValue): Builder
+    private function getTagSearchSubQuery(string $searchValue): Builder
     {
-        return $this->users
+        return $this->tags
             ->query()
             ->select('id')
-            ->where('username', 'like', "$searchValue%");
+            ->where('name', 'like', "$searchValue%")
+            ->orWhere('slug', 'like', "$searchValue%");
     }
 
     public function search(SearchState $state, string $query): void
@@ -38,7 +35,7 @@ class FulltextGambit extends AbstractFulltextFilter
         $state->getQuery()
             ->whereIn(
                 'id',
-                $this->getUserSearchSubQuery($query)
+                $this->getTagSearchSubQuery($query)
             );
     }
 }

--- a/extensions/tags/src/Search/HideHiddenTagsFromAllDiscussionsPage.php
+++ b/extensions/tags/src/Search/HideHiddenTagsFromAllDiscussionsPage.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Tags\Filter;
+namespace Flarum\Tags\Search;
 
 use Flarum\Search\SearchCriteria;
 use Flarum\Search\SearchState;

--- a/framework/core/src/Discussion/Search/Filter/AuthorFilter.php
+++ b/framework/core/src/Discussion/Search/Filter/AuthorFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Discussion\Filter;
+namespace Flarum\Discussion\Search\Filter;
 
 use Flarum\Search\FilterInterface;
 use Flarum\Search\SearchState;

--- a/framework/core/src/Discussion/Search/Filter/CreatedFilter.php
+++ b/framework/core/src/Discussion/Search/Filter/CreatedFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Discussion\Filter;
+namespace Flarum\Discussion\Search\Filter;
 
 use Flarum\Search\FilterInterface;
 use Flarum\Search\SearchState;

--- a/framework/core/src/Discussion/Search/Filter/HiddenFilter.php
+++ b/framework/core/src/Discussion/Search/Filter/HiddenFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Discussion\Filter;
+namespace Flarum\Discussion\Search\Filter;
 
 use Flarum\Search\FilterInterface;
 use Flarum\Search\SearchState;

--- a/framework/core/src/Discussion/Search/Filter/UnreadFilter.php
+++ b/framework/core/src/Discussion/Search/Filter/UnreadFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Discussion\Filter;
+namespace Flarum\Discussion\Search\Filter;
 
 use Flarum\Discussion\DiscussionRepository;
 use Flarum\Search\FilterInterface;

--- a/framework/core/src/Discussion/Search/FulltextFilter.php
+++ b/framework/core/src/Discussion/Search/FulltextFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Discussion\Search\Gambit;
+namespace Flarum\Discussion\Search;
 
 use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
@@ -15,7 +15,7 @@ use Flarum\Search\AbstractFulltextFilter;
 use Flarum\Search\SearchState;
 use Illuminate\Database\Query\Expression;
 
-class FulltextGambit extends AbstractFulltextFilter
+class FulltextFilter extends AbstractFulltextFilter
 {
     public function search(SearchState $state, string $query): void
     {

--- a/framework/core/src/Search/SearchServiceProvider.php
+++ b/framework/core/src/Search/SearchServiceProvider.php
@@ -9,18 +9,16 @@
 
 namespace Flarum\Search;
 
-use Flarum\Discussion\Filter as DiscussionFilter;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Discussion\Search\FulltextFilter as DiscussionFulltextFilter;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ContainerUtil;
 use Flarum\Group\Filter as GroupFilter;
 use Flarum\Group\Filter\GroupSearcher;
-use Flarum\Http\Filter as HttpFilter;
 use Flarum\Http\Filter\AccessTokenSearcher;
+use Flarum\Http\Filter as HttpFilter;
 use Flarum\Post\Filter as PostFilter;
 use Flarum\Post\Filter\PostSearcher;
-use Flarum\User\Filter as UserFilter;
 use Flarum\User\Search\FulltextFilter as UserFulltextFilter;
 use Flarum\User\Search\UserSearcher;
 use Illuminate\Contracts\Container\Container;

--- a/framework/core/src/Search/SearchServiceProvider.php
+++ b/framework/core/src/Search/SearchServiceProvider.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Search;
 
+use Flarum\Discussion\Search\Filter as DiscussionFilter;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Discussion\Search\FulltextFilter as DiscussionFulltextFilter;
 use Flarum\Foundation\AbstractServiceProvider;
@@ -19,6 +20,7 @@ use Flarum\Http\Filter\AccessTokenSearcher;
 use Flarum\Http\Filter as HttpFilter;
 use Flarum\Post\Filter as PostFilter;
 use Flarum\Post\Filter\PostSearcher;
+use Flarum\User\Search\Filter as UserFilter;
 use Flarum\User\Search\FulltextFilter as UserFulltextFilter;
 use Flarum\User\Search\UserSearcher;
 use Illuminate\Contracts\Container\Container;
@@ -41,14 +43,14 @@ class SearchServiceProvider extends AbstractServiceProvider
                     HttpFilter\UserFilter::class,
                 ],
                 DiscussionSearcher::class => [
-                    \Flarum\Discussion\Search\Filter\AuthorFilter::class,
-                    \Flarum\Discussion\Search\Filter\CreatedFilter::class,
-                    \Flarum\Discussion\Search\Filter\HiddenFilter::class,
-                    \Flarum\Discussion\Search\Filter\UnreadFilter::class,
+                    DiscussionFilter\AuthorFilter::class,
+                    DiscussionFilter\CreatedFilter::class,
+                    DiscussionFilter\HiddenFilter::class,
+                    DiscussionFilter\UnreadFilter::class,
                 ],
                 UserSearcher::class => [
-                    \Flarum\User\Search\Filter\EmailFilter::class,
-                    \Flarum\User\Search\Filter\GroupFilter::class,
+                    UserFilter\EmailFilter::class,
+                    UserFilter\GroupFilter::class,
                 ],
                 GroupSearcher::class => [
                     GroupFilter\HiddenFilter::class,

--- a/framework/core/src/Search/SearchServiceProvider.php
+++ b/framework/core/src/Search/SearchServiceProvider.php
@@ -11,17 +11,17 @@ namespace Flarum\Search;
 
 use Flarum\Discussion\Filter as DiscussionFilter;
 use Flarum\Discussion\Search\DiscussionSearcher;
-use Flarum\Discussion\Search\Gambit\FulltextGambit as DiscussionFulltextFilter;
+use Flarum\Discussion\Search\FulltextFilter as DiscussionFulltextFilter;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ContainerUtil;
 use Flarum\Group\Filter as GroupFilter;
 use Flarum\Group\Filter\GroupSearcher;
-use Flarum\Http\Filter\AccessTokenSearcher;
 use Flarum\Http\Filter as HttpFilter;
+use Flarum\Http\Filter\AccessTokenSearcher;
 use Flarum\Post\Filter as PostFilter;
 use Flarum\Post\Filter\PostSearcher;
 use Flarum\User\Filter as UserFilter;
-use Flarum\User\Search\Gambit\FulltextGambit as UserFulltextFilter;
+use Flarum\User\Search\FulltextFilter as UserFulltextFilter;
 use Flarum\User\Search\UserSearcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
@@ -43,14 +43,14 @@ class SearchServiceProvider extends AbstractServiceProvider
                     HttpFilter\UserFilter::class,
                 ],
                 DiscussionSearcher::class => [
-                    DiscussionFilter\AuthorFilter::class,
-                    DiscussionFilter\CreatedFilter::class,
-                    DiscussionFilter\HiddenFilter::class,
-                    DiscussionFilter\UnreadFilter::class,
+                    \Flarum\Discussion\Search\Filter\AuthorFilter::class,
+                    \Flarum\Discussion\Search\Filter\CreatedFilter::class,
+                    \Flarum\Discussion\Search\Filter\HiddenFilter::class,
+                    \Flarum\Discussion\Search\Filter\UnreadFilter::class,
                 ],
                 UserSearcher::class => [
-                    UserFilter\EmailFilter::class,
-                    UserFilter\GroupFilter::class,
+                    \Flarum\User\Search\Filter\EmailFilter::class,
+                    \Flarum\User\Search\Filter\GroupFilter::class,
                 ],
                 GroupSearcher::class => [
                     GroupFilter\HiddenFilter::class,

--- a/framework/core/src/Search/SearchServiceProvider.php
+++ b/framework/core/src/Search/SearchServiceProvider.php
@@ -9,8 +9,8 @@
 
 namespace Flarum\Search;
 
-use Flarum\Discussion\Search\Filter as DiscussionFilter;
 use Flarum\Discussion\Search\DiscussionSearcher;
+use Flarum\Discussion\Search\Filter as DiscussionFilter;
 use Flarum\Discussion\Search\FulltextFilter as DiscussionFulltextFilter;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ContainerUtil;

--- a/framework/core/src/User/Search/Filter/EmailFilter.php
+++ b/framework/core/src/User/Search/Filter/EmailFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\User\Filter;
+namespace Flarum\User\Search\Filter;
 
 use Flarum\Search\FilterInterface;
 use Flarum\Search\SearchState;

--- a/framework/core/src/User/Search/Filter/GroupFilter.php
+++ b/framework/core/src/User/Search/Filter/GroupFilter.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\User\Filter;
+namespace Flarum\User\Search\Filter;
 
 use Flarum\Group\Group;
 use Flarum\Search\FilterInterface;

--- a/framework/core/src/User/Search/FulltextFilter.php
+++ b/framework/core/src/User/Search/FulltextFilter.php
@@ -7,27 +7,30 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Tags\Search\Gambit;
+namespace Flarum\User\Search;
 
 use Flarum\Search\AbstractFulltextFilter;
 use Flarum\Search\SearchState;
-use Flarum\Tags\TagRepository;
+use Flarum\User\User;
+use Flarum\User\UserRepository;
 use Illuminate\Database\Eloquent\Builder;
 
-class FulltextGambit extends AbstractFulltextFilter
+class FulltextFilter extends AbstractFulltextFilter
 {
     public function __construct(
-        protected TagRepository $tags
+        protected UserRepository $users
     ) {
     }
 
-    private function getTagSearchSubQuery(string $searchValue): Builder
+    /**
+     * @return Builder<User>
+     */
+    private function getUserSearchSubQuery(string $searchValue): Builder
     {
-        return $this->tags
+        return $this->users
             ->query()
             ->select('id')
-            ->where('name', 'like', "$searchValue%")
-            ->orWhere('slug', 'like', "$searchValue%");
+            ->where('username', 'like', "$searchValue%");
     }
 
     public function search(SearchState $state, string $query): void
@@ -35,7 +38,7 @@ class FulltextGambit extends AbstractFulltextFilter
         $state->getQuery()
             ->whereIn(
                 'id',
-                $this->getTagSearchSubQuery($query)
+                $this->getUserSearchSubQuery($query)
             );
     }
 }


### PR DESCRIPTION
**Part of #3884**

**Changes proposed in this pull request:**
* Renames full text gambits to fulltext filter.
* Merges leftover separate Filter namespaces into Search namespaces.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
