### PR TITLE
fix(tags): Edit tags icon fontawesome url to v5

### DIFF
--- a/extensions/tags/js/src/admin/components/EditTagModal.tsx
+++ b/extensions/tags/js/src/admin/components/EditTagModal.tsx
@@ -117,7 +117,7 @@ export default class EditTagModal extends FormModal<EditTagModalAttrs> {
       <div className="Form-group">
         <label>{app.translator.trans('flarum-tags.admin.edit_tag.icon_label')}</label>
         <div className="helpText">
-          {app.translator.trans('flarum-tags.admin.edit_tag.icon_text', { a: <a href="https://fontawesome.com/icons?m=free" tabindex="-1" /> })}
+          {app.translator.trans('flarum-tags.admin.edit_tag.icon_text', { a: <a href="https://fontawesome.com/v5/icons?m=free" tabindex="-1" /> })}
         </div>
         <input className="FormControl" placeholder="fas fa-bolt" bidi={this.icon} />
       </div>,


### PR DESCRIPTION
**Fixes #0000** (no issue)

**Changes proposed in this pull request:**
The Fontawesome url referred to the newest icons overview, since the tags extension only supports v5 icons it's confusing for admin users why some icons don't work. The url for supported icons is: https://fontawesome.com/v5/icons?m=free.

<img width="347" alt="Scherm­afbeelding 2024-02-21 om 13 48 20" src="https://github.com/flarum/framework/assets/56150605/98e94435-0b51-49d0-9d90-775a6ab3a0c8">

**Reviewers should focus on:**
-

**Screenshot**
-

**QA**
-

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

