### PR TITLE
fix(testing): use cookie for testing authentication

### DIFF
--- a/framework/core/tests/integration/admin/IndexTest.php
+++ b/framework/core/tests/integration/admin/IndexTest.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Tests\integration\forum;
+namespace Flarum\Tests\integration\admin;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -28,31 +28,25 @@ class IndexTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function guest_not_serialized_by_current_user_serializer()
+    public function admin_can_access_admin_route(): void
     {
         $response = $this->send(
-            $this->request('GET', '/')
-        );
-
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringNotContainsString('preferences', $response->getBody()->getContents());
-    }
-
-    /**
-     * @test
-     */
-    public function user_serialized_by_current_user_serializer()
-    {
-        $response = $this->send(
-            $this->request('GET', '/', [
-                'authenticatedAs' => 2,
+            $this->request('GET', '/admin', [
+                'authenticatedAs' => 1,
             ])
         );
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringContainsString('preferences', $response->getBody()->getContents());
+    }
+
+    public function user_cannot_access_admin_route(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/admin', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
     }
 }

--- a/framework/core/tests/integration/forum/GlobalLogoutTest.php
+++ b/framework/core/tests/integration/forum/GlobalLogoutTest.php
@@ -59,19 +59,12 @@ class GlobalLogoutTest extends TestCase
      * @dataProvider canGloballyLogoutDataProvider
      * @test
      */
-    public function can_globally_log_out(int $authenticatedAs, string $identification, string $password)
+    public function can_globally_log_out(int $authenticatedAs)
     {
-        $loginResponse = $this->send(
-            $this->request('POST', '/login', [
-                'json' => compact('identification', 'password')
-            ])
-        );
-
         $response = $this->send(
-            $this->requestWithCookiesFrom(
-                $this->request('POST', '/global-logout'),
-                $loginResponse,
-            )
+            $this->request('POST', '/global-logout', [
+                'authenticatedAs' => $authenticatedAs,
+            ]),
         );
 
         $this->assertEquals(204, $response->getStatusCode());
@@ -85,10 +78,10 @@ class GlobalLogoutTest extends TestCase
     {
         return [
             // Admin
-            [1, 'admin', 'password'],
+            [1],
 
             // Normal user
-            [2, 'normal', 'too-obscure'],
+            [2],
         ];
     }
 }

--- a/php-packages/testing/src/integration/BuildsHttpRequests.php
+++ b/php-packages/testing/src/integration/BuildsHttpRequests.php
@@ -11,6 +11,7 @@ namespace Flarum\Testing\integration;
 
 use Carbon\Carbon;
 use Dflydev\FigCookies\SetCookie;
+use Flarum\Http\CookieFactory;
 use Illuminate\Support\Str;
 use Laminas\Diactoros\CallbackStream;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -46,11 +47,14 @@ trait BuildsHttpRequests
             'user_id' => $userId,
             'created_at' => Carbon::now()->toDateTimeString(),
             'last_activity_at' => Carbon::now()->toDateTimeString(),
-            'type' => 'session'
+            'type' => 'session_remember'
         ]);
 
+        $cookies = $this->app()->getContainer()->make(CookieFactory::class);
+
         return $req
-            ->withAddedHeader('Authorization', "Token {$token}")
+            ->withAttribute('bypassCsrfToken', true)
+            ->withCookieParams([$cookies->getName('remember') => $token])
             // We save the token as an attribute so that we can retrieve it for test purposes.
             ->withAttribute('tests_token', $token);
     }


### PR DESCRIPTION
**Fixes #3834**

**Changes proposed in this pull request:**
* The `authenticatedAs` testing option makes use of an authorization header to authenticate the user, this only works on the `api` frontend, for forum or admin frontends we've always had to make a normal identification/password request to the login endpoint and use the generated cookie to run our tests. This isn't ideal.
* This PR changed the `autheticatedAs` option to rely on a remember cookie by default. Which makes testing easier.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Tests have been added, or are not appropriate here.