### PR TITLE
[1.x] fix: Logout controller allows open redirects

### DIFF
--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -124,10 +124,11 @@ class LogOutController implements RequestHandlerInterface
         return $this->rememberer->forget($response);
     }
 
-    protected function sanitizeReturnUrl(string $url, string $base): string
+    protected function sanitizeReturnUrl(string $url, string $base): Uri
     {
+        $parsedBase = new Uri($base);
         if (empty($url)) {
-            return $base; // Return base URL for empty return URL
+            return $parsedBase; // Return base URL for empty return URL
         }
         
         $parsed = new Uri($url);
@@ -135,10 +136,10 @@ class LogOutController implements RequestHandlerInterface
         $host = $parsed->getHost();
 
         if (in_array($host, $this->getWhitelistedRedirectDomains())) {
-            return $url;
+            return $parsed;
         }
 
-        return $base; // Return base url for non-whitelisted domains
+        return $parsedBase; // Return base url for non-whitelisted domains
     }
 
     protected function getWhitelistedRedirectDomains(): array

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -93,8 +93,8 @@ class LogOutController implements RequestHandlerInterface
         $actor = RequestUtil::getActor($request);
         $base = $this->url->to('forum')->base();
 
-        $rurl = (string) Arr::get($request->getQueryParams(), 'return');
-        $return = $this->sanitizeReturnUrl($rurl, $base);
+        $rurl = Arr::get($request->getQueryParams(), 'return');
+        $return = $this->sanitizeReturnUrl((string) $rurl, $base);
 
         // If there is no user logged in, return to the index or the return url if it's set.
         if ($actor->isGuest()) {
@@ -107,7 +107,7 @@ class LogOutController implements RequestHandlerInterface
 
         if (Arr::get($request->getQueryParams(), 'token') !== $csrfToken) {
             $view = $this->view->make('flarum.forum::log-out')
-                ->with('url', $this->url->to('forum')->route('logout') . '?token=' . $csrfToken . ($return ? '&return=' . urlencode($return) : ''));
+                ->with('url', $this->url->to('forum')->route('logout') . '?token=' . $csrfToken . ($rurl ? '&return=' . urlencode($return) : ''));
 
             return new HtmlResponse($view->render());
         }

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -107,7 +107,7 @@ class LogOutController implements RequestHandlerInterface
             $return = $this->sanitizeReturnUrl($request->getQueryParams()['return'] ?? $base);
 
             $view = $this->view->make('flarum.forum::log-out')
-                ->with('url', $this->url->to('forum')->route('logout').'?token='.$csrfToken.($return ? '&return='.urlencode($return) : ''));
+                ->with('url', $this->url->to('forum')->route('logout') . '?token=' . $csrfToken . ($return ? '&return=' . urlencode($return) : ''));
 
             return new HtmlResponse($view->render());
         }
@@ -128,8 +128,8 @@ class LogOutController implements RequestHandlerInterface
     {
         $parsed = parse_url($url);
 
-        if (! $parsed || ! isset($parsed['host'])) {
-            return '';
+        if (!$parsed || !isset($parsed['host'])) {
+            return ''; // Return early for invalid URLs
         }
 
         $host = $parsed['host'];
@@ -138,14 +138,14 @@ class LogOutController implements RequestHandlerInterface
             return $url;
         }
 
-        return '';
+        return ''; // Return empty string for non-whitelisted domains
     }
 
     protected function getWhitelistedRedirectDomains(): array
     {
         return array_merge(
             [$this->config->url()],
-            $this->config->offsetGet('trustedHosts') ?? []
+            $this->config->offsetGet('redirectDomains') ?? []
         );
     }
 }

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -139,7 +139,6 @@ class LogOutController implements RequestHandlerInterface
         return new Uri($base);
     }
 
-
     protected function getWhitelistedRedirectDomains(): array
     {
         $forumUri = new Uri($this->config->url());

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -21,6 +21,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -129,13 +130,9 @@ class LogOutController implements RequestHandlerInterface
             return $base; // Return base URL for empty return URL
         }
         
-        $parsed = parse_url($url);
+        $parsed = new Uri($url);
 
-        if (!$parsed || !isset($parsed['host'])) {
-            return $base; // Return early for invalid URLs
-        }
-
-        $host = $parsed['host'];
+        $host = $parsed->getHost();
 
         if (in_array($host, $this->getWhitelistedRedirectDomains())) {
             return $url;
@@ -146,14 +143,10 @@ class LogOutController implements RequestHandlerInterface
 
     protected function getWhitelistedRedirectDomains(): array
     {
-        $forumUrl = $this->config->url();
-        $parsedForumUrl = parse_url($forumUrl);
-
-        // Extract the host from the parsed forum URL
-        $forumHost = isset($parsedForumUrl['host']) ? $parsedForumUrl['host'] : '';
-
+        $forumUri = new Uri($this->config->url());
+        
         return array_merge(
-            [$forumHost],
+            [$forumUri->getHost()],
             $this->config->offsetGet('redirectDomains') ?? []
         );
     }

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -130,7 +130,11 @@ class LogOutController implements RequestHandlerInterface
             return new Uri($base);
         }
 
-        $parsedUrl = new Uri($url);
+        try {
+            $parsedUrl = new Uri($url);
+        } catch (\InvalidArgumentException $e) {
+            return new Uri($base);
+        }
 
         if (in_array($parsedUrl->getHost(), $this->getWhitelistedRedirectDomains())) {
             return $parsedUrl;

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -93,8 +93,8 @@ class LogOutController implements RequestHandlerInterface
         $actor = RequestUtil::getActor($request);
         $base = $this->url->to('forum')->base();
 
-        $rurl = Arr::get($request->getQueryParams(), 'return');
-        $return = $this->sanitizeReturnUrl((string) $rurl, $base);
+        $returnUrl = Arr::get($request->getQueryParams(), 'return');
+        $return = $this->sanitizeReturnUrl((string) $returnUrl, $base);
 
         // If there is no user logged in, return to the index or the return url if it's set.
         if ($actor->isGuest()) {
@@ -107,7 +107,7 @@ class LogOutController implements RequestHandlerInterface
 
         if (Arr::get($request->getQueryParams(), 'token') !== $csrfToken) {
             $view = $this->view->make('flarum.forum::log-out')
-                ->with('url', $this->url->to('forum')->route('logout') . '?token=' . $csrfToken . ($rurl ? '&return=' . urlencode($return) : ''));
+                ->with('url', $this->url->to('forum')->route('logout') . '?token=' . $csrfToken . ($returnUrl ? '&return=' . urlencode($return) : ''));
 
             return new HtmlResponse($view->render());
         }
@@ -136,16 +136,16 @@ class LogOutController implements RequestHandlerInterface
             return new Uri($base);
         }
 
-        if (in_array($parsedUrl->getHost(), $this->getWhitelistedRedirectDomains())) {
+        if (in_array($parsedUrl->getHost(), $this->getAllowedRedirectDomains())) {
             return $parsedUrl;
         }
 
         return new Uri($base);
     }
 
-    protected function getWhitelistedRedirectDomains(): array
+    protected function getAllowedRedirectDomains(): array
     {
-        $forumUri = new Uri($this->config->url());
+        $forumUri = $this->config->url();
 
         return array_merge(
             [$forumUri->getHost()],

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -126,26 +126,24 @@ class LogOutController implements RequestHandlerInterface
 
     protected function sanitizeReturnUrl(string $url, string $base): Uri
     {
-        $parsedBase = new Uri($base);
         if (empty($url)) {
-            return $parsedBase; // Return base URL for empty return URL
-        }
-        
-        $parsed = new Uri($url);
-
-        $host = $parsed->getHost();
-
-        if (in_array($host, $this->getWhitelistedRedirectDomains())) {
-            return $parsed;
+            return new Uri($base);
         }
 
-        return $parsedBase; // Return base url for non-whitelisted domains
+        $parsedUrl = new Uri($url);
+
+        if (in_array($parsedUrl->getHost(), $this->getWhitelistedRedirectDomains())) {
+            return $parsedUrl;
+        }
+
+        return new Uri($base);
     }
+
 
     protected function getWhitelistedRedirectDomains(): array
     {
         $forumUri = new Uri($this->config->url());
-        
+
         return array_merge(
             [$forumUri->getHost()],
             $this->config->offsetGet('redirectDomains') ?? []

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -92,11 +92,11 @@ class LogOutController implements RequestHandlerInterface
         $actor = RequestUtil::getActor($request);
         $base = $this->url->to('forum')->base();
 
-        $url = Arr::get($request->getQueryParams(), 'return', $base);
+        $sanitizedUrl = $this->sanitizeReturnUrl((string) Arr::get($request->getQueryParams(), 'return', $base));
 
         // If there is no user logged in, return to the index.
         if ($actor->isGuest()) {
-            return new RedirectResponse($base);
+            return new RedirectResponse(empty($sanitizedUrl) ? $base : $sanitizedUrl);
         }
 
         // If a valid CSRF token hasn't been provided, show a view which will
@@ -113,7 +113,7 @@ class LogOutController implements RequestHandlerInterface
         }
 
         $accessToken = $session->get('access_token');
-        $response = new RedirectResponse($url);
+        $response = new RedirectResponse($sanitizedUrl);
 
         $this->authenticator->logOut($session);
 


### PR DESCRIPTION
Prevents open redirects on the `LogoutController`

By default, only return URL's on the forum host are permitted. Additional domains may be whitelisted using `config.php`:

```php
...
  'redirectDomains' =>
  array (
    'trusted.com`,
    'another-trusted.org'
  )
```