### PR TITLE
chore: use `hex_color` rule for color validation

### DIFF
--- a/extensions/tags/src/TagValidator.php
+++ b/extensions/tags/src/TagValidator.php
@@ -18,6 +18,6 @@ class TagValidator extends AbstractValidator
         'slug' => ['required', 'unique:tags', 'regex:/^[^\/\\ ]*$/i'],
         'is_hidden' => ['bool'],
         'description' => ['string', 'max:700'],
-        'color' => ['regex:/^#([a-f0-9]{6}|[a-f0-9]{3})$/i'],
+        'color' => ['hex_color'],
     ];
 }

--- a/framework/core/locale/validation.yml
+++ b/framework/core/locale/validation.yml
@@ -41,6 +41,7 @@ validation:
     file: "The :attribute must be greater than or equal :value kilobytes."
     string: "The :attribute must be greater than or equal :value characters."
     array: "The :attribute must have :value items or more."
+  hex_color: "The :attribute field must be a valid hexadecimal color."
   image: "The :attribute must be an image."
   in: "The selected :attribute is invalid."
   in_array: "The :attribute field does not exist in :other."


### PR DESCRIPTION
Add the `hex_color` rule to Laravel's validation system for improved color validation.

See here: https://github.com/laravel/framework/pull/49056

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
