### PR TITLE
[1.x] fix(Mentions): allow renderer to be used without context

### DIFF
--- a/extensions/mentions/src/Formatter/FormatPostMentions.php
+++ b/extensions/mentions/src/Formatter/FormatPostMentions.php
@@ -11,6 +11,7 @@ namespace Flarum\Mentions\Formatter;
 
 use Flarum\Discussion\Discussion;
 use Flarum\Http\SlugManager;
+use Flarum\Post\Post;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Utils;
@@ -39,16 +40,17 @@ class FormatPostMentions
      *
      * @param \s9e\TextFormatter\Renderer $renderer
      * @param mixed $context
-     * @param string|null $xml
-     * @param \Psr\Http\Message\ServerRequestInterface $request
-     * @return string
+     * @param string $xml
+     * @param \Psr\Http\Message\ServerRequestInterface|null $request
+     * @return string $xml to be rendered
      */
     public function __invoke(Renderer $renderer, $context, $xml, Request $request = null)
     {
-        $post = $context;
+        return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($context) {
+            $post = (($context && isset($context->getRelations()['mentionsPosts'])) || $context instanceof Post)
+                ? $context->mentionsPosts->find($attributes['id'])
+                : Post::find($attributes['id']);
 
-        return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($post) {
-            $post = $post->mentionsPosts->find($attributes['id']);
             if ($post && $post->user) {
                 $attributes['displayname'] = $post->user->display_name;
             }

--- a/extensions/mentions/src/Formatter/UnparsePostMentions.php
+++ b/extensions/mentions/src/Formatter/UnparsePostMentions.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Mentions\Formatter;
 
+use Flarum\Post\Post;
 use s9e\TextFormatter\Utils;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -50,8 +51,11 @@ class UnparsePostMentions
     {
         $post = $context;
 
-        return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($post) {
-            $post = $post->mentionsPosts->find($attributes['id']);
+        return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($context) {
+            $post = (($context && isset($context->getRelations()['mentionsPosts'])) || $context instanceof Post)
+                ? $context->mentionsPosts->find($attributes['id'])
+                : Post::find($attributes['id']);
+
             if ($post && $post->user) {
                 $attributes['displayname'] = $post->user->display_name;
             }

--- a/extensions/mentions/tests/integration/api/PostMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/PostMentionsTest.php
@@ -11,6 +11,8 @@ namespace Flarum\Mentions\Tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Extend;
+use Flarum\Formatter\Formatter;
+use Flarum\Post\Post;
 use Flarum\Post\CommentPost;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -538,6 +540,41 @@ class PostMentionsTest extends TestCase
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(11));
     }
+
+    /**
+     * @test
+     */
+    public function rendering_post_mention_with_a_post_context_works()
+    {
+        /** @var Formatter $formatter */
+        $formatter = $this->app()->getContainer()->make(Formatter::class);
+
+        $post = Post::find(4);
+        $user = User::find(1);
+
+        $xml = $formatter->parse($post->content, $post, $user);
+        $renderedHtml = $formatter->render($xml, $post);
+
+        $this->assertStringContainsString('TOBY$', $renderedHtml);
+    }
+
+    /**
+     * @test
+     */
+    public function rendering_post_mention_without_a_context_works()
+    {
+        /** @var Formatter $formatter */
+        $formatter = $this->app()->getContainer()->make(Formatter::class);
+
+        $post = Post::find(4);
+        $user = User::find(1);
+
+        $xml = $formatter->parse($post->content, null, $user);
+        $renderedHtml = $formatter->render($xml);
+
+        $this->assertStringContainsString('TOBY$', $renderedHtml);
+    }
+
 }
 
 class CustomOtherDisplayNameDriver implements DriverInterface


### PR DESCRIPTION
**Changes proposed in this pull request:**
Allow post mentions to be used without context. As far as I understand, the same thing has already been done for user mentions in the past:

- https://github.com/flarum/mentions/commit/c9d70a844c0a9eb8e9c5d63eb2f7fee3185ac370
- https://github.com/flarum/mentions/commit/344abc0f87a1d1514f650b247f9d7511b5245088

**Reviewers should focus on:**
Focus if this PR introduces regression in other parts of the code. I'll also have a quick look and see if I can quickly create a test which tests this.

**Screenshot**
_Not applicable_

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
