### PR TITLE
fix(webpack-config): split chunks can fail in dev mode

### DIFF
--- a/js-packages/webpack-config/src/index.cjs
+++ b/js-packages/webpack-config/src/index.cjs
@@ -102,6 +102,7 @@ module.exports = function () {
     optimization: {
       splitChunks: {
         chunks: 'async',
+        maxAsyncRequests: 1,
         cacheGroups: {
           // Avoid node_modules being split into separate chunks
           defaultVendors: false,


### PR DESCRIPTION
**Changes proposed in this pull request:**
* When running `yarn dev` webpack changes certain behavior that can break spit chunks.
  * In the example where `TagDiscussionModal` extends from `TagSelectionModal` and both components are split chunks. The normal wted behavior in `yarn build` is two separate chunks where `TagDiscussionModal` also has the `TagSelectionModal` component inside. In `yarn dev` webpack attempts to speed up its process by just async loading `TagSelectionModal` first. Since our internal process can only handle explicit async loading (to determine the source package/extension), this behavior errors out.
  * By configuring webpack's auto async calls to a max of 1, this is prevented.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.