### PR TITLE
fix: paginated list limit hard to change

### DIFF
--- a/extensions/package-manager/js/src/admin/states/QueueState.ts
+++ b/extensions/package-manager/js/src/admin/states/QueueState.ts
@@ -21,7 +21,7 @@ export default class QueueState {
 
     return app.store.find<Task[]>('package-manager-tasks', params || {}).then((data) => {
       this.tasks = data;
-      this.total = data.payload.meta?.total;
+      this.total = data.payload.meta?.total!;
 
       m.redraw();
 

--- a/framework/core/js/src/common/Store.ts
+++ b/framework/core/js/src/common/Store.ts
@@ -49,7 +49,11 @@ export interface ApiPayloadPlural {
     next?: string;
     prev?: string;
   };
-  meta?: MetaInformation;
+  meta?: MetaInformation & {
+    total?: number;
+    page?: number;
+    perPage?: number;
+  };
 }
 
 export type ApiPayload = ApiPayloadSingle | ApiPayloadPlural;

--- a/framework/core/js/src/forum/states/DiscussionListState.ts
+++ b/framework/core/js/src/forum/states/DiscussionListState.ts
@@ -15,7 +15,7 @@ export default class DiscussionListState<P extends DiscussionListParams = Discus
   protected eventEmitter: EventEmitter;
 
   constructor(params: P, page: number = 1) {
-    super(params, page, 20);
+    super(params, page, null);
 
     this.eventEmitter = globalEventEmitter.on('discussion.deleted', this.deleteDiscussion.bind(this));
   }
@@ -44,6 +44,7 @@ export default class DiscussionListState<P extends DiscussionListParams = Discus
 
     if (preloadedDiscussions) {
       this.initialLoading = false;
+      this.pageSize = preloadedDiscussions.payload.meta?.perPage || 20;
 
       return Promise.resolve(preloadedDiscussions);
     }

--- a/framework/core/js/src/forum/states/DiscussionListState.ts
+++ b/framework/core/js/src/forum/states/DiscussionListState.ts
@@ -44,7 +44,7 @@ export default class DiscussionListState<P extends DiscussionListParams = Discus
 
     if (preloadedDiscussions) {
       this.initialLoading = false;
-      this.pageSize = preloadedDiscussions.payload.meta?.perPage || 20;
+      this.pageSize = preloadedDiscussions.payload.meta?.perPage || DiscussionListState.DEFAULT_PAGE_SIZE;
 
       return Promise.resolve(preloadedDiscussions);
     }

--- a/framework/core/js/src/forum/states/NotificationListState.ts
+++ b/framework/core/js/src/forum/states/NotificationListState.ts
@@ -4,7 +4,7 @@ import Notification from '../../common/models/Notification';
 
 export default class NotificationListState extends PaginatedListState<Notification> {
   constructor() {
-    super({}, 1, 20);
+    super({}, 1, null);
   }
 
   get type(): string {

--- a/framework/core/src/Api/Controller/AbstractListController.php
+++ b/framework/core/src/Api/Controller/AbstractListController.php
@@ -23,4 +23,24 @@ abstract class AbstractListController extends AbstractSerializeController
     }
 
     abstract protected function data(ServerRequestInterface $request, Document $document): iterable;
+
+    protected function addPaginationData(Document $document, ServerRequestInterface $request, string $url, ?int $total): void
+    {
+        $limit = $this->extractLimit($request);
+        $offset = $this->extractOffset($request);
+
+        $document->addPaginationLinks(
+            $url,
+            $request->getQueryParams(),
+            $offset,
+            $limit,
+            $total,
+        );
+
+        $document->setMeta([
+            'total' => $total,
+            'perPage' => $limit,
+            'page' => $offset / $limit + 1,
+        ]);
+    }
 }

--- a/framework/core/src/Api/Controller/AbstractSerializeController.php
+++ b/framework/core/src/Api/Controller/AbstractSerializeController.php
@@ -55,7 +55,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     /**
      * The number of records included by default.
      */
-    public int $limit = 40;
+    public int $limit = 20;
 
     /**
      * The fields that are available to be sorted by.

--- a/framework/core/src/Api/Controller/AbstractSerializeController.php
+++ b/framework/core/src/Api/Controller/AbstractSerializeController.php
@@ -55,7 +55,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     /**
      * The number of records included by default.
      */
-    public int $limit = 20;
+    public int $limit = 40;
 
     /**
      * The fields that are available to be sorted by.

--- a/framework/core/src/Api/Controller/ListDiscussionsController.php
+++ b/framework/core/src/Api/Controller/ListDiscussionsController.php
@@ -64,11 +64,10 @@ class ListDiscussionsController extends AbstractListController
             $results = $this->filterer->filter($criteria, $limit, $offset);
         }
 
-        $document->addPaginationLinks(
+        $this->addPaginationData(
+            $document,
+            $request,
             $this->url->to('api')->route('discussions.index'),
-            $request->getQueryParams(),
-            $offset,
-            $limit,
             $results->areMoreResults() ? null : 0
         );
 

--- a/framework/core/src/Api/Controller/ListNotificationsController.php
+++ b/framework/core/src/Api/Controller/ListNotificationsController.php
@@ -62,11 +62,10 @@ class ListNotificationsController extends AbstractListController
             $areMoreResults = true;
         }
 
-        $document->addPaginationLinks(
+        $this->addPaginationData(
+            $document,
+            $request,
             $this->url->to('api')->route('notifications.index'),
-            $request->getQueryParams(),
-            $offset,
-            $limit,
             $areMoreResults ? null : 0
         );
 

--- a/framework/core/src/Forum/Content/Index.php
+++ b/framework/core/src/Forum/Content/Index.php
@@ -10,6 +10,7 @@
 namespace Flarum\Forum\Content;
 
 use Flarum\Api\Client;
+use Flarum\Api\Controller\ListDiscussionsController;
 use Flarum\Frontend\Document;
 use Flarum\Http\UrlGenerator;
 use Flarum\Locale\TranslatorInterface;
@@ -25,7 +26,8 @@ class Index
         protected Factory $view,
         protected SettingsRepositoryInterface $settings,
         protected UrlGenerator $url,
-        protected TranslatorInterface $translator
+        protected TranslatorInterface $translator,
+        protected ListDiscussionsController $controller
     ) {
     }
 
@@ -39,11 +41,15 @@ class Index
         $filters = Arr::pull($queryParams, 'filter', []);
 
         $sortMap = resolve('flarum.forum.discussions.sortmap');
+        $limit = $this->controller->limit;
 
         $params = [
             'sort' => $sort && isset($sortMap[$sort]) ? $sortMap[$sort] : '',
             'filter' => $filters,
-            'page' => ['offset' => ($page - 1) * 20, 'limit' => 20]
+            'page' => [
+                'offset' => ($page - 1) * $limit,
+                'limit' => $limit
+            ],
         ];
 
         if ($q) {


### PR DESCRIPTION
**Fixes #3861**

**Changes proposed in this pull request:**
* This PR creates a single source of truth for the limit (page size) of API lists.
* The source of truth/limit value is always from the backend controller limit. That way, changing the limit there affects the rest, even frontend listings.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.