### PR TITLE
[2.x] feat: support composer auth in workflows

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -52,10 +52,16 @@ on:
         required: false
         default: error_reporting=E_ALL
 
+    secrets:
+      composer_auth:
+        description: The Composer auth tokens to use for private packages.
+        required: false
+
 env:
   COMPOSER_ROOT_VERSION: dev-main
   # `inputs.composer_directory` defaults to `inputs.backend_directory`
   FLARUM_TEST_TMP_DIR_LOCAL: tests/integration/tmp
+  COMPOSER_AUTH: ${{ secrets.composer_auth }}
 
 jobs:
   test:

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -90,11 +90,15 @@ on:
       bundlewatch_github_token:
         description: The GitHub token to use for Bundlewatch.
         required: false
+      composer_auth:
+        description: The Composer auth tokens to use for private packages.
+        required: false
 
 env:
   COMPOSER_ROOT_VERSION: dev-main
   ci_script: ${{ inputs.js_package_manager == 'yarn' && 'yarn install --immutable' || 'npm ci' }}
   cache_dependency_path: ${{ inputs.cache_dependency_path || format(inputs.js_package_manager == 'yarn' && '{0}/yarn.lock' || '{0}/package-lock.json', inputs.frontend_directory) }}
+  COMPOSER_AUTH: ${{ secrets.composer_auth }}
 
 jobs:
   build:


### PR DESCRIPTION
Sometimes it is necessary to use private packagist, extiverse or such to retrieve composer packages for use in CI/CD tests. This PR allows setting of the `COMPOSER_AUTH` environment variable from an extension's workflow file.

For example:

```yml
name: Extension PHP

on: [workflow_dispatch, push, pull_request]

jobs:
  run:
    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@1.x
    with:
      enable_backend_testing: true
      enable_phpstan: true
      php_versions: '["8.1", "8.2", "8.3"]'

      backend_directory: .

    secrets:
      composer_auth: '{"bearer":{"extiverse.com": "${{secrets.EXTIVERSE_COMPOSER_TOKEN}}"}}'
```

This allows us to pass the Bearer JSON array, and therefore covers cases where multiple secrets are required. Extiverse example shown.

2.x companion to https://github.com/flarum/framework/commit/50dd73b07ceb42c1bd9a3085ed63d6bcf77557fb