### PR TITLE
fix: set parameter to string in explode function

### DIFF
--- a/framework/core/src/Search/GambitManager.php
+++ b/framework/core/src/Search/GambitManager.php
@@ -64,7 +64,7 @@ class GambitManager
      */
     protected function explode($query)
     {
-        return str_getcsv($query, ' ');
+        return str_getcsv((string)$query, ' ');
     }
 
     /**


### PR DESCRIPTION
**Fixes FriendsOfFlarum/user-directory#109**

The issue can be reproduced in PHP8.x environment when using the extension [FriendsOfFlarum/user-directory](https://github.com/FriendsOfFlarum/user-directory). Issue is caused by passing null parameter into function `str_getcsv()` in Flarum Core, where PHP8.x doesn't allow that.

Issue is solved by set the parameter to string.

**Changes proposed in this pull request:**
GambitManager.php

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
