### PR TITLE
chore: improve debugging experience

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -604,7 +604,9 @@ export default class Application {
         console.groupEnd();
       }
 
-      if (e.alert) {
+      if (e.status === 500 && isDebug) {
+        app.modal.show(RequestErrorModal, { error: e, formattedError: formattedErrors });
+      } else if (e.alert) {
         this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
       }
     } else {

--- a/framework/core/js/src/common/components/RequestErrorModal.tsx
+++ b/framework/core/js/src/common/components/RequestErrorModal.tsx
@@ -30,6 +30,19 @@ export default class RequestErrorModal<CustomAttrs extends IRequestErrorModalAtt
       responseText = error.responseText;
     }
 
+    if (responseText?.includes('<script> Sfdump = window.Sfdump')) {
+      responseText = (
+        <iframe
+          srcdoc={responseText}
+          className="RequestErrorModal-iframe"
+          onload={(e: Event) => {
+            const iframe = e.target as HTMLIFrameElement;
+            iframe.style.height = (iframe.contentWindow?.document.body.offsetHeight || 0) + 50 + 'px';
+          }}
+        />
+      );
+    }
+
     return (
       <div className="Modal-body">
         <pre>

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -137,6 +137,12 @@ blockquote ol:last-child {
     white-space: pre-wrap;
     margin: 0;
   }
+
+  &-iframe {
+    width: 100%;
+    max-height: 90vh;
+    border: 0;
+  }
 }
 
 #flarum-loading {


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Auto displays the error modal with evaluated var dumper output when the API returns 500 and we are in debugging mode.
* This improves the development/debugging experience for developers

![image](https://github.com/flarum/framework/assets/20267363/bb0249a3-de4c-429b-a3d7-c595a797d602)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
