### PR TITLE
Patch vulnerability advisory

### DIFF
--- a/extensions/package-manager/composer.json
+++ b/extensions/package-manager/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "flarum/core": "^2.0",
-        "composer/composer": "^2.3"
+        "composer/composer": "^2.7"
     },
     "require-dev": {
         "flarum/testing": "^2.0",


### PR DESCRIPTION
Seems composer has a vulnerability, see https://github.com/advisories/GHSA-7c6p-848j-wh5h


Affected versions
>= 2.0.0-alpha1, < 2.2.23 -- patched in 2.2.23
>= 2.3.0-rc1, < 2.7.0 -- patched in 2.7.0

---

Let's raise the minimum to enforce the latest. This probably needs to be backported to 1.x once this is merged.

Thank you @peopleinside for reporting this.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

