### PR TITLE
fix: console extender does not accept `::class` attribute for schedule

### DIFF
--- a/framework/core/src/Extend/Console.php
+++ b/framework/core/src/Extend/Console.php
@@ -11,6 +11,7 @@ namespace Flarum\Extend;
 
 use Flarum\Console\AbstractCommand;
 use Flarum\Extension\Extension;
+use Flarum\Foundation\ContainerUtil;
 use Illuminate\Contracts\Container\Container;
 
 class Console implements ExtenderInterface
@@ -62,7 +63,11 @@ class Console implements ExtenderInterface
             return array_merge($existingCommands, $this->addCommands);
         });
 
-        $container->extend('flarum.console.scheduled', function ($existingScheduled) {
+        $container->extend('flarum.console.scheduled', function ($existingScheduled) use ($container) {
+            foreach ($this->scheduled as &$schedule) {
+                $schedule['callback'] = ContainerUtil::wrapCallback($schedule['callback'], $container);
+            }
+
             return array_merge($existingScheduled, $this->scheduled);
         });
     }

--- a/framework/core/tests/integration/extenders/ConsoleTest.php
+++ b/framework/core/tests/integration/extenders/ConsoleTest.php
@@ -78,6 +78,23 @@ class ConsoleTest extends ConsoleTestCase
 
         $this->assertStringContainsString('cache:clear', $this->runCommand($input));
     }
+
+    /**
+     * @test
+     */
+    public function scheduled_command_exists_when_added_with_class_syntax()
+    {
+        $this->extend(
+            (new Extend\Console())
+                ->schedule('cache:clear', ScheduledCommandCallback::class)
+        );
+
+        $input = [
+            'command' => 'schedule:list'
+        ];
+
+        $this->assertStringContainsString('cache:clear', $this->runCommand($input));
+    }
 }
 
 class CustomCommand extends AbstractCommand
@@ -92,5 +109,13 @@ class CustomCommand extends AbstractCommand
         $this->info('Custom Command.');
 
         return Command::SUCCESS;
+    }
+}
+
+class ScheduledCommandCallback
+{
+    public function __invoke(Event $event)
+    {
+        $event->everyMinute();
     }
 }


### PR DESCRIPTION
Fixes #3899 

Related #3900 `1.x`