### PR TITLE
fix: use dynamic viewport units for height of Modals

### DIFF
--- a/framework/core/less/common/Modal.less
+++ b/framework/core/less/common/Modal.less
@@ -149,7 +149,7 @@
     margin: 0;
     -webkit-transform: none !important;
     transform: none !important;
-    top: 100vh;
+    top: 100dvh;
 
     &.fade {
       opacity: 1;
@@ -162,7 +162,7 @@
   .Modal-content {
     border-radius: 0;
     border: 0;
-    min-height: 100vh;
+    min-height: 100dvh;
     padding-top: var(--header-height-phone);
     box-shadow: none;
   }


### PR DESCRIPTION
**Fixes #3950**

**Changes proposed in this pull request:**
This change addresses an issue where the height and position of Modals on mobile is inconsistent. I propose to use [dynamic viewport units](https://web.dev/blog/viewport-units) which take UI elements of the browser/device into consideration and adjusts the height accordingly. 

**Reviewers should focus on:**
Since nearly every browser on a reasonable version supports dynamic viewport units, I'm not sure if it makes sense to include the fallback everywhere. Maybe it would make more sense to automatically add fallback values when the CSS is complied?

**Screenshot**

https://github.com/flarum/framework/assets/146922689/2d276ef7-e433-48ee-b9fd-34b7fa99971d

**QA**
**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
