### PR TITLE
fix: overflowing forum stats

### DIFF
--- a/extensions/statistics/less/admin.less
+++ b/extensions/statistics/less/admin.less
@@ -18,6 +18,7 @@
     display: flex;
     align-items: flex-end;
     margin: 0 20px;
+    overflow: auto;
 
     & > :not(:last-child) {
       margin-right: 10px;


### PR DESCRIPTION
before
![Screenshot 2023-11-26 at 00 06 55](https://github.com/flarum/framework/assets/56961917/d9646c4a-d5dd-442a-b39d-fbc2942b6eae)

after
![Screenshot 2023-11-26 at 00 07 37](https://github.com/flarum/framework/assets/56961917/d90b4601-9931-4f0e-9ccd-5fda5998ea61)

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
