### PR TITLE
feat: advanced page and localized driver settings

### DIFF
--- a/extensions/nicknames/js/src/admin/index.js
+++ b/extensions/nicknames/js/src/admin/index.js
@@ -1,6 +1,9 @@
 import app from 'flarum/admin/app';
 import Alert from 'flarum/common/components/Alert';
 import Link from 'flarum/common/components/Link';
+import BasicsPage from 'flarum/admin/components/BasicsPage';
+import extractText from 'flarum/common/utils/extractText';
+import { extend } from 'flarum/common/extend';
 
 app.initializers.add('flarum/nicknames', () => {
   app.extensionData
@@ -55,4 +58,8 @@ app.initializers.add('flarum/nicknames', () => {
       },
       'start'
     );
+
+  extend(BasicsPage.prototype, 'driverLocale', function (locale) {
+    locale.display_name['nickname'] = extractText(app.translator.trans('flarum-nicknames.admin.basics.display_name_driver_options.nickname'));
+  });
 });

--- a/extensions/nicknames/locale/en.yml
+++ b/extensions/nicknames/locale/en.yml
@@ -1,5 +1,8 @@
 flarum-nicknames:
   admin:
+    basics:
+      display_name_driver_options:
+        nickname: Nickname
     permissions:
       edit_own_nickname_label: Edit own nickname
     settings:

--- a/extensions/tags/js/src/admin/components/TagsPage.js
+++ b/extensions/tags/js/src/admin/components/TagsPage.js
@@ -10,6 +10,7 @@ import Form from 'flarum/common/components/Form';
 import EditTagModal from './EditTagModal';
 import tagIcon from '../../common/helpers/tagIcon';
 import sortTags from '../../common/utils/sortTags';
+import FormSectionGroup, { FormSection } from '@flarum/core/src/admin/components/FormSectionGroup';
 
 function tagItem(tag) {
   return (
@@ -66,17 +67,15 @@ export default class TagsPage extends ExtensionPage {
       <div className="TagsContent">
         <div className="TagsContent-list">
           <div className="container" key={this.forcedRefreshKey} oncreate={this.onListOnCreate.bind(this)}>
-            <div className="SettingsGroups">
-              <div className="TagGroup">
-                <label>{app.translator.trans('flarum-tags.admin.tags.primary_heading')}</label>
+            <FormSectionGroup>
+              <FormSection className="TagGroup" label={app.translator.trans('flarum-tags.admin.tags.primary_heading')}>
                 <ol className="TagList TagList--primary">{tags.filter((tag) => tag.position() !== null && !tag.isChild()).map(tagItem)}</ol>
                 <Button className="Button TagList-button" icon="fas fa-plus" onclick={() => app.modal.show(EditTagModal, { primary: true })}>
                   {app.translator.trans('flarum-tags.admin.tags.create_primary_tag_button')}
                 </Button>
-              </div>
+              </FormSection>
 
-              <div className="TagGroup TagGroup--secondary">
-                <label>{app.translator.trans('flarum-tags.admin.tags.secondary_heading')}</label>
+              <FormSection className="TagGroup TagGroup--secondary" label={app.translator.trans('flarum-tags.admin.tags.secondary_heading')}>
                 <ul className="TagList">
                   {tags
                     .filter((tag) => tag.position() === null)
@@ -86,41 +85,44 @@ export default class TagsPage extends ExtensionPage {
                 <Button className="Button TagList-button" icon="fas fa-plus" onclick={() => app.modal.show(EditTagModal, { primary: false })}>
                   {app.translator.trans('flarum-tags.admin.tags.create_secondary_tag_button')}
                 </Button>
-              </div>
-              <Form label={app.translator.trans('flarum-tags.admin.tags.settings_heading')}>
-                <div className="Form-group">
-                  <label>{app.translator.trans('flarum-tags.admin.tag_settings.required_primary_heading')}</label>
-                  <div className="helpText">{app.translator.trans('flarum-tags.admin.tag_settings.required_primary_text')}</div>
-                  <div className="TagSettings-rangeInput">
-                    <input
-                      className="FormControl"
-                      type="number"
-                      min="0"
-                      value={minPrimaryTags()}
-                      oninput={withAttr('value', this.setMinTags.bind(this, minPrimaryTags, maxPrimaryTags))}
-                    />
-                    {app.translator.trans('flarum-tags.admin.tag_settings.range_separator_text')}
-                    <input className="FormControl" type="number" min={minPrimaryTags()} bidi={maxPrimaryTags} />
+              </FormSection>
+
+              <FormSection label={app.translator.trans('flarum-tags.admin.tags.settings_heading')}>
+                <Form>
+                  <div className="Form-group">
+                    <label>{app.translator.trans('flarum-tags.admin.tag_settings.required_primary_heading')}</label>
+                    <div className="helpText">{app.translator.trans('flarum-tags.admin.tag_settings.required_primary_text')}</div>
+                    <div className="TagSettings-rangeInput">
+                      <input
+                        className="FormControl"
+                        type="number"
+                        min="0"
+                        value={minPrimaryTags()}
+                        oninput={withAttr('value', this.setMinTags.bind(this, minPrimaryTags, maxPrimaryTags))}
+                      />
+                      {app.translator.trans('flarum-tags.admin.tag_settings.range_separator_text')}
+                      <input className="FormControl" type="number" min={minPrimaryTags()} bidi={maxPrimaryTags} />
+                    </div>
                   </div>
-                </div>
-                <div className="Form-group">
-                  <label>{app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_heading')}</label>
-                  <div className="helpText">{app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_text')}</div>
-                  <div className="TagSettings-rangeInput">
-                    <input
-                      className="FormControl"
-                      type="number"
-                      min="0"
-                      value={minSecondaryTags()}
-                      oninput={withAttr('value', this.setMinTags.bind(this, minSecondaryTags, maxSecondaryTags))}
-                    />
-                    {app.translator.trans('flarum-tags.admin.tag_settings.range_separator_text')}
-                    <input className="FormControl" type="number" min={minSecondaryTags()} bidi={maxSecondaryTags} />
+                  <div className="Form-group">
+                    <label>{app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_heading')}</label>
+                    <div className="helpText">{app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_text')}</div>
+                    <div className="TagSettings-rangeInput">
+                      <input
+                        className="FormControl"
+                        type="number"
+                        min="0"
+                        value={minSecondaryTags()}
+                        oninput={withAttr('value', this.setMinTags.bind(this, minSecondaryTags, maxSecondaryTags))}
+                      />
+                      {app.translator.trans('flarum-tags.admin.tag_settings.range_separator_text')}
+                      <input className="FormControl" type="number" min={minSecondaryTags()} bidi={maxSecondaryTags} />
+                    </div>
                   </div>
-                </div>
-                <div className="Form-group Form-controls">{this.submitButton()}</div>
-              </Form>
-            </div>
+                  <div className="Form-group Form-controls">{this.submitButton()}</div>
+                </Form>
+              </FormSection>
+            </FormSectionGroup>
             <div className="TagsContent-footer">
               <p>{app.translator.trans('flarum-tags.admin.tags.about_tags_text')}</p>
             </div>

--- a/extensions/tags/less/admin/TagsPage.less
+++ b/extensions/tags/less/admin/TagsPage.less
@@ -13,7 +13,6 @@
 
 .TagsContent-list {
   padding: 20px 0 0;
-
 }
 
 .TagList,
@@ -22,6 +21,7 @@
   padding: 0;
   color: var(--muted-color);
   font-size: 13px;
+  margin-top: 0;
 
   >li {
     display: inline-block;
@@ -80,77 +80,35 @@ li:not(.sortable-dragging)>.TagListItem-info:hover>.Button {
   height: 34px;
 }
 
-.SettingsGroups {
-  display: flex;
-  column-count: 3;
-  column-gap: 30px;
-  flex-wrap: wrap;
+@media (@tablet-up) {
+  .TagGroup--secondary {
+    max-width: 250px !important;
+  }
+}
 
-  @media (@tablet-up) {
-    .TagGroup--secondary {
-      max-width: 250px !important;
+.TagList-button {
+  background: none;
+  border: 1px dashed var(--control-bg);
+  height: 40px;
+  margin: auto auto 0 0;
+}
+
+.TagSettings-rangeInput {
+  input {
+    width: 80px;
+    display: inline;
+    margin: 0 5px;
+
+    &:first-child {
+      margin-left: 0;
     }
   }
+}
 
-  .Form {
-    min-width: 300px;
-    max-height: 500px;
-
-    >label {
-      margin-bottom: 10px;
-    }
-
-    .TagSettings-rangeInput {
-      input {
-        width: 80px;
-        display: inline;
-        margin: 0 5px;
-
-        &:first-child {
-          margin-left: 0;
-        }
-      }
-    }
-  }
-
-  .TagGroup,
-  .Form {
-    display: inline-grid;
-    padding: 10px 20px;
-    min-height: 20vh;
-    max-width: 400px;
-    grid-template-rows: min-content;
-    border: 1px solid var(--control-bg);
-    border-radius: var(--border-radius);
-    flex: 1 1 160px;
-
-    @media (max-width: 1209px) {
-      margin-bottom: 20px;
-    }
-
-    >ol {
-      >li {
-        margin-top: 8px;
-
-        .Button {
-          float: right;
-          visibility: hidden;
-          margin: -8px -16px -8px 16px;
-        }
-      }
-    }
-
-    .TagList-button {
-      background: none;
-      border: 1px dashed var(--control-bg);
-      height: 40px;
-      margin: auto auto 0 0;
-    }
-
-    >label {
-      float: left;
-      font-weight: bold;
-      color: var(--muted-color);
+.TagGroup {
+  ol {
+    > li:not(:first-child) {
+      margin-top: 8px;
     }
   }
 }

--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -42,6 +42,7 @@ export interface AdminApplicationData extends ApplicationData {
   slugDrivers: Record<string, string[]>;
   searchDrivers: Record<string, string[]>;
   permissions: Record<string, string[]>;
+  advancedPageEmpty: boolean;
 }
 
 export default class AdminApplication extends Application {

--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -40,6 +40,7 @@ export interface AdminApplicationData extends ApplicationData {
   modelStatistics: Record<string, { total: number }>;
   displayNameDrivers: string[];
   slugDrivers: Record<string, string[]>;
+  searchDrivers: Record<string, string[]>;
   permissions: Record<string, string[]>;
 }
 

--- a/framework/core/js/src/admin/components/AdminNav.js
+++ b/framework/core/js/src/admin/components/AdminNav.js
@@ -110,6 +110,16 @@ export default class AdminNav extends Component {
       50
     );
 
+    if (app.data.settings.show_advanced_settings) {
+      items.add(
+        'advanced',
+        <LinkButton href={app.route('advanced')} icon="fas fa-cog" title={app.translator.trans('core.admin.nav.advanced_title')}>
+          {app.translator.trans('core.admin.nav.advanced_button')}
+        </LinkButton>,
+        40
+      );
+    }
+
     items.add(
       'search',
       <div className="Search-input">

--- a/framework/core/js/src/admin/components/AdminNav.js
+++ b/framework/core/js/src/admin/components/AdminNav.js
@@ -110,7 +110,7 @@ export default class AdminNav extends Component {
       50
     );
 
-    if (app.data.settings.show_advanced_settings) {
+    if (app.data.settings.show_advanced_settings && !app.data.advancedPageEmpty) {
       items.add(
         'advanced',
         <LinkButton href={app.route('advanced')} icon="fas fa-cog" title={app.translator.trans('core.admin.nav.advanced_title')}>

--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -14,6 +14,7 @@ import ColorPreviewInput from '../../common/components/ColorPreviewInput';
 import ItemList from '../../common/utils/ItemList';
 import type { IUploadImageButtonAttrs } from './UploadImageButton';
 import UploadImageButton from './UploadImageButton';
+import extractText from '../../common/utils/extractText';
 
 export interface AdminHeaderOptions {
   title: Mithril.Children;
@@ -409,5 +410,13 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
     this.loading = true;
 
     return saveSettings(this.dirty()).then(this.onsaved.bind(this));
+  }
+
+  modelLocale(): Record<string, string> {
+    return {
+      'Flarum\\Discussion\\Discussion': extractText(app.translator.trans('core.admin.models.discussions')),
+      'Flarum\\User\\User': extractText(app.translator.trans('core.admin.models.users')),
+      'Flarum\\Post\\Post': extractText(app.translator.trans('core.admin.models.posts')),
+    };
   }
 }

--- a/framework/core/js/src/admin/components/AdvancedPage.tsx
+++ b/framework/core/js/src/admin/components/AdvancedPage.tsx
@@ -1,0 +1,73 @@
+import app from '../../admin/app';
+import AdminPage from './AdminPage';
+import type { IPageAttrs } from '../../common/components/Page';
+import type Mithril from 'mithril';
+import Form from '../../common/components/Form';
+import extractText from '../../common/utils/extractText';
+import FormSectionGroup, { FormSection } from './FormSectionGroup';
+
+export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends AdminPage<CustomAttrs> {
+  searchDriverOptions: Record<string, Record<string, string>> = {};
+
+  oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
+    super.oninit(vnode);
+
+    const locale = this.driverLocale();
+
+    Object.keys(app.data.searchDrivers).forEach((model) => {
+      this.searchDriverOptions[model] = {};
+
+      app.data.searchDrivers[model].forEach((option) => {
+        this.searchDriverOptions[model][option] = locale.search[option] || option;
+      });
+    });
+  }
+
+  headerInfo() {
+    return {
+      className: 'AdvancedPage',
+      icon: 'fas fa-cog',
+      title: app.translator.trans('core.admin.advanced.title'),
+      description: app.translator.trans('core.admin.advanced.description'),
+    };
+  }
+
+  content() {
+    return [
+      <Form className="AdvancedPage-container">
+        <FormSectionGroup>
+          <FormSection label={app.translator.trans('core.admin.advanced.search.section_label')}>
+            <Form>
+              {Object.keys(this.searchDriverOptions).map((model) => {
+                const options = this.searchDriverOptions[model];
+                const modelLocale = this.modelLocale()[model] || model;
+
+                if (Object.keys(options).length > 1) {
+                  return this.buildSettingComponent({
+                    type: 'select',
+                    setting: `search_driver_${model}`,
+                    options,
+                    label: app.translator.trans('core.admin.advanced.search.driver_heading', { model: modelLocale }),
+                    help: app.translator.trans('core.admin.advanced.search.driver_text', { model: modelLocale }),
+                  });
+                }
+
+                return null;
+              })}
+            </Form>
+          </FormSection>
+        </FormSectionGroup>
+
+        <div className="Form-group Form-controls">{this.submitButton()}</div>
+      </Form>,
+    ];
+  }
+
+  driverLocale(): Record<string, Record<string, string>> {
+    return {
+      search: {
+        default: extractText(app.translator.trans('core.admin.advanced.search.driver_options.default')),
+      },
+    };
+  }
+}

--- a/framework/core/js/src/admin/components/FormSectionGroup.tsx
+++ b/framework/core/js/src/admin/components/FormSectionGroup.tsx
@@ -1,0 +1,35 @@
+import Component from '../../common/Component';
+import type { ComponentAttrs } from '../../common/Component';
+import Mithril from 'mithril';
+import classList from '../../common/utils/classList';
+
+export interface IFormSectionGroupAttrs extends ComponentAttrs {}
+
+export default class FormSectionGroup<CustomAttrs extends IFormSectionGroupAttrs = IFormSectionGroupAttrs> extends Component<CustomAttrs> {
+  view(vnode: Mithril.Vnode<CustomAttrs, this>) {
+    const { className, ...attrs } = this.attrs;
+
+    return (
+      <div className={classList('FormSectionGroup', className)} {...attrs}>
+        {vnode.children}
+      </div>
+    );
+  }
+}
+
+export interface IFormSectionAttrs extends ComponentAttrs {
+  label: any;
+}
+
+export class FormSection<CustomAttrs extends IFormSectionAttrs = IFormSectionAttrs> extends Component<CustomAttrs> {
+  view(vnode: Mithril.Vnode<CustomAttrs, this>) {
+    const { className, ...attrs } = this.attrs;
+
+    return (
+      <div className={classList('FormSection', className)} {...attrs}>
+        <label>{this.attrs.label}</label>
+        <div className="FormSection-body">{vnode.children}</div>
+      </div>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -72,22 +72,24 @@ export default class StatusWidget extends DashboardWidget {
       <Button onclick={this.handleClearCache.bind(this)}>{app.translator.trans('core.admin.dashboard.clear_cache_button')}</Button>
     );
 
-    items.add(
-      'toggleAdvancedPage',
-      <Button
-        onclick={() => {
-          saveSettings({
-            show_advanced_settings: !app.data.settings.show_advanced_settings,
-          });
+    if (!app.data.advancedPageEmpty) {
+      items.add(
+        'toggleAdvancedPage',
+        <Button
+          onclick={() => {
+            saveSettings({
+              show_advanced_settings: !app.data.settings.show_advanced_settings,
+            });
 
-          if (app.data.settings.show_advanced_settings) {
-            m.route.set(app.route('advanced'));
-          }
-        }}
-      >
-        {app.translator.trans('core.admin.dashboard.toggle_advanced_page_button')}
-      </Button>
-    );
+            if (app.data.settings.show_advanced_settings) {
+              m.route.set(app.route('advanced'));
+            }
+          }}
+        >
+          {app.translator.trans('core.admin.dashboard.toggle_advanced_page_button')}
+        </Button>
+      );
+    }
 
     return items;
   }

--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -6,6 +6,7 @@ import Dropdown from '../../common/components/Dropdown';
 import Button from '../../common/components/Button';
 import LoadingModal from './LoadingModal';
 import LinkButton from '../../common/components/LinkButton';
+import saveSettings from '../utils/saveSettings.js';
 
 export default class StatusWidget extends DashboardWidget {
   className() {
@@ -69,6 +70,23 @@ export default class StatusWidget extends DashboardWidget {
     items.add(
       'clearCache',
       <Button onclick={this.handleClearCache.bind(this)}>{app.translator.trans('core.admin.dashboard.clear_cache_button')}</Button>
+    );
+
+    items.add(
+      'toggleAdvancedPage',
+      <Button
+        onclick={() => {
+          saveSettings({
+            show_advanced_settings: !app.data.settings.show_advanced_settings,
+          });
+
+          if (app.data.settings.show_advanced_settings) {
+            m.route.set(app.route('advanced'));
+          }
+        }}
+      >
+        {app.translator.trans('core.admin.dashboard.toggle_advanced_page_button')}
+      </Button>
     );
 
     return items;

--- a/framework/core/js/src/admin/routes.ts
+++ b/framework/core/js/src/admin/routes.ts
@@ -7,6 +7,7 @@ import MailPage from './components/MailPage';
 import UserListPage from './components/UserListPage';
 import ExtensionPage from './components/ExtensionPage';
 import ExtensionPageResolver from './resolvers/ExtensionPageResolver';
+import AdvancedPage from './components/AdvancedPage';
 
 /**
  * Helper functions to generate URLs to admin pages.
@@ -24,6 +25,7 @@ export default function (app: AdminApplication) {
     appearance: { path: '/appearance', component: AppearancePage },
     mail: { path: '/mail', component: MailPage },
     users: { path: '/users', component: UserListPage },
+    advanced: { path: '/advanced', component: AdvancedPage },
     extension: { path: '/extension/:id', component: ExtensionPage, resolverClass: ExtensionPageResolver },
   };
 }

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -5,6 +5,7 @@
 @import "admin/CreateUserModal";
 @import "admin/DashboardPage";
 @import "admin/DebugWarningWidget";
+@import "admin/FormSectionGroup";
 @import "admin/BasicsPage";
 @import "admin/PermissionsPage";
 @import "admin/EditGroupModal";

--- a/framework/core/less/admin/FormSectionGroup.less
+++ b/framework/core/less/admin/FormSectionGroup.less
@@ -1,0 +1,24 @@
+.FormSectionGroup {
+  display: flex;
+  column-gap: 30px;
+  flex-wrap: wrap;
+}
+
+.FormSection {
+  --gap: 24px;
+  display: inline-grid;
+  padding: 10px 20px 20px;
+  min-height: 20vh;
+  min-width: 300px;
+  max-width: 400px;
+  grid-template-rows: min-content;
+  border: 1px solid var(--control-bg);
+  border-radius: var(--border-radius);
+  flex: 1 1 160px;
+  gap: var(--gap);
+}
+
+.FormSection > label {
+  font-weight: bold;
+  color: var(--muted-color);
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -7,6 +7,17 @@ core:
   # Translations in this namespace are used by the admin interface.
   admin:
 
+    # These translations are used in the Advanced page.
+    advanced:
+      description: "Configure advanced settings for your forum."
+      search:
+        section_label: Search Drivers
+        driver_heading: "Search Driver: {model}"
+        driver_text: Select a driver to be used for searching this model.
+        driver_options:
+          default: Default database search
+      title: Advanced
+
     # These translations are used in the Appearance page.
     appearance:
       colored_header_label: Colored Header
@@ -38,6 +49,8 @@ core:
       all_discussions_label: => core.ref.all_discussions
       default_language_heading: Default Language
       description: "Set your forum title, language, and other basic settings."
+      display_name_driver_options:
+        username: Username
       display_name_heading: User Display Name
       display_name_text: Select the driver that should be used for users' display names. By default, the username is shown.
       forum_description_heading: Forum Description
@@ -46,6 +59,13 @@ core:
       home_page_heading: Home Page
       home_page_text: Choose the page which users will first see when they visit your forum.
       show_language_selector_label: Show language selector
+      slug_driver_options:
+        discussions:
+          default: ID with slug
+          utf8: ID with UTF-8 slug
+        users:
+          default: Username
+          id: ID
       slug_driver_heading: "Slug Driver: {model}"
       slug_driver_text: Select a driver to be used for slugging this model.
       title: Basics
@@ -78,6 +98,7 @@ core:
           inactive: Inactive
           never-run: Never run
       title: Dashboard
+      toggle_advanced_page_button: Toggle Advanced Page
       tools_button: Tools
 
     # These translations are used in the debug warning widget.
@@ -183,8 +204,16 @@ core:
     loading:
       title: Please Wait...
 
+    # These translations are used anywhere to localize model names for drivers.
+    models:
+      discussions: => core.ref.discussions
+      posts: => core.ref.posts
+      users: => core.ref.users
+
     # These translations are used in the navigation bar.
     nav:
+      advanced_button: => core.admin.advanced.title
+      advanced_title: => core.admin.advanced.description
       appearance_button: => core.admin.appearance.title
       appearance_title: => core.admin.appearance.description
       basics_button: => core.admin.basics.title

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -57,6 +57,8 @@ class AdminPayload
         }, $this->container->make('flarum.http.slugDrivers'));
         $document->payload['searchDrivers'] = $this->getSearchDrivers();
 
+        $document->payload['advancedPageEmpty'] = $this->checkAdvancedPageEmpty();
+
         $document->payload['phpVersion'] = $this->appInfo->identifyPHPVersion();
         $document->payload['mysqlVersion'] = $this->appInfo->identifyDatabaseVersion();
         $document->payload['debugEnabled'] = Arr::get($this->config, 'debug');
@@ -97,5 +99,10 @@ class AdminPayload
         }
 
         return $searchDriversPerModel;
+    }
+
+    protected function checkAdvancedPageEmpty(): bool
+    {
+        return count($this->container->make('flarum.search.drivers')) === 1;
     }
 }

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -89,11 +89,9 @@ class AdminPayload
         $searchDriversPerModel = [];
 
         foreach ($this->container->make('flarum.search.drivers') as $driverClass => $searcherClasses) {
-            /**
-             * @var class-string<AbstractDriver> $driverClass
-             * @var array<class-string<AbstractModel>, class-string<SearcherInterface>> $searcherClasses
-             */
+            /** @var array<class-string<AbstractModel>, class-string<SearcherInterface>> $searcherClasses */
             foreach ($searcherClasses as $modelClass => $searcherClass) {
+                /** @var class-string<AbstractDriver> $driverClass */
                 $searchDriversPerModel[$modelClass][] = $driverClass::name();
             }
         }

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -24,7 +24,6 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class AdminPayload

--- a/framework/core/src/Install/Steps/WriteSettings.php
+++ b/framework/core/src/Install/Steps/WriteSettings.php
@@ -60,7 +60,7 @@ class WriteSettings implements Step
             'mail_driver' => 'mail',
             'mail_format' => 'multipart',
             'mail_from' => 'noreply@localhost',
-            'slug_driver_Flarum\User\User' => 'default',  // @todo: use a morph map instead `User::class => 'user'` = slug_driver_user (below as well)
+            'slug_driver_Flarum\User\User' => 'default',
             'theme_colored_header' => '0',
             'theme_dark_mode' => '0',
             'theme_primary_color' => '#4D698E',

--- a/framework/core/src/Settings/SettingsServiceProvider.php
+++ b/framework/core/src/Settings/SettingsServiceProvider.php
@@ -25,7 +25,7 @@ class SettingsServiceProvider extends AbstractServiceProvider
                 'theme_primary_color' => '#4D698E',
                 'theme_secondary_color' => '#4D698E',
                 'mail_format' => 'multipart',
-                'search_driver_Flarum\User\User' => 'default',  // @todo: use a morph map instead `User::class => 'user'` = search_driver_user (below as well)
+                'search_driver_Flarum\User\User' => 'default',
                 'search_driver_Flarum\Discussion\Discussion' => 'default',
                 'search_driver_Flarum\Group\Group' => 'default',
                 'search_driver_Flarum\Post\Post' => 'default',


### PR DESCRIPTION
**Part of #3884** (https://github.com/flarum/framework/issues/3884#issuecomment-1773742849)

**Changes proposed in this pull request:**
* Adds an advanced page where search drivers can be configured per model (will contain more settings in the future, hence the visual sections)
* Localizes search driver names and model names (applies that to other driver settings like slug and display name drivers).
* Adds a toggle underneath the clear cache button.
* The toggle is hidden if the advanced page is empty (at this time that is the case when there are no alternative search drivers installed).

**Screenshot**
![Screenshot from 2023-10-21 14-53-13](https://github.com/flarum/framework/assets/20267363/f2e9c91d-2a29-436b-827f-5c4d20e2ed54)
![Screenshot from 2023-10-21 14-53-00](https://github.com/flarum/framework/assets/20267363/9d75b9a3-f225-4a2b-9f42-8e5b9d13d5e8)

**This is emulating having an alternative search driver installed for many models**
![Screenshot from 2023-10-21 14-52-43](https://github.com/flarum/framework/assets/20267363/695f0ff5-31ad-412d-9c17-6c1c4e4bca45)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
