### PR TITLE
feat: allow getting total search results and replacing filters

### DIFF
--- a/framework/core/src/Search/Database/AbstractSearcher.php
+++ b/framework/core/src/Search/Database/AbstractSearcher.php
@@ -9,11 +9,12 @@
 
 namespace Flarum\Search\Database;
 
+use Closure;
 use Flarum\Search\Filter\FilterManager;
 use Flarum\Search\SearchCriteria;
 use Flarum\Search\SearcherInterface;
 use Flarum\Search\SearchResults;
-use Flarum\User\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 abstract class AbstractSearcher implements SearcherInterface
@@ -53,7 +54,31 @@ abstract class AbstractSearcher implements SearcherInterface
             $results->pop();
         }
 
-        return new SearchResults($results, $areMoreResults);
+        return new SearchResults($results, $areMoreResults, $this->getTotalResults($query));
+    }
+
+    protected function getTotalResults(Builder $query): Closure
+    {
+        return function () use ($query) {
+            $query = $query->toBase();
+
+            if ($query->unions) {
+                $query->unions = null;
+                $query->unionLimit = null;
+                $query->unionOffset = null;
+                $query->unionOrders = null;
+                $query->setBindings([], 'union');
+            }
+
+            $query->offset = null;
+            $query->limit = null;
+            $query->orders = null;
+            $query->setBindings([], 'order');
+
+            return $query->getConnection()
+                ->table($query, 'results')
+                ->count();
+        };
     }
 
     protected function applySort(DatabaseSearchState $state, ?array $sort = null, bool $sortIsDefault = false): void

--- a/framework/core/src/Search/Database/AbstractSearcher.php
+++ b/framework/core/src/Search/Database/AbstractSearcher.php
@@ -63,16 +63,16 @@ abstract class AbstractSearcher implements SearcherInterface
             $query = $query->toBase();
 
             if ($query->unions) {
-                $query->unions = null;
-                $query->unionLimit = null;
-                $query->unionOffset = null;
-                $query->unionOrders = null;
+                $query->unions = null; // @phpstan-ignore-line
+                $query->unionLimit = null; // @phpstan-ignore-line
+                $query->unionOffset = null; // @phpstan-ignore-line
+                $query->unionOrders = null; // @phpstan-ignore-line
                 $query->setBindings([], 'union');
             }
 
-            $query->offset = null;
-            $query->limit = null;
-            $query->orders = null;
+            $query->offset = null; // @phpstan-ignore-line
+            $query->limit = null; // @phpstan-ignore-line
+            $query->orders = null; // @phpstan-ignore-line
             $query->setBindings([], 'order');
 
             return $query->getConnection()

--- a/framework/core/src/Search/SearchResults.php
+++ b/framework/core/src/Search/SearchResults.php
@@ -17,7 +17,7 @@ class SearchResults
     public function __construct(
         protected Collection $results,
         protected bool $areMoreResults,
-        /** @var callable(): int */
+        /** @var Closure(): int */
         protected Closure $totalResults
     ) {
     }

--- a/framework/core/src/Search/SearchResults.php
+++ b/framework/core/src/Search/SearchResults.php
@@ -9,13 +9,16 @@
 
 namespace Flarum\Search;
 
+use Closure;
 use Illuminate\Database\Eloquent\Collection;
 
 class SearchResults
 {
     public function __construct(
         protected Collection $results,
-        protected bool $areMoreResults
+        protected bool $areMoreResults,
+        /** @var callable(): int */
+        protected Closure $totalResults
     ) {
     }
 
@@ -27,5 +30,10 @@ class SearchResults
     public function areMoreResults(): bool
     {
         return $this->areMoreResults;
+    }
+
+    public function getTotalResults(): int
+    {
+        return ($this->totalResults)();
     }
 }

--- a/framework/core/tests/integration/extenders/SearchDriverTest.php
+++ b/framework/core/tests/integration/extenders/SearchDriverTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\extenders;
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Search\DiscussionSearcher;
+use Flarum\Discussion\Search\Filter\UnreadFilter;
 use Flarum\Extend;
 use Flarum\Search\AbstractFulltextFilter;
 use Flarum\Search\Database\DatabaseSearchDriver;
@@ -121,6 +122,23 @@ class SearchDriverTest extends TestCase
         $withResultSearch = json_encode($this->searchDiscussions('', 5, ['noResult' => '0']));
         $this->assertStringContainsString('DISCUSSION 1', $withResultSearch);
         $this->assertStringContainsString('DISCUSSION 2', $withResultSearch);
+        $this->assertEquals('[]', json_encode($this->searchDiscussions('', 5, ['noResult' => '1'])));
+    }
+
+    /**
+     * @test
+     */
+    public function existing_filter_can_be_replaced()
+    {
+        $this->extend(
+            (new Extend\SearchDriver(DatabaseSearchDriver::class))
+                ->replaceFilter(DiscussionSearcher::class, UnreadFilter::class, NoResultFilter::class)
+        );
+
+        $this->prepDb();
+
+        $this->assertNotContains(UnreadFilter::class, $this->app()->getContainer()->make('flarum.search.filters')[DiscussionSearcher::class]);
+        $this->assertContains(NoResultFilter::class, $this->app()->getContainer()->make('flarum.search.filters')[DiscussionSearcher::class]);
         $this->assertEquals('[]', json_encode($this->searchDiscussions('', 5, ['noResult' => '1'])));
     }
 


### PR DESCRIPTION
**Part of #3884** (https://github.com/flarum/framework/issues/3884#issuecomment-1773742849)

**Changes proposed in this pull request:**
* Allows grabbing the total search results count. Useful for extensions that need this information.
* Allows replacing existing filters.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.