### PR TITLE
fix: handled API errors break preloaded content

### DIFF
--- a/extensions/tags/src/Content/Tag.php
+++ b/extensions/tags/src/Content/Tag.php
@@ -96,8 +96,15 @@ class Tag
 
     protected function getTagsDocument(Request $request, string $slug): object
     {
-        return json_decode($this->api->withParentRequest($request)->withQueryParams([
-            'include' => 'children,children.parent,parent,parent.children.parent,state'
-        ])->get("/tags/$slug")->getBody());
+        return json_decode(
+            $this->api
+                ->withoutErrorHandling()
+                ->withParentRequest($request)
+                ->withQueryParams([
+                    'include' => 'children,children.parent,parent,parent.children.parent,state'
+                ])
+                ->get("/tags/$slug")
+                ->getBody()
+        );
     }
 }

--- a/extensions/tags/src/Content/Tags.php
+++ b/extensions/tags/src/Content/Tags.php
@@ -58,8 +58,16 @@ class Tags
 
     protected function getTagsDocument(Request $request): array
     {
-        return json_decode($this->api->withParentRequest($request)->withQueryParams([
-            'include' => 'children,lastPostedDiscussion,parent'
-        ])->get('/tags')->getBody(), true);
+        return json_decode(
+            $this->api
+                ->withoutErrorHandling()
+                ->withParentRequest($request)
+                ->withQueryParams([
+                    'include' => 'children,lastPostedDiscussion,parent'
+                ])
+                ->get('/tags')
+                ->getBody(),
+            true
+        );
     }
 }

--- a/framework/core/src/Api/ApiServiceProvider.php
+++ b/framework/core/src/Api/ApiServiceProvider.php
@@ -114,21 +114,17 @@ class ApiServiceProvider extends AbstractServiceProvider
         });
 
         $this->container->singleton(Client::class, function ($container) {
-            $pipe = new MiddlewarePipe;
-
             $exclude = $container->make('flarum.api_client.exclude_middleware');
 
             $middlewareStack = array_filter($container->make('flarum.api.middleware'), function ($middlewareClass) use ($exclude) {
                 return ! in_array($middlewareClass, $exclude);
             });
 
-            foreach ($middlewareStack as $middleware) {
-                $pipe->pipe($container->make($middleware));
-            }
+            $middlewareStack[] = HttpMiddleware\ExecuteRoute::class;
 
-            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
-
-            return new Client($pipe);
+            return new Client(
+                new ClientMiddlewarePipe($container, $middlewareStack)
+            );
         });
     }
 

--- a/framework/core/src/Api/Client.php
+++ b/framework/core/src/Api/Client.php
@@ -23,9 +23,10 @@ class Client
     protected ?ServerRequestInterface $parent = null;
     protected array $queryParams = [];
     protected array $body = [];
+    protected bool $errorHandling = true;
 
     public function __construct(
-        protected MiddlewarePipeInterface $pipe
+        protected ClientMiddlewarePipe $pipe
     ) {
     }
 
@@ -62,6 +63,22 @@ class Client
     {
         $new = clone $this;
         $new->body = $body;
+
+        return $new;
+    }
+
+    public function withoutErrorHandling(): Client
+    {
+        $new = clone $this;
+        $new->errorHandling = false;
+
+        return $new;
+    }
+
+    public function withErrorHandling(): Client
+    {
+        $new = clone $this;
+        $new->errorHandling = true;
 
         return $new;
     }
@@ -114,6 +131,8 @@ class Client
             $request = RequestUtil::withActor($request, $this->actor);
         }
 
-        return $this->pipe->handle($request);
+        return $this->pipe
+            ->errorHandling($this->errorHandling)
+            ->handle($request);
     }
 }

--- a/framework/core/src/Api/Client.php
+++ b/framework/core/src/Api/Client.php
@@ -13,7 +13,6 @@ use Flarum\Http\RequestUtil;
 use Flarum\User\User;
 use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\Diactoros\Uri;
-use Laminas\Stratigility\MiddlewarePipeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/framework/core/src/Api/ClientMiddlewarePipe.php
+++ b/framework/core/src/Api/ClientMiddlewarePipe.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Flarum\Api;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Collection;
+use Laminas\Stratigility\MiddlewarePipe;
+use Laminas\Stratigility\MiddlewarePipeInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ClientMiddlewarePipe implements MiddlewarePipeInterface
+{
+    protected Collection $middlewares;
+    protected MiddlewarePipeInterface $pipe;
+
+    public function __construct(
+        protected Container $container,
+        array $middlewares
+    ) {
+        $this->middlewares = new Collection($middlewares);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $this->getPipe()->process($request, $handler);
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->getPipe()->handle($request);
+    }
+
+    public function pipe(MiddlewareInterface $middleware): void
+    {
+        $this->middlewares->push($middleware);
+    }
+
+    protected function getPipe(): MiddlewarePipeInterface
+    {
+        if (isset($this->pipe)) {
+            return $this->pipe;
+        }
+
+        $this->pipe = new MiddlewarePipe();
+
+        foreach ($this->middlewares as $middleware) {
+            $this->pipe->pipe($this->container->make($middleware));
+        }
+
+        return $this->pipe;
+    }
+
+    public function errorHandling(bool $handleErrors): static
+    {
+        $errorHandler = 'flarum.api.error_handler';
+
+        if ($handleErrors && ! $this->middlewares->contains($errorHandler)) {
+            $this->middlewares = $this->middlewares->prepend($errorHandler);
+        } elseif (! $handleErrors && $this->middlewares->contains($errorHandler)) {
+            $this->middlewares = $this->middlewares->reject($errorHandler);
+        }
+
+        return $this;
+    }
+}

--- a/framework/core/src/Api/ClientMiddlewarePipe.php
+++ b/framework/core/src/Api/ClientMiddlewarePipe.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Api;
 
 use Illuminate\Contracts\Container\Container;

--- a/framework/core/src/Forum/Content/Discussion.php
+++ b/framework/core/src/Forum/Content/Discussion.php
@@ -95,16 +95,14 @@ class Discussion
     protected function getApiDocument(Request $request, string $id, array $params): object
     {
         $params['bySlug'] = true;
-        $response = $this->api
-            ->withParentRequest($request)
-            ->withQueryParams($params)
-            ->get("/discussions/$id");
-        $statusCode = $response->getStatusCode();
 
-        if ($statusCode === 404) {
-            throw new RouteNotFoundException;
-        }
-
-        return json_decode($response->getBody());
+        return json_decode(
+            $this->api
+                ->withoutErrorHandling()
+                ->withParentRequest($request)
+                ->withQueryParams($params)
+                ->get("/discussions/$id")
+                ->getBody()
+        );
     }
 }

--- a/framework/core/src/Forum/Content/Index.php
+++ b/framework/core/src/Forum/Content/Index.php
@@ -69,6 +69,13 @@ class Index
      */
     protected function getApiDocument(Request $request, array $params): object
     {
-        return json_decode($this->api->withParentRequest($request)->withQueryParams($params)->get('/discussions')->getBody());
+        return json_decode(
+            $this->api
+                ->withoutErrorHandling()
+                ->withParentRequest($request)
+                ->withQueryParams($params)
+                ->get('/discussions')
+                ->getBody()
+        );
     }
 }

--- a/framework/core/src/Forum/Content/User.php
+++ b/framework/core/src/Forum/Content/User.php
@@ -46,13 +46,12 @@ class User
      */
     protected function getApiDocument(Request $request, string $username): object
     {
-        $response = $this->api->withParentRequest($request)->withQueryParams(['bySlug' => true])->get("/users/$username");
-        $statusCode = $response->getStatusCode();
-
-        if ($statusCode === 404) {
-            throw new ModelNotFoundException;
-        }
-
-        return json_decode($response->getBody());
+        return json_decode(
+            $this->api
+                ->withoutErrorHandling()
+                ->withParentRequest($request)
+                ->withQueryParams(['bySlug' => true])
+                ->get("/users/$username")->getBody()
+        );
     }
 }

--- a/framework/core/src/Frontend/Frontend.php
+++ b/framework/core/src/Frontend/Frontend.php
@@ -59,7 +59,9 @@ class Frontend
     private function getForumDocument(Request $request): array
     {
         return $this->getResponseBody(
-            $this->api->withParentRequest($request)->get('/')
+            $this->api->withoutErrorHandling()
+                ->withParentRequest($request)
+                ->get('/')
         );
     }
 


### PR DESCRIPTION
**Fixes flarum/issue-archive#39**

**Changes proposed in this pull request:**
* Frontend content such as the `Discussion` page or the `IndexPage` run calls to the API using the internal API client. When that process errors out, it is handled by the API error handler which means we get a JSON response other than what we expect, leading to incomprehensible error pages where the frontend is broken, even when it is a simple 404 or 403 exception.
* In this case we want the exceptions/errors not to be handled by the API client, but instead propagate to the forum/admin error handler.
* But there are other cases where we want the client to handle the errors, such as in a testing context where we might be testing error response structure.
* This PR adds a way to tell the client when to handle errors and when not to do so. We tell the client not to handle errors for all preloaded content.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.