### PR TITLE
Fix clear search button height issue

### DIFF
--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -86,6 +86,7 @@
     top: 0;
     margin-left: -36px;
     width: 36px !important;
+    height: 100%;
 
     &.LoadingIndicator {
       width: var(--size) !important;


### PR DESCRIPTION
Before:

![Screenshot 2023-11-25 at 23 40 09](https://github.com/flarum/framework/assets/56961917/136b46c5-ceac-47dc-b2fa-fa1b73fb01de)

After: (by adding `height: 100%` to `.Search-input .Button`)

![Screenshot 2023-11-25 at 23 40 21](https://github.com/flarum/framework/assets/56961917/5f1fa378-5a21-4631-9c18-2f77a89c8cc4)
**Fixes #0000**


**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
