### PR TITLE
Fix width issue in edit user modal

### DIFF
--- a/framework/core/js/src/common/components/EditUserModal.tsx
+++ b/framework/core/js/src/common/components/EditUserModal.tsx
@@ -101,20 +101,22 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
           'password',
           <div className="Form-group">
             <label>{app.translator.trans('core.lib.edit_user.password_heading')}</label>
-            <label className="checkbox">
-              <input
-                type="checkbox"
-                onchange={(e: KeyboardEvent) => {
-                  const target = e.target as HTMLInputElement;
-                  this.setPassword(target.checked);
-                  m.redraw.sync();
-                  if (target.checked) this.$('[name=password]').select();
-                  e.redraw = false;
-                }}
-                disabled={this.nonAdminEditingAdmin()}
-              />
-              {app.translator.trans('core.lib.edit_user.set_password_label')}
-            </label>
+            <div>
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  onchange={(e: KeyboardEvent) => {
+                    const target = e.target as HTMLInputElement;
+                    this.setPassword(target.checked);
+                    m.redraw.sync();
+                    if (target.checked) this.$('[name=password]').select();
+                    e.redraw = false;
+                  }}
+                  disabled={this.nonAdminEditingAdmin()}
+                />
+                {app.translator.trans('core.lib.edit_user.set_password_label')}
+              </label>
+            </div>
             {this.setPassword() && (
               <input
                 className="FormControl"

--- a/framework/core/js/src/common/components/EditUserModal.tsx
+++ b/framework/core/js/src/common/components/EditUserModal.tsx
@@ -82,20 +82,16 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
           'email',
           <div className="Form-group">
             <label>{app.translator.trans('core.lib.edit_user.email_heading')}</label>
-            <div>
-              <input
-                className="FormControl"
-                placeholder={extractText(app.translator.trans('core.lib.edit_user.email_label'))}
-                bidi={this.email}
-                disabled={this.nonAdminEditingAdmin()}
-              />
-            </div>
+            <input
+              className="FormControl"
+              placeholder={extractText(app.translator.trans('core.lib.edit_user.email_label'))}
+              bidi={this.email}
+              disabled={this.nonAdminEditingAdmin()}
+            />
             {!this.isEmailConfirmed() && this.userIsAdmin(app.session.user) && (
-              <div>
-                <Button className="Button Button--block" loading={this.loading} onclick={this.activate.bind(this)}>
-                  {app.translator.trans('core.lib.edit_user.activate_button')}
-                </Button>
-              </div>
+              <Button className="Button Button--block" loading={this.loading} onclick={this.activate.bind(this)}>
+                {app.translator.trans('core.lib.edit_user.activate_button')}
+              </Button>
             )}
           </div>,
           30
@@ -105,32 +101,30 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
           'password',
           <div className="Form-group">
             <label>{app.translator.trans('core.lib.edit_user.password_heading')}</label>
-            <div>
-              <label className="checkbox">
-                <input
-                  type="checkbox"
-                  onchange={(e: KeyboardEvent) => {
-                    const target = e.target as HTMLInputElement;
-                    this.setPassword(target.checked);
-                    m.redraw.sync();
-                    if (target.checked) this.$('[name=password]').select();
-                    e.redraw = false;
-                  }}
-                  disabled={this.nonAdminEditingAdmin()}
-                />
-                {app.translator.trans('core.lib.edit_user.set_password_label')}
-              </label>
-              {this.setPassword() && (
-                <input
-                  className="FormControl"
-                  type="password"
-                  name="password"
-                  placeholder={extractText(app.translator.trans('core.lib.edit_user.password_label'))}
-                  bidi={this.password}
-                  disabled={this.nonAdminEditingAdmin()}
-                />
-              )}
-            </div>
+            <label className="checkbox">
+              <input
+                type="checkbox"
+                onchange={(e: KeyboardEvent) => {
+                  const target = e.target as HTMLInputElement;
+                  this.setPassword(target.checked);
+                  m.redraw.sync();
+                  if (target.checked) this.$('[name=password]').select();
+                  e.redraw = false;
+                }}
+                disabled={this.nonAdminEditingAdmin()}
+              />
+              {app.translator.trans('core.lib.edit_user.set_password_label')}
+            </label>
+            {this.setPassword() && (
+              <input
+                className="FormControl"
+                type="password"
+                name="password"
+                placeholder={extractText(app.translator.trans('core.lib.edit_user.password_label'))}
+                bidi={this.password}
+                disabled={this.nonAdminEditingAdmin()}
+              />
+            )}
           </div>,
           20
         );


### PR DESCRIPTION
The input width gets affected when wrapped within a div in a `.Form-group`. This PR aims to unwrap these inputs from the div tag to prevent width loss

Before:
![Screenshot 2023-11-26 at 00 00 12](https://github.com/flarum/framework/assets/56961917/0098ebdc-9891-49cc-9b50-0aee9b2c9e5a)

After:
![Screenshot 2023-11-26 at 00 00 28](https://github.com/flarum/framework/assets/56961917/93aaa79d-f00e-4688-96bd-429e4af9421c)


**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
