### PR TITLE
fix: user pages history not registered

### DIFF
--- a/framework/core/js/src/forum/components/UserPage.tsx
+++ b/framework/core/js/src/forum/components/UserPage.tsx
@@ -82,6 +82,8 @@ export default class UserPage<CustomAttrs extends IUserPageAttrs = IUserPageAttr
 
     app.setTitle(user.displayName());
 
+    app.history.push(app.current.get('routeName'), user.displayName());
+
     m.redraw();
   }
 


### PR DESCRIPTION
Submitting on behalf of @iPurpl3x 

> You know the back button in the header ? Well, all the pages extending the UserPage, don't get into the history and therefore when one comes from home (first page load), and the open the user page, there will be no back button. This fixes it.