### PR TITLE
feat(emoji): allow the user to set the cdn address

### DIFF
--- a/extensions/emoji/extend.php
+++ b/extensions/emoji/extend.php
@@ -11,6 +11,9 @@ use Flarum\Extend;
 use s9e\TextFormatter\Configurator;
 
 return [
+    (new Extend\Frontend('admin'))
+        ->js(__DIR__.'/js/dist/admin.js'),
+
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/less/forum.less'),
@@ -29,4 +32,7 @@ return [
         }),
 
     new Extend\Locales(__DIR__.'/locale'),
+
+    (new Extend\Settings)
+        ->serializeToForum('flarum-emoji.cdn', 'flarum-emoji.cdn'),
 ];

--- a/extensions/emoji/js/admin.js
+++ b/extensions/emoji/js/admin.js
@@ -1,0 +1,1 @@
+export * from './src/admin';

--- a/extensions/emoji/js/src/admin/index.js
+++ b/extensions/emoji/js/src/admin/index.js
@@ -1,0 +1,19 @@
+import app from 'flarum/admin/app';
+import {version} from "../forum/cdn";
+
+app.initializers.add('flarum-emoji', () => {
+
+  app.extensionData
+    .for('flarum-emoji')
+
+    // add a cdn address to the settings page
+    .registerSetting({
+      setting: 'flarum-emoji.cdn',
+      type: 'text',
+      label: app.translator.trans('flarum-emoji.admin.settings.cdn_label'),
+      help: app.translator.trans('flarum-emoji.admin.settings.cdn_help', {
+        version: version
+      }),
+    })
+
+});

--- a/extensions/emoji/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/emoji/js/src/forum/addComposerAutocomplete.js
@@ -80,7 +80,7 @@ export default function addComposerAutocomplete() {
                 dropdown.setIndex($(this).parent().index() - 1);
               }}
             >
-              <img alt={emoji} className="emoji" draggable="false" loading="lazy" src={`${cdn}72x72/${code}.png`} />
+              <img alt={emoji} className="emoji" draggable="false" loading="lazy" src={`${cdn()}72x72/${code}.png`} />
               {name}
             </button>
           );

--- a/extensions/emoji/js/src/forum/cdn.js
+++ b/extensions/emoji/js/src/forum/cdn.js
@@ -1,5 +1,11 @@
 import twemoji from 'twemoji';
+import app from 'flarum/forum/app';
 
 export const version = /([0-9]+).[0-9]+.[0-9]+/g.exec(twemoji.base)[1];
 
-export default `https://cdn.jsdelivr.net/gh/twitter/twemoji@${version}/assets/`;
+const cdn = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@[version]/assets/'
+
+export default function () {
+  return (app.forum.attribute('flarum-emoji.cdn') || cdn)
+    .replace('[version]', version)
+};

--- a/extensions/emoji/js/src/forum/renderEmoji.js
+++ b/extensions/emoji/js/src/forum/renderEmoji.js
@@ -3,14 +3,16 @@ import twemoji from 'twemoji';
 import { override } from 'flarum/common/extend';
 import Post from 'flarum/common/models/Post';
 
-import base from './cdn';
+import cdn from './cdn';
 
-const options = {
-  base,
-  attributes: () => ({
-    loading: 'lazy',
-  }),
-};
+function options() {
+  return {
+    base: cdn(),
+    attributes: () => ({
+      loading: 'lazy',
+    }),
+  }
+}
 
 /**
  * Parses an HTML string into a `<body>` node containing the HTML content.
@@ -40,7 +42,7 @@ export default function renderEmoji() {
       // element. This gets stripped below.
       //
       // See https://github.com/flarum/core/issues/2958
-      const emojifiedDom = twemoji.parse(parseHTML(contentHtml), options);
+      const emojifiedDom = twemoji.parse(parseHTML(contentHtml), options());
 
       // Steal the HTML string inside the emojified DOM `<body>` tag.
       this.emojifiedContentHtml = emojifiedDom.innerHTML;
@@ -54,6 +56,6 @@ export default function renderEmoji() {
   override(s9e.TextFormatter, 'preview', (original, text, element) => {
     original(text, element);
 
-    twemoji.parse(element, options);
+    twemoji.parse(element, options());
   });
 }

--- a/extensions/emoji/locale/en.yml
+++ b/extensions/emoji/locale/en.yml
@@ -4,6 +4,18 @@ flarum-emoji:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
+  # Translations in this namespace are used by the admin interface.
+  admin:
+
+    # These translations are used in the Settings page of the admin interface.
+    settings:
+      cdn_label: CDN mirror address
+      cdn_help: "e.g. https://cdn.jsdelivr.net/gh/twitter/twemoji@[version]/assets/, The current version is: {version}"
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
   # Translations in this namespace are used by the forum user interface.
   forum:
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**add cdn mirror address configuration items**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Modified extension emoji, the cdn mirror address configuration item is added to the extended emoji settings page of the management interface.
This option affects the Preview address of emoji in the Post, Reply, and Reply edit box Autocomplete.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Some cdn only provide version Hao 14.0.2 and do not provide a short address of 14, and if the user enters the wrong address, it cannot be displayed.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://github.com/flarum/framework/assets/993536/da5c7921-9b27-4ef6-b212-5eb38d30b512)


**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->
None

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

