### PR TITLE
chore(mentions,emoji): tie autocomplete to editor instance

### DIFF
--- a/extensions/emoji/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/emoji/js/src/forum/addComposerAutocomplete.js
@@ -7,8 +7,6 @@ import getEmojiIconCode from './helpers/getEmojiIconCode';
 import cdn from './cdn';
 
 export default function addComposerAutocomplete() {
-  const $container = $('<div class="ComposerBody-emojiDropdownContainer"></div>');
-  const dropdown = new AutocompleteDropdown();
   let emojiMap = null;
 
   extend('flarum/common/components/TextEditor', 'oninit', function () {
@@ -16,18 +14,19 @@ export default function addComposerAutocomplete() {
   });
 
   extend('flarum/common/components/TextEditor', 'onbuild', function () {
+    this.emojiDropdown = new AutocompleteDropdown();
     const $editor = this.$('.TextEditor-editor').wrap('<div class="ComposerBody-emojiWrapper"></div>');
 
     this.navigator = new KeyboardNavigatable();
     this.navigator
-      .when(() => dropdown.active)
-      .onUp(() => dropdown.navigate(-1))
-      .onDown(() => dropdown.navigate(1))
-      .onSelect(dropdown.complete.bind(dropdown))
-      .onCancel(dropdown.hide.bind(dropdown))
+      .when(() => this.emojiDropdown.active)
+      .onUp(() => this.emojiDropdown.navigate(-1))
+      .onDown(() => this.emojiDropdown.navigate(1))
+      .onSelect(this.emojiDropdown.complete.bind(this.emojiDropdown))
+      .onCancel(this.emojiDropdown.hide.bind(this.emojiDropdown))
       .bindTo($editor);
 
-    $editor.after($container);
+    $editor.after($('<div class="ComposerBody-emojiDropdownContainer"></div>'));
   });
 
   extend('flarum/common/components/TextEditor', 'buildEditorParams', function (params) {
@@ -40,7 +39,7 @@ export default function addComposerAutocomplete() {
     const applySuggestion = (replacement) => {
       this.attrs.composer.editor.replaceBeforeCursor(absEmojiStart - 1, replacement + ' ');
 
-      dropdown.hide();
+      this.emojiDropdown.hide();
     };
 
     params.inputListeners.push(() => {
@@ -68,8 +67,8 @@ export default function addComposerAutocomplete() {
         }
       }
 
-      dropdown.hide();
-      dropdown.active = false;
+      this.emojiDropdown.hide();
+      this.emojiDropdown.active = false;
 
       if (absEmojiStart) {
         typed = lastChunk.substring(relEmojiStart).toLowerCase();
@@ -80,7 +79,7 @@ export default function addComposerAutocomplete() {
               key={emoji}
               onclick={() => applySuggestion(emoji)}
               onmouseenter={function () {
-                dropdown.setIndex($(this).parent().index() - 1);
+                this.emojiDropdown.setIndex($(this).parent().index() - 1);
               }}
             >
               <img alt={emoji} className="emoji" draggable="false" loading="lazy" src={`${cdn}72x72/${code}.png`} />
@@ -133,14 +132,14 @@ export default function addComposerAutocomplete() {
             .map(makeSuggestion);
 
           if (suggestions.length) {
-            dropdown.items = suggestions;
-            m.render($container[0], dropdown.render());
+            this.emojiDropdown.items = suggestions;
+            m.render(this.$('.ComposerBody-emojiDropdownContainer')[0], this.emojiDropdown.render());
 
-            dropdown.show();
+            this.emojiDropdown.show();
             const coordinates = this.attrs.composer.editor.getCaretCoordinates(absEmojiStart);
-            const width = dropdown.$().outerWidth();
-            const height = dropdown.$().outerHeight();
-            const parent = dropdown.$().offsetParent();
+            const width = this.emojiDropdown.$().outerWidth();
+            const height = this.emojiDropdown.$().outerHeight();
+            const parent = this.emojiDropdown.$().offsetParent();
             let left = coordinates.left;
             let top = coordinates.top + 15;
 
@@ -156,15 +155,15 @@ export default function addComposerAutocomplete() {
             top = Math.max(-(parent.offset().top - $(document).scrollTop()), top);
             left = Math.max(-parent.offset().left, left);
 
-            dropdown.show(left, top);
+            this.emojiDropdown.show(left, top);
           }
         };
 
         buildSuggestions();
 
-        dropdown.setIndex(0);
-        dropdown.$().scrollTop(0);
-        dropdown.active = true;
+        this.emojiDropdown.setIndex(0);
+        this.emojiDropdown.$().scrollTop(0);
+        this.emojiDropdown.active = true;
       }
     });
   });

--- a/extensions/mentions/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/mentions/js/src/forum/addComposerAutocomplete.js
@@ -7,22 +7,20 @@ import AutocompleteDropdown from './fragments/AutocompleteDropdown';
 import MentionableModels from './mentionables/MentionableModels';
 
 export default function addComposerAutocomplete() {
-  const $container = $('<div class="ComposerBody-mentionsDropdownContainer"></div>');
-  const dropdown = new AutocompleteDropdown();
-
   extend('flarum/common/components/TextEditor', 'onbuild', function () {
+    this.mentionsDropdown = new AutocompleteDropdown();
     const $editor = this.$('.TextEditor-editor').wrap('<div class="ComposerBody-mentionsWrapper"></div>');
 
     this.navigator = new KeyboardNavigatable();
     this.navigator
-      .when(() => dropdown.active)
-      .onUp(() => dropdown.navigate(-1))
-      .onDown(() => dropdown.navigate(1))
-      .onSelect(dropdown.complete.bind(dropdown))
-      .onCancel(dropdown.hide.bind(dropdown))
+      .when(() => this.mentionsDropdown.active)
+      .onUp(() => this.mentionsDropdown.navigate(-1))
+      .onDown(() => this.mentionsDropdown.navigate(1))
+      .onSelect(this.mentionsDropdown.complete.bind(this.mentionsDropdown))
+      .onCancel(this.mentionsDropdown.hide.bind(this.mentionsDropdown))
       .bindTo($editor);
 
-    $editor.after($container);
+    $editor.after($('<div class="ComposerBody-mentionsDropdownContainer"></div>'));
   });
 
   extend('flarum/common/components/TextEditor', 'buildEditorParams', function (params) {
@@ -32,12 +30,12 @@ export default function addComposerAutocomplete() {
 
     let mentionables = new MentionableModels({
       onmouseenter: function () {
-        dropdown.setIndex($(this).parent().index());
+        this.mentionsDropdown.setIndex($(this).parent().index());
       },
       onclick: (replacement) => {
         this.attrs.composer.editor.replaceBeforeCursor(absMentionStart - 1, replacement + ' ');
 
-        dropdown.hide();
+        this.mentionsDropdown.hide();
       },
     });
 
@@ -66,8 +64,8 @@ export default function addComposerAutocomplete() {
         }
       }
 
-      dropdown.hide();
-      dropdown.active = false;
+      this.mentionsDropdown.hide();
+      this.mentionsDropdown.active = false;
 
       if (absMentionStart) {
         const typed = lastChunk.substring(relMentionStart).toLowerCase();
@@ -83,14 +81,14 @@ export default function addComposerAutocomplete() {
           const suggestions = mentionables.buildSuggestions();
 
           if (suggestions.length) {
-            dropdown.items = suggestions;
-            m.render($container[0], dropdown.render());
+            this.mentionsDropdown.items = suggestions;
+            m.render(this.$('.ComposerBody-mentionsDropdownContainer')[0], this.mentionsDropdown.render());
 
-            dropdown.show();
+            this.mentionsDropdown.show();
             const coordinates = this.attrs.composer.editor.getCaretCoordinates(absMentionStart);
-            const width = dropdown.$().outerWidth();
-            const height = dropdown.$().outerHeight();
-            const parent = dropdown.$().offsetParent();
+            const width = this.mentionsDropdown.$().outerWidth();
+            const height = this.mentionsDropdown.$().outerHeight();
+            const parent = this.mentionsDropdown.$().offsetParent();
             let left = coordinates.left;
             let top = coordinates.top + 15;
 
@@ -106,19 +104,19 @@ export default function addComposerAutocomplete() {
             top = Math.max(-(parent.offset().top - $(document).scrollTop()), top);
             left = Math.max(-parent.offset().left, left);
 
-            dropdown.show(left, top);
+            this.mentionsDropdown.show(left, top);
           } else {
-            dropdown.active = false;
-            dropdown.hide();
+            this.mentionsDropdown.active = false;
+            this.mentionsDropdown.hide();
           }
         };
 
-        dropdown.active = true;
+        this.mentionsDropdown.active = true;
 
         buildSuggestions();
 
-        dropdown.setIndex(0);
-        dropdown.$().scrollTop(0);
+        this.mentionsDropdown.setIndex(0);
+        this.mentionsDropdown.$().scrollTop(0);
 
         mentionables.search()?.then(buildSuggestions);
       }


### PR DESCRIPTION
**Changes proposed in this pull request:**
If an extension attempts to use multiple editors on the same page, you face issues with the autocomplete dropdowns since they assume there is only one editor on the page. By tying the autocomplete instance and element to the texteditor instance, this can be improved.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.