### PR TITLE
fix: only set actor on events that have it

### DIFF
--- a/framework/core/src/Foundation/DispatchEventsTrait.php
+++ b/framework/core/src/Foundation/DispatchEventsTrait.php
@@ -25,7 +25,9 @@ trait DispatchEventsTrait
         }
 
         foreach ($entity->releaseEvents() as $event) {
-            $event->actor = $actor;
+            if (property_exists($event, 'actor') && ! $event->actor) {
+                $event->actor = $actor;
+            }
 
             $this->events->dispatch($event);
         }


### PR DESCRIPTION
**Fixes #3889**

**Changes proposed in this pull request:**
* I was going to update update all relevant events so that the actor property is always named `actor` but I figured that would be too breaking? honestly not sure, but at least this fixes the deprecation warning.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.