### PR TITLE
fix: notify for all posts switch field loading state

### DIFF
--- a/extensions/subscriptions/js/src/forum/addSubscriptionSettings.tsx
+++ b/extensions/subscriptions/js/src/forum/addSubscriptionSettings.tsx
@@ -29,8 +29,14 @@ export default function () {
         id="flarum_subscriptions__notify_for_all_posts"
         state={!!this.user!.preferences()?.['flarum-subscriptions.notify_for_all_posts']}
         onchange={(val: boolean) => {
-          this.user!.savePreferences({ 'flarum-subscriptions.notify_for_all_posts': val });
+          this.notifyForAllPostsLoading = true;
+
+          this.user!.savePreferences({ 'flarum-subscriptions.notify_for_all_posts': val }).then(() => {
+            this.notifyForAllPostsLoading = false;
+            m.redraw();
+          });
         }}
+        loading={this.notifyForAllPostsLoading}
       >
         {app.translator.trans('flarum-subscriptions.forum.settings.notify_for_all_posts_label')}
       </Switch>


### PR DESCRIPTION
All the others have their own loading state, but `notifyForAllPosts` has no loading state. So this PR is add loading state to this field

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
