### PR TITLE
Add fallback timeout to reset `modalClosing` flag in `ModalManager`

### DIFF
--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -173,7 +173,21 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
       closedCallback();
     };
 
-    this.activeDialogElement.addEventListener('transitionend', afterModalClosedCallback, { once: true });
+    // Set a fallback timeout to ensure the modalClosing flag is reset
+    // If not reset, there could be another modal that cannot be closed anymore
+    // because the modalClosing flag is still set to true
+    const timeoutId = setTimeout(() => {
+      this.modalClosing = false;
+    }, 1000);
+
+    this.activeDialogElement.addEventListener(
+      'transitionend',
+      () => {
+        clearTimeout(timeoutId); // Clear the timeout if transition ends
+        afterModalClosedCallback();
+      },
+      { once: true }
+    );
 
     this.activeDialogElement.classList.remove('in');
     this.activeDialogElement.classList.add('out');


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Added a fallback timeout to the `animateHide` function to ensure the `modalClosing` flag is reset. This change aims to prevent potential issues where a modal could become unresponsive if the `modalClosing` flag remains set to `true`.

**Reviewers should focus on:**
- The implementation of the timeout in the `animateHide` function. 
- Ensuring that the addition of the timeout and the clearTimeout call do not introduce any regressions or unintended side effects.

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
