### PR TITLE
chore: use `::class` syntax to fetch class name instead of `get_class()` function

### DIFF
--- a/extensions/flags/src/Api/Serializer/FlagSerializer.php
+++ b/extensions/flags/src/Api/Serializer/FlagSerializer.php
@@ -24,7 +24,7 @@ class FlagSerializer extends AbstractSerializer
     {
         if (! ($model instanceof Flag)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.Flag::class
+                $this::class.' can only serialize instances of '.Flag::class
             );
         }
 

--- a/extensions/package-manager/src/Api/Serializer/TaskSerializer.php
+++ b/extensions/package-manager/src/Api/Serializer/TaskSerializer.php
@@ -24,7 +24,7 @@ class TaskSerializer extends AbstractSerializer
     {
         if (! ($model instanceof Task)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.Task::class
+                $this::class.' can only serialize instances of '.Task::class
             );
         }
 

--- a/extensions/tags/src/Api/Serializer/TagSerializer.php
+++ b/extensions/tags/src/Api/Serializer/TagSerializer.php
@@ -29,7 +29,7 @@ class TagSerializer extends AbstractSerializer
     {
         if (! ($model instanceof Tag)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.Tag::class
+                $this::class.' can only serialize instances of '.Tag::class
             );
         }
 

--- a/framework/core/src/Api/Serializer/AccessTokenSerializer.php
+++ b/framework/core/src/Api/Serializer/AccessTokenSerializer.php
@@ -27,7 +27,7 @@ class AccessTokenSerializer extends AbstractSerializer
     {
         if (! ($model instanceof AccessToken)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.AccessToken::class
+                $this::class.' can only serialize instances of '.AccessToken::class
             );
         }
 

--- a/framework/core/src/Api/Serializer/BasicDiscussionSerializer.php
+++ b/framework/core/src/Api/Serializer/BasicDiscussionSerializer.php
@@ -30,7 +30,7 @@ class BasicDiscussionSerializer extends AbstractSerializer
     {
         if (! ($model instanceof Discussion)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.Discussion::class
+                $this::class.' can only serialize instances of '.Discussion::class
             );
         }
 

--- a/framework/core/src/Api/Serializer/BasicPostSerializer.php
+++ b/framework/core/src/Api/Serializer/BasicPostSerializer.php
@@ -34,7 +34,7 @@ class BasicPostSerializer extends AbstractSerializer
     {
         if (! ($model instanceof Post)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.Post::class
+                $this::class.' can only serialize instances of '.Post::class
             );
         }
 

--- a/framework/core/src/Api/Serializer/BasicUserSerializer.php
+++ b/framework/core/src/Api/Serializer/BasicUserSerializer.php
@@ -30,7 +30,7 @@ class BasicUserSerializer extends AbstractSerializer
     {
         if (! ($model instanceof User)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.User::class
+                $this::class.' can only serialize instances of '.User::class
             );
         }
 

--- a/framework/core/src/Api/Serializer/CurrentUserSerializer.php
+++ b/framework/core/src/Api/Serializer/CurrentUserSerializer.php
@@ -18,7 +18,7 @@ class CurrentUserSerializer extends UserSerializer
     {
         if (! ($model instanceof User)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.User::class
+                $this::class.' can only serialize instances of '.User::class
             );
         }
 

--- a/framework/core/src/Api/Serializer/GroupSerializer.php
+++ b/framework/core/src/Api/Serializer/GroupSerializer.php
@@ -29,7 +29,7 @@ class GroupSerializer extends AbstractSerializer
     {
         if (! ($model instanceof Group)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.Group::class
+                $this::class.' can only serialize instances of '.Group::class
             );
         }
 

--- a/framework/core/src/Api/Serializer/NotificationSerializer.php
+++ b/framework/core/src/Api/Serializer/NotificationSerializer.php
@@ -30,7 +30,7 @@ class NotificationSerializer extends AbstractSerializer
     {
         if (! ($model instanceof Notification)) {
             throw new InvalidArgumentException(
-                get_class($this).' can only serialize instances of '.Notification::class
+                $this::class.' can only serialize instances of '.Notification::class
             );
         }
 

--- a/framework/core/src/Bus/Dispatcher.php
+++ b/framework/core/src/Bus/Dispatcher.php
@@ -15,7 +15,7 @@ class Dispatcher extends BaseDispatcher
 {
     public function getCommandHandler($command)
     {
-        $handler = get_class($command).'Handler';
+        $handler = $command::class.'Handler';
 
         if (class_exists($handler)) {
             return $this->container->make($handler);

--- a/framework/core/src/Extension/Exception/ExtensionBootError.php
+++ b/framework/core/src/Extension/Exception/ExtensionBootError.php
@@ -20,7 +20,7 @@ class ExtensionBootError extends Exception
         public object $extender,
         Throwable $previous = null
     ) {
-        $extenderClass = get_class($extender);
+        $extenderClass = $extender::class;
 
         parent::__construct("Experienced an error while booting extension: {$extension->getTitle()}.\n\nError occurred while applying an extender of type: $extenderClass.", 0, $previous);
     }

--- a/framework/core/src/Foundation/Application.php
+++ b/framework/core/src/Foundation/Application.php
@@ -115,7 +115,7 @@ class Application extends IlluminateContainer implements LaravelApplication
 
     public function getProvider(string|ServiceProvider $provider): ?ServiceProvider
     {
-        $name = is_string($provider) ? $provider : get_class($provider);
+        $name = is_string($provider) ? $provider : $provider::class;
 
         return Arr::first($this->serviceProviders, function ($key, $value) use ($name) {
             return $value instanceof $name;
@@ -134,7 +134,7 @@ class Application extends IlluminateContainer implements LaravelApplication
 
     protected function markAsRegistered(ServiceProvider $provider): void
     {
-        $this['events']->dispatch($class = get_class($provider), [$provider]);
+        $this['events']->dispatch($class = $provider::class, [$provider]);
 
         $this->serviceProviders[] = $provider;
 

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -57,7 +57,7 @@ class ApplicationInfoProvider
     public function identifyQueueDriver(): string
     {
         // Get class name
-        $queue = get_class($this->queue);
+        $queue = $this->queue::class;
         // Drop the namespace
         $queue = Str::afterLast($queue, '\\');
         // Lowercase the class name
@@ -103,7 +103,7 @@ class ApplicationInfoProvider
          * And compare that to the current configured driver.
          */
         // Get class name
-        $handlerName = get_class($this->sessionHandler);
+        $handlerName = $this->sessionHandler::class;
         // Drop the namespace
         $handlerName = Str::afterLast($handlerName, '\\');
         // Lowercase the class name

--- a/framework/core/src/Foundation/Concerns/InteractsWithLaravel.php
+++ b/framework/core/src/Foundation/Concerns/InteractsWithLaravel.php
@@ -184,7 +184,7 @@ trait InteractsWithLaravel
 
     public function getProviders($provider): array
     {
-        $name = is_string($provider) ? $provider : get_class($provider);
+        $name = is_string($provider) ? $provider : $provider::class;
 
         return Arr::where($this->serviceProviders, fn ($value) => $value instanceof $name);
     }

--- a/framework/core/src/Foundation/ErrorHandling/Registry.php
+++ b/framework/core/src/Foundation/ErrorHandling/Registry.php
@@ -54,7 +54,7 @@ class Registry
         if ($error instanceof KnownError) {
             $errorType = $error->getType();
         } else {
-            $errorClass = get_class($error);
+            $errorClass = $error::class;
             if (isset($this->classMap[$errorClass])) {
                 $errorType = $this->classMap[$errorClass];
             }
@@ -73,7 +73,7 @@ class Registry
 
     private function handleCustomTypes(Throwable $error): ?HandledError
     {
-        $errorClass = get_class($error);
+        $errorClass = $error::class;
 
         if (isset($this->handlerMap[$errorClass])) {
             $handler = new $this->handlerMap[$errorClass];

--- a/framework/core/src/Frontend/Compiler/Source/SourceCollector.php
+++ b/framework/core/src/Frontend/Compiler/Source/SourceCollector.php
@@ -77,7 +77,7 @@ class SourceCollector
         if (! empty($this->allowedSourceTypes) && ! $isInstanceOfOneOfTheAllowedSourceTypes) {
             throw new \InvalidArgumentException(sprintf(
                 'Source type %s is not allowed for this collector. Allowed types are: %s',
-                get_class($source),
+                $source::class,
                 implode(', ', $this->allowedSourceTypes)
             ));
         }

--- a/framework/core/src/Http/Server.php
+++ b/framework/core/src/Http/Server.php
@@ -89,7 +89,7 @@ class Server
             $message = $error->getMessage();
             $file = $error->getFile();
             $line = $error->getLine();
-            $type = get_class($error);
+            $type = $error::class;
 
             echo <<<ERROR
             Flarum encountered a boot error ($type)<br />

--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -137,7 +137,7 @@ class Notification extends AbstractModel
      */
     public function scopeWhereSubject(Builder $query, AbstractModel $model): Builder
     {
-        return $query->whereSubjectModel(get_class($model))
+        return $query->whereSubjectModel($model::class)
             ->where('subject_id', $model->getAttribute('id'));
     }
 

--- a/framework/core/src/Search/GambitManager.php
+++ b/framework/core/src/Search/GambitManager.php
@@ -60,7 +60,7 @@ class GambitManager
             foreach ($this->gambits as $gambit) {
                 if (! $gambit instanceof GambitInterface) {
                     throw new LogicException(
-                        'Gambit '.get_class($gambit).' does not implement '.GambitInterface::class
+                        'Gambit '.$gambit::class.' does not implement '.GambitInterface::class
                     );
                 }
 

--- a/framework/core/src/User/Access/Gate.php
+++ b/framework/core/src/User/Access/Gate.php
@@ -50,7 +50,7 @@ class Gate
         $appliedPolicies = [];
 
         if ($model) {
-            $modelClasses = is_string($model) ? [$model] : array_merge(class_parents($model), [get_class($model)]);
+            $modelClasses = is_string($model) ? [$model] : array_merge(class_parents($model), [$model::class]);
 
             foreach ($modelClasses as $class) {
                 $appliedPolicies = array_merge($appliedPolicies, $this->getPolicies($class));

--- a/framework/core/tests/integration/extenders/FilesystemTest.php
+++ b/framework/core/tests/integration/extenders/FilesystemTest.php
@@ -51,7 +51,7 @@ class FilesystemTest extends TestCase
         /** @var FilesystemAdapter $uploadsDisk */
         $uploadsDisk = $this->app()->getContainer()->make('filesystem')->disk('flarum-uploads');
 
-        $this->assertEquals(get_class($uploadsDisk->getAdapter()), LocalFilesystemAdapter::class);
+        $this->assertEquals($uploadsDisk->getAdapter()::class, LocalFilesystemAdapter::class);
     }
 
     /**
@@ -64,7 +64,7 @@ class FilesystemTest extends TestCase
         /** @var FilesystemAdapter $uploadsDisk */
         $uploadsDisk = $this->app()->getContainer()->make('filesystem')->disk('flarum-uploads');
 
-        $this->assertEquals(get_class($uploadsDisk->getAdapter()), LocalFilesystemAdapter::class);
+        $this->assertEquals($uploadsDisk->getAdapter()::class, LocalFilesystemAdapter::class);
     }
 
     /**
@@ -77,7 +77,7 @@ class FilesystemTest extends TestCase
         /** @var FilesystemAdapter $assetsDisk */
         $assetsDisk = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets');
 
-        $this->assertEquals(get_class($assetsDisk->getAdapter()), LocalFilesystemAdapter::class);
+        $this->assertEquals($assetsDisk->getAdapter()::class, LocalFilesystemAdapter::class);
     }
 
     /**
@@ -90,7 +90,7 @@ class FilesystemTest extends TestCase
         /** @var FilesystemAdapter $assetsDisk */
         $assetsDisk = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets');
 
-        $this->assertEquals(get_class($assetsDisk->getAdapter()), LocalFilesystemAdapter::class);
+        $this->assertEquals($assetsDisk->getAdapter()::class, LocalFilesystemAdapter::class);
     }
 
     /**
@@ -107,7 +107,7 @@ class FilesystemTest extends TestCase
         /** @var FilesystemAdapter $assetsDisk */
         $assetsDisk = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets');
 
-        $this->assertEquals(get_class($assetsDisk->getAdapter()), InMemoryFilesystemAdapter::class);
+        $this->assertEquals($assetsDisk->getAdapter()::class, InMemoryFilesystemAdapter::class);
     }
 
     /**
@@ -124,7 +124,7 @@ class FilesystemTest extends TestCase
         /** @var FilesystemAdapter $assetsDisk */
         $assetsDisk = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets');
 
-        $this->assertEquals(get_class($assetsDisk->getAdapter()), InMemoryFilesystemAdapter::class);
+        $this->assertEquals($assetsDisk->getAdapter()::class, InMemoryFilesystemAdapter::class);
     }
 }
 

--- a/framework/core/tests/integration/extenders/SessionTest.php
+++ b/framework/core/tests/integration/extenders/SessionTest.php
@@ -51,7 +51,7 @@ class SessionTest extends TestCase
 
         $driver = $this->app()->getContainer()->make('session')->driver('flarum-acme');
 
-        $this->assertEquals(NullSessionHandler::class, get_class($driver->getHandler()));
+        $this->assertEquals(NullSessionHandler::class, $driver->getHandler()::class);
     }
 
     /**
@@ -63,7 +63,7 @@ class SessionTest extends TestCase
 
         $driver = $this->app()->getContainer()->make('session')->driver('redis');
 
-        $this->assertEquals(NullSessionHandler::class, get_class($driver->getHandler()));
+        $this->assertEquals(NullSessionHandler::class, $driver->getHandler()::class);
     }
 
     /**
@@ -75,7 +75,7 @@ class SessionTest extends TestCase
 
         $handler = $this->app()->getContainer()->make('session.handler');
 
-        $this->assertEquals(FileSessionHandler::class, get_class($handler));
+        $this->assertEquals(FileSessionHandler::class, $handler::class);
     }
 
     /**
@@ -87,7 +87,7 @@ class SessionTest extends TestCase
 
         $handler = $this->app()->getContainer()->make('session.handler');
 
-        $this->assertEquals(FileSessionHandler::class, get_class($handler));
+        $this->assertEquals(FileSessionHandler::class, $handler::class);
     }
 
     /**
@@ -103,7 +103,7 @@ class SessionTest extends TestCase
 
         $handler = $this->app()->getContainer()->make('session.handler');
 
-        $this->assertEquals(NullSessionHandler::class, get_class($handler));
+        $this->assertEquals(NullSessionHandler::class, $handler::class);
     }
 }
 

--- a/php-packages/phpstan/src/Extender/Extender.php
+++ b/php-packages/phpstan/src/Extender/Extender.php
@@ -38,7 +38,7 @@ class Extender
         foreach ($this->constructorArguments as $index => $constructorArgument) {
             $string = null;
 
-            switch (get_class($constructorArgument)) {
+            switch ($constructorArgument::class) {
                 case Expr\ClassConstFetch::class:
                     $string = $constructorArgument->class->toString();
                     break;

--- a/php-packages/phpstan/src/Extender/Resolver.php
+++ b/php-packages/phpstan/src/Extender/Resolver.php
@@ -147,7 +147,7 @@ class Resolver
         $methodStack = array_reverse($methodStack);
 
         if (! $value->var instanceof New_) {
-            throw new \Exception('Unable to resolve extender for '.get_class($value->var));
+            throw new \Exception('Unable to resolve extender for '.$value->var::class);
         }
 
         return $this->resolveExtenderNew($value->var, $methodStack);


### PR DESCRIPTION
This pull request updates the codebase to use the `::class` syntax for obtaining the fully qualified class name from objects. This improvement aligns with the introduction of this syntax in PHP 8.0.

See more: https://wiki.php.net/rfc/class_name_literal_on_object

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
