### PR TITLE
[1.x] fix: reset admin page save button in catch handler

### DIFF
--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -352,6 +352,13 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
   }
 
   /**
+   * Called when `saveSettings` completes with errors.
+   */
+  onsavefailed(): void {
+    this.loading = false;
+  }
+
+  /**
    * Returns a function that fetches the setting from the `app` global.
    */
   setting(key: string, fallback: string = ''): Stream<string> {
@@ -394,6 +401,6 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
 
     this.loading = true;
 
-    return saveSettings(this.dirty()).then(this.onsaved.bind(this));
+    return saveSettings(this.dirty()).then(this.onsaved.bind(this)).catch(this.onsavefailed.bind(this));
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3962**

**Changes proposed in this pull request:**
Add a catch handler to `saveSettings()` to reset admin page's save button state.

**Reviewers should focus on:**
Should a newly added function that only sets `loading` to `false` be created.

**Screenshot**
No much changes will be shown to users.

**QA**
Create a `Saving` event listener and throw an exception to create a saving error.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
