### PR TITLE
fix: load event mentioned tags on show discussion endpoint

### DIFF
--- a/extensions/tags/extend.php
+++ b/extensions/tags/extend.php
@@ -177,10 +177,14 @@ return [
     (new Extend\ApiController(FlarumController\ListPostsController::class))
         ->addInclude('eventPostMentionsTags')
         // Restricted tags should still appear as `deleted` to unauthorized users.
-        ->loadWhere('eventPostMentionsTags', function (Relation|Builder $query, ?ServerRequestInterface $request) {
+        ->loadWhere('eventPostMentionsTags', $restrictMentionedTags = function (Relation|Builder $query, ?ServerRequestInterface $request) {
             if ($request) {
                 $actor = RequestUtil::getActor($request);
                 $query->whereVisibleTo($actor);
             }
         }),
+
+    (new Extend\ApiController(FlarumController\ShowDiscussionController::class))
+        ->addInclude('posts.eventPostMentionsTags')
+        ->loadWhere('posts.eventPostMentionsTags', $restrictMentionedTags),
 ];


### PR DESCRIPTION
**Fixes #3863**

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.