### PR TITLE
fix(1.x): textformatter `2.15` has breaking changes

### DIFF
--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -75,7 +75,7 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "s9e/text-formatter": "^2.3.6",
+        "s9e/text-formatter": ">=2.3.6 <2.15",
         "staudenmeir/eloquent-eager-limit": "^1.0",
         "sycho/json-api": "^0.5.0",
         "sycho/sourcemap": "^2.0.0",


### PR DESCRIPTION
**Changes proposed in this pull request:**
The recent 2.15 textformatter release seems to have some breaking changes:
* https://discuss.flarum.org/d/33746-an-error-occurred-while-trying-to-load-this-page/15
* https://github.com/s9e/TextFormatter/issues/226

Best to prevent updates to it for now until further notice for the 1.x line

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.