### PR TITLE
feat: eloquent factories (primarily for tests)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
         "dflydev/fig-cookies": "^3.0",
         "doctrine/dbal": "^3.6.2",
         "dragonmantank/cron-expression": "^3.3",
+        "fakerphp/faker": "^1.9.1",
         "franzl/whoops-middleware": "2.0",
         "guzzlehttp/guzzle": "*",
         "illuminate/bus": "^10.0",

--- a/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
+++ b/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
@@ -11,14 +11,16 @@ namespace Flarum\Approval\Tests\integration;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\User\User;
 
 trait InteractsWithUnapprovedContent
 {
     protected function prepareUnapprovedDatabaseContent()
     {
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
@@ -47,7 +49,7 @@ trait InteractsWithUnapprovedContent
                 ['id' => 10, 'discussion_id' => 7, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 4],
                 ['id' => 11, 'discussion_id' => 7, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 1, 'is_approved' => 0, 'number' => 5],
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 4, 'name_singular' => 'Acme', 'name_plural' => 'Acme', 'is_hidden' => 0]
             ],
             'group_user' => [

--- a/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
+++ b/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
@@ -10,6 +10,7 @@
 namespace Flarum\Approval\Tests\integration;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 
 trait InteractsWithUnapprovedContent
 {
@@ -22,7 +23,7 @@ trait InteractsWithUnapprovedContent
                 ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'luceos', 'email' => 'luceos@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 1, 'comment_count' => 1, 'is_approved' => 1, 'is_private' => 0],
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 2, 'comment_count' => 1, 'is_approved' => 0, 'is_private' => 1],
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 3, 'comment_count' => 1, 'is_approved' => 0, 'is_private' => 1],

--- a/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
+++ b/extensions/approval/tests/integration/InteractsWithUnapprovedContent.php
@@ -11,6 +11,7 @@ namespace Flarum\Approval\Tests\integration;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 
 trait InteractsWithUnapprovedContent
 {
@@ -32,7 +33,7 @@ trait InteractsWithUnapprovedContent
                 ['id' => 6, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 6, 'comment_count' => 1, 'is_approved' => 0, 'is_private' => 1],
                 ['id' => 7, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 7, 'comment_count' => 1, 'is_approved' => 1, 'is_private' => 0],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
                 ['id' => 2, 'discussion_id' => 2, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],
                 ['id' => 3, 'discussion_id' => 3, 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'is_approved' => 1, 'number' => 1],

--- a/extensions/flags/tests/integration/api/flags/ListTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListTest.php
@@ -14,6 +14,7 @@ use Flarum\Group\Group;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListTest extends TestCase
@@ -30,7 +31,7 @@ class ListTest extends TestCase
         $this->extension('flarum-flags');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 [
                     'id' => 3,

--- a/extensions/flags/tests/integration/api/flags/ListTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Flags\Tests\integration\api\flags;
 
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -48,7 +49,7 @@ class ListTest extends TestCase
             Discussion::class => [
                 ['id' => 1, 'title' => '', 'user_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],
                 ['id' => 2, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],
                 ['id' => 3, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],

--- a/extensions/flags/tests/integration/api/flags/ListTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Flags\Tests\integration\api\flags;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -44,7 +45,7 @@ class ListTest extends TestCase
             'group_permission' => [
                 ['group_id' => Group::MODERATOR_ID, 'permission' => 'discussion.viewFlags'],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => '', 'user_id' => 1, 'comment_count' => 1],
             ],
             'posts' => [

--- a/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Flags\Tests\integration\api\flags;
 
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -69,7 +70,7 @@ class ListWithTagsTest extends TestCase
                 ['discussion_id' => 4, 'tag_id' => 4],
                 ['discussion_id' => 5, 'tag_id' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 // From regular ListTest
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],
                 ['id' => 2, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],

--- a/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Flags\Tests\integration\api\flags;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -55,7 +56,7 @@ class ListWithTagsTest extends TestCase
                 ['group_id' => Group::MODERATOR_ID, 'permission' => 'tag4.viewDiscussions'],
                 ['group_id' => Group::MODERATOR_ID, 'permission' => 'tag4.discussion.viewFlags'],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'no tags', 'user_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => 'has tags where mods can view discussions but not flags', 'user_id' => 1, 'comment_count' => 1],
                 ['id' => 3, 'title' => 'has tags where mods can view flags but not discussions', 'user_id' => 1, 'comment_count' => 1],

--- a/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
@@ -12,8 +12,10 @@ namespace Flarum\Flags\Tests\integration\api\flags;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListWithTagsTest extends TestCase
@@ -31,13 +33,13 @@ class ListWithTagsTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => [
+            Tag::class => [
                 ['id' => 1, 'name' => 'Unrestricted', 'slug' => '1', 'position' => 0, 'parent_id' => null],
                 ['id' => 2, 'name' => 'Mods can view discussions', 'slug' => '2', 'position' => 0, 'parent_id' => null, 'is_restricted' => true],
                 ['id' => 3, 'name' => 'Mods can view flags', 'slug' => '3', 'position' => 0, 'parent_id' => null, 'is_restricted' => true],
                 ['id' => 4, 'name' => 'Mods can view discussions and flags', 'slug' => '4', 'position' => 0, 'parent_id' => null, 'is_restricted' => true],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 [
                     'id' => 3,

--- a/extensions/likes/tests/integration/api/LikePostTest.php
+++ b/extensions/likes/tests/integration/api/LikePostTest.php
@@ -11,10 +11,12 @@ namespace Flarum\Likes\Tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
 use Flarum\Post\CommentPost;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Psr\Http\Message\ResponseInterface;
 
 class LikePostTest extends TestCase
@@ -28,7 +30,7 @@ class LikePostTest extends TestCase
         $this->extension('flarum-likes');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'Acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
@@ -42,7 +44,7 @@ class LikePostTest extends TestCase
                 ['id' => 5, 'number' => 3, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'discussionRenamed', 'content' => '<t><p>something</p></t>'],
                 ['id' => 6, 'number' => 4, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>something</p></t>'],
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 5, 'name_singular' => 'Acme', 'name_plural' => 'Acme', 'is_hidden' => 0],
                 ['id' => 6, 'name_singular' => 'Acme1', 'name_plural' => 'Acme1', 'is_hidden' => 0]
             ],

--- a/extensions/likes/tests/integration/api/LikePostTest.php
+++ b/extensions/likes/tests/integration/api/LikePostTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Likes\Tests\integration\api;
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Post\CommentPost;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -35,7 +36,7 @@ class LikePostTest extends TestCase
             Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>something</p></t>'],
                 ['id' => 3, 'number' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>something</p></t>'],
                 ['id' => 5, 'number' => 3, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'discussionRenamed', 'content' => '<t><p>something</p></t>'],

--- a/extensions/likes/tests/integration/api/LikePostTest.php
+++ b/extensions/likes/tests/integration/api/LikePostTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Likes\Tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Post\CommentPost;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -31,7 +32,7 @@ class LikePostTest extends TestCase
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'Acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2],
             ],
             'posts' => [

--- a/extensions/likes/tests/integration/api/ListPostsTest.php
+++ b/extensions/likes/tests/integration/api/ListPostsTest.php
@@ -16,6 +16,7 @@ use Flarum\Likes\Api\LoadLikesRelationship;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListPostsTest extends TestCase
@@ -38,7 +39,7 @@ class ListPostsTest extends TestCase
             Post::class => [
                 ['id' => 101, 'discussion_id' => 100, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 102, 'username' => 'user102', 'email' => '102@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 103, 'username' => 'user103', 'email' => '103@machine.local', 'is_email_confirmed' => 1],

--- a/extensions/likes/tests/integration/api/ListPostsTest.php
+++ b/extensions/likes/tests/integration/api/ListPostsTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Likes\Tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Likes\Api\LoadLikesRelationship;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
@@ -30,7 +31,7 @@ class ListPostsTest extends TestCase
         $this->extension('flarum-likes');
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 100, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 101, 'comment_count' => 1],
             ],
             'posts' => [

--- a/extensions/likes/tests/integration/api/ListPostsTest.php
+++ b/extensions/likes/tests/integration/api/ListPostsTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Likes\Api\LoadLikesRelationship;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -34,7 +35,7 @@ class ListPostsTest extends TestCase
             Discussion::class => [
                 ['id' => 100, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 101, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 101, 'discussion_id' => 100, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>'],
             ],
             'users' => [

--- a/extensions/mentions/tests/integration/api/GroupMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/GroupMentionsTest.php
@@ -55,7 +55,7 @@ class GroupMentionsTest extends TestCase
                 ['group_id' => Group::MEMBER_ID, 'permission' => 'postWithoutThrottle'],
                 ['group_id' => 9, 'permission' => 'mentionGroups'],
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 9, 'name_singular' => 'HasPermissionToMentionGroups', 'name_plural' => 'test'],
                 ['id' => 10, 'name_singular' => 'Hidden', 'name_plural' => 'Ninjas', 'icon' => 'fas fa-wrench', 'color' => '#000', 'is_hidden' => 1],
                 ['id' => 11, 'name_singular' => 'Fresh Name', 'name_plural' => 'Fresh Name', 'color' => '#ccc', 'icon' => 'fas fa-users', 'is_hidden' => 0]

--- a/extensions/mentions/tests/integration/api/GroupMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/GroupMentionsTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\CommentPost;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -38,7 +39,7 @@ class GroupMentionsTest extends TestCase
             Discussion::class => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><p>One of the <GROUPMENTION groupname="Mods" id="4">@"Mods"#g4</GROUPMENTION> will look at this</p></r>'],
                 ['id' => 6, 'number' => 3, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><p><GROUPMENTION groupname="OldGroupName" id="100">@"OldGroupName"#g100</GROUPMENTION></p></r>'],
                 ['id' => 7, 'number' => 4, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><p><GROUPMENTION groupname="OldGroupName" id="11">@"OldGroupName"#g11</GROUPMENTION></p></r>'],

--- a/extensions/mentions/tests/integration/api/GroupMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/GroupMentionsTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Mentions\Tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\CommentPost;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
@@ -30,11 +31,11 @@ class GroupMentionsTest extends TestCase
         $this->extension('flarum-mentions');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 3, 'username' => 'potato', 'email' => 'potato@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'toby', 'email' => 'toby@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
             ],
             'posts' => [

--- a/extensions/mentions/tests/integration/api/ListPostsTest.php
+++ b/extensions/mentions/tests/integration/api/ListPostsTest.php
@@ -15,6 +15,7 @@ use Flarum\Mentions\Api\LoadMentionedByRelationship;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListPostsTest extends TestCase
@@ -45,7 +46,7 @@ class ListPostsTest extends TestCase
                 ['post_id' => 3, 'mentions_user_id' => 1],
                 ['post_id' => 4, 'mentions_user_id' => 2]
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/extensions/mentions/tests/integration/api/ListPostsTest.php
+++ b/extensions/mentions/tests/integration/api/ListPostsTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Mentions\Tests\integration\api\discussions;
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Mentions\Api\LoadMentionedByRelationship;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -33,7 +34,7 @@ class ListPostsTest extends TestCase
             Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>'],
                 ['id' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>text</p></t>'],
                 ['id' => 3, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>text</p></t>'],
@@ -116,7 +117,7 @@ class ListPostsTest extends TestCase
             Discussion::class => [
                 ['id' => 100, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 101, 'comment_count' => 12],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 101, 'discussion_id' => 100, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>'],
                 ['id' => 102, 'discussion_id' => 100, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>'],
                 ['id' => 103, 'discussion_id' => 100, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>', 'is_private' => 1],

--- a/extensions/mentions/tests/integration/api/ListPostsTest.php
+++ b/extensions/mentions/tests/integration/api/ListPostsTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Mentions\Tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Mentions\Api\LoadMentionedByRelationship;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -29,7 +30,7 @@ class ListPostsTest extends TestCase
         $this->extension('flarum-mentions');
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
             'posts' => [
@@ -112,7 +113,7 @@ class ListPostsTest extends TestCase
     protected function prepareMentionedByData(): void
     {
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 100, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 101, 'comment_count' => 12],
             ],
             'posts' => [

--- a/extensions/mentions/tests/integration/api/PostMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/PostMentionsTest.php
@@ -34,7 +34,7 @@ class PostMentionsTest extends TestCase
         $this->extension('flarum-mentions');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 3, 'username' => 'potato', 'email' => 'potato@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'toby', 'email' => 'toby@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 5, 'username' => 'bad_user', 'email' => 'bad_user@machine.local', 'is_email_confirmed' => 1],

--- a/extensions/mentions/tests/integration/api/PostMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/PostMentionsTest.php
@@ -43,7 +43,7 @@ class PostMentionsTest extends TestCase
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
                 ['id' => 50, 'title' => __CLASS__, 'is_private' => true, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="TobyFlarum___" id="5" number="2" discussionid="2" username="toby">@tobyuuu#5</POSTMENTION></r>'],
                 ['id' => 5, 'number' => 3, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="potato" id="4" number="3" discussionid="2" username="potato">@potato#4</POSTMENTION></r>'],
                 ['id' => 6, 'number' => 4, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="i_am_a_deleted_user" id="7" number="5" discussionid="2" username="i_am_a_deleted_user">@"i_am_a_deleted_user"#p7</POSTMENTION></r>'],

--- a/extensions/mentions/tests/integration/api/PostMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/PostMentionsTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Mentions\Tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Formatter\Formatter;
 use Flarum\Post\CommentPost;
@@ -38,7 +39,7 @@ class PostMentionsTest extends TestCase
                 ['id' => 4, 'username' => 'toby', 'email' => 'toby@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 5, 'username' => 'bad_user', 'email' => 'bad_user@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
                 ['id' => 50, 'title' => __CLASS__, 'is_private' => true, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 1],
             ],

--- a/extensions/mentions/tests/integration/api/TagMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/TagMentionsTest.php
@@ -14,6 +14,7 @@ use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\CommentPost;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -42,7 +43,7 @@ class TagMentionsTest extends TestCase
                 ['id' => 8, 'number' => 6, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><TAGMENTION id="2020" slug="i_am_a_deleted_tag" tagname="i_am_a_deleted_tag">#i_am_a_deleted_tag</TAGMENTION></r>'],
                 ['id' => 10, 'number' => 11, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><TAGMENTION id="5" slug="laravel">#laravel</TAGMENTION></r>'],
             ],
-            'tags' => [
+            Tag::class => [
                 ['id' => 1, 'name' => 'Test', 'slug' => 'test', 'is_restricted' => 0],
                 ['id' => 2, 'name' => 'Flarum', 'slug' => 'flarum', 'is_restricted' => 0],
                 ['id' => 3, 'name' => 'Support', 'slug' => 'support', 'is_restricted' => 0],

--- a/extensions/mentions/tests/integration/api/TagMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/TagMentionsTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\CommentPost;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -35,7 +36,7 @@ class TagMentionsTest extends TestCase
             Discussion::class => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><TAGMENTION id="1" slug="test_old_slug" tagname="TestOldName">#test_old_slug</TAGMENTION></r>'],
                 ['id' => 7, 'number' => 5, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2021, 'type' => 'comment', 'content' => '<r><TAGMENTION id="3" slug="support" tagname="Support">#deleted_relation</TAGMENTION></r>'],
                 ['id' => 8, 'number' => 6, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><TAGMENTION id="2020" slug="i_am_a_deleted_tag" tagname="i_am_a_deleted_tag">#i_am_a_deleted_tag</TAGMENTION></r>'],

--- a/extensions/mentions/tests/integration/api/TagMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/TagMentionsTest.php
@@ -10,10 +10,12 @@
 namespace Flarum\Mentions\Tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\CommentPost;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class TagMentionsTest extends TestCase
 {
@@ -26,11 +28,11 @@ class TagMentionsTest extends TestCase
         $this->extension('flarum-tags', 'flarum-mentions');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 3, 'username' => 'potato', 'email' => 'potato@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'toby', 'email' => 'toby@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
             ],
             'posts' => [

--- a/extensions/mentions/tests/integration/api/UserMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/UserMentionsTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Mentions\Tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Post\CommentPost;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
@@ -31,13 +32,13 @@ class UserMentionsTest extends TestCase
         $this->extension('flarum-mentions');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'potato', 'email' => 'potato@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'toby', 'email' => 'toby@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 5, 'username' => 'bad_user', 'email' => 'bad_user@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
             ],
             'posts' => [

--- a/extensions/mentions/tests/integration/api/UserMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/UserMentionsTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Post\CommentPost;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\DisplayName\DriverInterface;
@@ -41,7 +42,7 @@ class UserMentionsTest extends TestCase
             Discussion::class => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><USERMENTION displayname="TobyFlarum___" id="4" username="toby">@tobyuuu</USERMENTION></r>'],
                 ['id' => 6, 'number' => 3, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><USERMENTION displayname="i_am_a_deleted_user" id="2021" username="i_am_a_deleted_user">@"i_am_a_deleted_user"#2021</USERMENTION></r>'],
                 ['id' => 10, 'number' => 11, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 5, 'type' => 'comment', 'content' => '<r><USERMENTION displayname="Bad &quot;#p6 User" id="5">@"Bad "#p6 User"#5</USERMENTION></r>'],

--- a/extensions/nicknames/tests/integration/api/EditUserTest.php
+++ b/extensions/nicknames/tests/integration/api/EditUserTest.php
@@ -27,7 +27,7 @@ class UpdateTest extends TestCase
 
         $this->extension('flarum-nicknames');
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
@@ -10,8 +10,10 @@
 namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class CanRequestCustomTimedStatisticsTest extends TestCase
 {
@@ -36,12 +38,12 @@ class CanRequestCustomTimedStatisticsTest extends TestCase
     protected function getDatabaseData(): array
     {
         return [
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()],
                 ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()->subDays(1)],
                 ['id' => 3, 'username' => 'normal2', 'email' => 'normal2@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()->subDays(2)],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],

--- a/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestCustomTimedStatisticsTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -49,7 +50,7 @@ class CanRequestCustomTimedStatisticsTest extends TestCase
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 4, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(2), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()],
                 ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],
                 ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],

--- a/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -48,7 +49,7 @@ class CanRequestLifetimeStatisticsTest extends TestCase
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 4, 'title' => __CLASS__, 'created_at' => $this->nowTime->subDays(2), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1],
                 ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1],
                 ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1],
@@ -77,9 +78,9 @@ class CanRequestLifetimeStatisticsTest extends TestCase
 
         $this->assertEqualsCanonicalizing(
             [
-                'users' => count($db['users']),
-                'discussions' => count($db['discussions']),
-                'posts' => count($db['posts']),
+                'users' => count($db[User::class]),
+                'discussions' => count($db[Discussion::class]),
+                'posts' => count($db[Post::class]),
             ],
             $body
         );

--- a/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestLifetimeStatisticsTest.php
@@ -10,8 +10,10 @@
 namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class CanRequestLifetimeStatisticsTest extends TestCase
 {
@@ -36,11 +38,11 @@ class CanRequestLifetimeStatisticsTest extends TestCase
     protected function getDatabaseData(): array
     {
         return [
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->subDays(1)],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => $this->nowTime, 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => $this->nowTime->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],

--- a/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
@@ -10,8 +10,10 @@
 namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class CanRequestTimedStatisticsTest extends TestCase
 {
@@ -36,11 +38,11 @@ class CanRequestTimedStatisticsTest extends TestCase
     protected function getDatabaseData(): array
     {
         return [
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()],
                 ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'is_email_confirmed' => 1, 'joined_at' => $this->nowTime->copy()->subDays(1)],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],

--- a/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
+++ b/extensions/statistics/tests/integration/api/CanRequestTimedStatisticsTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Statistics\tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -48,7 +49,7 @@ class CanRequestTimedStatisticsTest extends TestCase
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(1), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 4, 'title' => __CLASS__, 'created_at' => $this->nowTime->copy()->subDays(2), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()],
                 ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],
                 ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Text</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => $this->nowTime->copy()->subDays(1)],

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Sticky\tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Tags\Tag;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -42,7 +43,7 @@ class ListDiscussionsTest extends TestCase
                 ['discussion_id' => 1, 'user_id' => 3, 'last_read_post_number' => 1],
                 ['discussion_id' => 3, 'user_id' => 3, 'last_read_post_number' => 1],
             ],
-            'tags' => [
+            Tag::class => [
                 ['id' => 1, 'slug' => 'general', 'position' => 0, 'parent_id' => null]
             ],
             'discussion_tag' => [

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -10,8 +10,10 @@
 namespace Flarum\Sticky\tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListDiscussionsTest extends TestCase
@@ -25,12 +27,12 @@ class ListDiscussionsTest extends TestCase
         $this->extension('flarum-tags', 'flarum-sticky');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'Muralf_', 'email' => 'muralf_@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => true, 'last_post_number' => 1],
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now()->addMinutes(2), 'last_posted_at' => Carbon::now()->addMinutes(5), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => false, 'last_post_number' => 1],
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now()->addMinutes(3), 'last_posted_at' => Carbon::now()->addMinute(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => true, 'last_post_number' => 1],

--- a/extensions/subscriptions/tests/integration/api/discussions/ReplyNotificationTest.php
+++ b/extensions/subscriptions/tests/integration/api/discussions/ReplyNotificationTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Subscriptions\tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Extend\ModelVisibility;
 use Flarum\Group\Group;
 use Flarum\Post\Post;
@@ -28,12 +29,12 @@ class ReplyNotificationTest extends TestCase
         $this->extension('flarum-subscriptions');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1, 'preferences' => json_encode(['flarum-subscriptions.notify_for_all_posts' => true])],
                 ['id' => 4, 'username' => 'acme2', 'email' => 'acme2@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'last_post_number' => 1, 'last_post_id' => 1],
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1, 'last_post_number' => 1, 'last_post_id' => 2],
 
@@ -169,7 +170,7 @@ class ReplyNotificationTest extends TestCase
     public function deleting_last_posts_then_posting_new_one_sends_reply_notification(array $postIds)
     {
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 5, 'last_post_number' => 5, 'last_post_id' => 10],
             ],
             'posts' => [

--- a/extensions/subscriptions/tests/integration/api/discussions/ReplyNotificationTest.php
+++ b/extensions/subscriptions/tests/integration/api/discussions/ReplyNotificationTest.php
@@ -40,7 +40,7 @@ class ReplyNotificationTest extends TestCase
 
                 ['id' => 33, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 33, 'comment_count' => 6, 'last_post_number' => 6, 'last_post_id' => 38],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 1],
                 ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 1],
 
@@ -173,7 +173,7 @@ class ReplyNotificationTest extends TestCase
             Discussion::class => [
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 5, 'last_post_number' => 5, 'last_post_id' => 10],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 5, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 1],
                 ['id' => 6, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 2],
                 ['id' => 7, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 3],

--- a/extensions/suspend/tests/integration/api/UseForumTest.php
+++ b/extensions/suspend/tests/integration/api/UseForumTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Suspend\Tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -33,7 +34,7 @@ class UseForumTest extends TestCase
             Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'number' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'discussion_id' => 1, 'content' => '<t><p>Hello, world!</p></t>'],
             ]
         ]);

--- a/extensions/suspend/tests/integration/api/UseForumTest.php
+++ b/extensions/suspend/tests/integration/api/UseForumTest.php
@@ -10,8 +10,10 @@
 namespace Flarum\Suspend\Tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class UseForumTest extends TestCase
 {
@@ -24,11 +26,11 @@ class UseForumTest extends TestCase
         $this->extension('flarum-suspend');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 2, 'username' => 'SuspendedDonny', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->addDay(), 'suspend_reason' => 'acme', 'suspend_message' => 'acme'],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
             'posts' => [

--- a/extensions/suspend/tests/integration/api/users/ListUsersTest.php
+++ b/extensions/suspend/tests/integration/api/users/ListUsersTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Suspend\Tests\integration\api\users;
 use Carbon\Carbon;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListUsersTest extends TestCase
@@ -25,7 +26,7 @@ class ListUsersTest extends TestCase
         $this->extension('flarum-suspend');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 2, 'username' => 'SuspendedDonny1', 'email' => 'acme1@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->addDay(), 'suspend_reason' => 'acme', 'suspend_message' => 'acme'],
                 ['id' => 3, 'username' => 'SuspendedDonny2', 'email' => 'acme2@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->addDay(), 'suspend_reason' => 'acme', 'suspend_message' => 'acme'],

--- a/extensions/suspend/tests/integration/api/users/SuspendUserTest.php
+++ b/extensions/suspend/tests/integration/api/users/SuspendUserTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Suspend\Tests\integration\api\users;
 
 use Carbon\Carbon;
+use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -31,7 +32,7 @@ class SuspendUserTest extends TestCase
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 5, 'name_singular' => 'Acme', 'name_plural' => 'Acme', 'is_hidden' => 0]
             ],
             'group_user' => [

--- a/extensions/suspend/tests/integration/api/users/SuspendUserTest.php
+++ b/extensions/suspend/tests/integration/api/users/SuspendUserTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Suspend\Tests\integration\api\users;
 use Carbon\Carbon;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Psr\Http\Message\ResponseInterface;
 
 class SuspendUserTest extends TestCase
@@ -25,7 +26,7 @@ class SuspendUserTest extends TestCase
         $this->extension('flarum-suspend');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],

--- a/extensions/tags/src/Tag.php
+++ b/extensions/tags/src/Tag.php
@@ -16,6 +16,7 @@ use Flarum\Group\Permission;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -51,6 +52,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 class Tag extends AbstractModel
 {
     use ScopeVisibilityTrait;
+    use HasFactory;
 
     protected $table = 'tags';
 

--- a/extensions/tags/src/TagFactory.php
+++ b/extensions/tags/src/TagFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Flarum\Tags;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TagFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word,
+            'slug' => $this->faker->slug,
+            'description' => $this->faker->sentence,
+            'color' => $this->faker->hexColor,
+            'background_path' => null,
+            'background_mode' => null,
+            'position' => 0,
+            'parent_id' => null,
+            'default_sort' => null,
+            'is_restricted' => false,
+            'is_hidden' => false,
+            'discussion_count' => 0,
+            'last_posted_at' => null,
+            'last_posted_discussion_id' => null,
+            'last_posted_user_id' => null,
+            'icon' => null,
+            'created_at' => Carbon::now(),
+        ];
+    }
+}

--- a/extensions/tags/src/TagFactory.php
+++ b/extensions/tags/src/TagFactory.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Tags;
 
 use Carbon\Carbon;

--- a/extensions/tags/tests/integration/api/discussions/CreateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/CreateTest.php
@@ -10,9 +10,11 @@
 namespace Flarum\Tags\Tests\integration\api\discussions;
 
 use Flarum\Group\Group;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class CreateTest extends TestCase
 {
@@ -29,8 +31,8 @@ class CreateTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
-            'users' => [
+            Tag::class => $this->tags(),
+            User::class => [
                 $this->normalUser(),
             ],
             'group_permission' => [

--- a/extensions/tags/tests/integration/api/discussions/ListTest.php
+++ b/extensions/tags/tests/integration/api/discussions/ListTest.php
@@ -10,7 +10,9 @@
 namespace Flarum\Tags\Tests\integration\api\discussions;
 
 use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -32,7 +34,7 @@ class ListTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
+            Tag::class => $this->tags(),
             User::class => [
                 $this->normalUser(),
                 [
@@ -43,7 +45,7 @@ class ListTest extends TestCase
                     'is_email_confirmed' => 1,
                 ]
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 100, 'name_singular' => 'acme', 'name_plural' => 'acme']
             ],
             'group_user' => [

--- a/extensions/tags/tests/integration/api/discussions/ListTest.php
+++ b/extensions/tags/tests/integration/api/discussions/ListTest.php
@@ -9,9 +9,11 @@
 
 namespace Flarum\Tags\Tests\integration\api\discussions;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListTest extends TestCase
@@ -30,7 +32,7 @@ class ListTest extends TestCase
 
         $this->prepareDatabase([
             'tags' => $this->tags(),
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 [
                     'id' => 3,
@@ -52,7 +54,7 @@ class ListTest extends TestCase
                 ['group_id' => 100, 'permission' => 'tag11.viewForum'],
                 ['group_id' => 100, 'permission' => 'tag13.viewForum'],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'no tags', 'user_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => 'open tags', 'user_id' => 1, 'comment_count' => 1],
                 ['id' => 3, 'title' => 'open tag, restricted child tag', 'user_id' => 1, 'comment_count' => 1],

--- a/extensions/tags/tests/integration/api/discussions/ListTest.php
+++ b/extensions/tags/tests/integration/api/discussions/ListTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tags\Tests\integration\api\discussions;
 
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -68,7 +69,7 @@ class ListTest extends TestCase
                 ['id' => 11, 'title' => 'private, all closed',  'user_id' => 1, 'comment_count' => 1, 'is_private' => 1],
                 ['id' => 12, 'title' => 'private, closed parent, open child tag',  'user_id' => 1, 'comment_count' => 1, 'is_private' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],
                 ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],
                 ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],

--- a/extensions/tags/tests/integration/api/discussions/UpdateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/UpdateTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tags\Tests\integration\api\discussions;
 
+use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
@@ -43,7 +44,7 @@ class UpdateTest extends TestCase
                 ['group_id' => Group::MEMBER_ID, 'permission' => 'tag11.startDiscussion'],
             ],
             Discussion::class => [
-                ['id' => 1, 'title' => 'Discussion with post', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 1, 'title' => 'Discussion with post', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()->subDay()],
             ],
             'posts' => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Text</p></t>'],
@@ -243,7 +244,7 @@ class UpdateTest extends TestCase
             ])
         );
 
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(403, $response->getStatusCode(), $response->getBody());
     }
 
     /**

--- a/extensions/tags/tests/integration/api/discussions/UpdateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/UpdateTest.php
@@ -9,10 +9,12 @@
 
 namespace Flarum\Tags\Tests\integration\api\discussions;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class UpdateTest extends TestCase
 {
@@ -30,7 +32,7 @@ class UpdateTest extends TestCase
 
         $this->prepareDatabase([
             'tags' => $this->tags(),
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
             'group_permission' => [
@@ -40,7 +42,7 @@ class UpdateTest extends TestCase
                 ['group_id' => Group::MEMBER_ID, 'permission' => 'tag11.viewForum'],
                 ['group_id' => Group::MEMBER_ID, 'permission' => 'tag11.startDiscussion'],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Discussion with post', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1],
             ],
             'posts' => [

--- a/extensions/tags/tests/integration/api/discussions/UpdateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/UpdateTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -33,7 +34,7 @@ class UpdateTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
+            Tag::class => $this->tags(),
             User::class => [
                 $this->normalUser(),
             ],

--- a/extensions/tags/tests/integration/api/discussions/UpdateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/UpdateTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tags\Tests\integration\api\discussions;
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
+use Flarum\Post\Post;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -46,7 +47,7 @@ class UpdateTest extends TestCase
             Discussion::class => [
                 ['id' => 1, 'title' => 'Discussion with post', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()->subDay()],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Text</p></t>'],
             ],
             'discussion_tag' => [

--- a/extensions/tags/tests/integration/api/posts/ListTest.php
+++ b/extensions/tags/tests/integration/api/posts/ListTest.php
@@ -10,7 +10,9 @@
 namespace Flarum\Tags\Tests\integration\api\posts;
 
 use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -31,7 +33,7 @@ class ListTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
+            Tag::class => $this->tags(),
             User::class => [
                 $this->normalUser(),
                 [
@@ -42,7 +44,7 @@ class ListTest extends TestCase
                     'is_email_confirmed' => 1,
                 ]
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 100, 'name_singular' => 'acme', 'name_plural' => 'acme']
             ],
             'group_user' => [

--- a/extensions/tags/tests/integration/api/posts/ListTest.php
+++ b/extensions/tags/tests/integration/api/posts/ListTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tags\Tests\integration\api\posts;
 
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -53,7 +54,7 @@ class ListTest extends TestCase
             Discussion::class => [
                 ['id' => 1, 'title' => 'no tags', 'user_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>', 'number' => 1],
                 ['id' => 2, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'discussionTagged', 'content' => '[[1,5],[5]]', 'number' => 2],
                 ['id' => 3, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>', 'number' => 3],

--- a/extensions/tags/tests/integration/api/posts/ListTest.php
+++ b/extensions/tags/tests/integration/api/posts/ListTest.php
@@ -9,9 +9,11 @@
 
 namespace Flarum\Tags\Tests\integration\api\posts;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class ListTest extends TestCase
 {
@@ -29,7 +31,7 @@ class ListTest extends TestCase
 
         $this->prepareDatabase([
             'tags' => $this->tags(),
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 [
                     'id' => 3,
@@ -48,7 +50,7 @@ class ListTest extends TestCase
             'group_permission' => [
                 ['group_id' => 100, 'permission' => 'tag5.viewForum'],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'no tags', 'user_id' => 1, 'comment_count' => 1],
             ],
             'posts' => [

--- a/extensions/tags/tests/integration/api/tags/CreateTest.php
+++ b/extensions/tags/tests/integration/api/tags/CreateTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tags\Tests\integration\api\tags;
 use Flarum\Tags\Tag;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class CreateTest extends TestCase
@@ -28,7 +29,7 @@ class CreateTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/extensions/tags/tests/integration/api/tags/ListTest.php
+++ b/extensions/tags/tests/integration/api/tags/ListTest.php
@@ -10,9 +10,11 @@
 namespace Flarum\Tags\Tests\integration\api\tags;
 
 use Flarum\Group\Group;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListTest extends TestCase
@@ -30,8 +32,8 @@ class ListTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
-            'users' => [
+            Tag::class => $this->tags(),
+            User::class => [
                 $this->normalUser(),
             ],
             'group_permission' => [

--- a/extensions/tags/tests/integration/api/tags/ListWithFulltextSearchTest.php
+++ b/extensions/tags/tests/integration/api/tags/ListWithFulltextSearchTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tags\Tests\integration\api\tags;
 
+use Flarum\Tags\Tag;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
 
@@ -21,7 +22,7 @@ class ListWithFulltextSearchTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => [
+            Tag::class => [
                 ['id' => 2, 'name' => 'Acme', 'slug' => 'acme'],
                 ['id' => 3, 'name' => 'Test', 'slug' => 'test'],
                 ['id' => 4, 'name' => 'Tag', 'slug' => 'tag'],

--- a/extensions/tags/tests/integration/api/tags/ShowTest.php
+++ b/extensions/tags/tests/integration/api/tags/ShowTest.php
@@ -10,9 +10,11 @@
 namespace Flarum\Tags\Tests\integration\api\tags;
 
 use Flarum\Group\Group;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ShowTest extends TestCase
@@ -30,8 +32,8 @@ class ShowTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
-            'users' => [
+            Tag::class => $this->tags(),
+            User::class => [
                 $this->normalUser(),
             ],
             'group_permission' => [
@@ -45,7 +47,7 @@ class ShowTest extends TestCase
     public function can_show_tag_with_url_decoded_utf8_slug()
     {
         $this->prepareDatabase([
-            'tags' => [
+            Tag::class => [
                 ['id' => 155, 'name' => '测试', 'slug' => '测试', 'position' => 0, 'parent_id' => null]
             ]
         ]);
@@ -67,7 +69,7 @@ class ShowTest extends TestCase
     public function can_show_tag_with_url_encoded_utf8_slug()
     {
         $this->prepareDatabase([
-            'tags' => [
+            Tag::class => [
                 ['id' => 155, 'name' => '测试', 'slug' => '测试', 'position' => 0, 'parent_id' => null]
             ]
         ]);

--- a/extensions/tags/tests/integration/authorization/GlobalPolicyTest.php
+++ b/extensions/tags/tests/integration/authorization/GlobalPolicyTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tags\Tests\integration\authorization;
 
 use Flarum\Group\Group;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -30,8 +31,8 @@ class GlobalPolicyTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
-            'users' => [
+            Tag::class => $this->tags(),
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/extensions/tags/tests/integration/authorization/TagPolicyTest.php
+++ b/extensions/tags/tests/integration/authorization/TagPolicyTest.php
@@ -31,8 +31,8 @@ class TagPolicyTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
-            'users' => [
+            Tag::class => $this->tags(),
+            User::class => [
                 $this->normalUser(),
             ],
             'group_permission' => [

--- a/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
+++ b/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
@@ -34,7 +34,7 @@ class DiscussionVisibilityTest extends TestCase
 
         $this->prepareDatabase([
             'tags' => $this->tags(),
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
             'group_permission' => [
@@ -46,7 +46,7 @@ class DiscussionVisibilityTest extends TestCase
                 ['group_id' => Group::MEMBER_ID, 'permission' => 'arbitraryAbility'],
                 ['group_id' => Group::GUEST_ID, 'permission' => 'arbitraryAbility']
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'no tags', 'user_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => 'open tags', 'user_id' => 1, 'comment_count' => 1],
                 ['id' => 3, 'title' => 'open tag, restricted child tag', 'user_id' => 1, 'comment_count' => 1],

--- a/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
+++ b/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tags\Tests\integration\api\discussions;
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Post\Post;
+use Flarum\Tags\Tag;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -34,7 +35,7 @@ class DiscussionVisibilityTest extends TestCase
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([
-            'tags' => $this->tags(),
+            Tag::class => $this->tags(),
             User::class => [
                 $this->normalUser(),
             ],

--- a/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
+++ b/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tags\Tests\integration\api\discussions;
 
 use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
+use Flarum\Post\Post;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -55,7 +56,7 @@ class DiscussionVisibilityTest extends TestCase
                 ['id' => 6, 'title' => 'closed parent, open child tag',  'user_id' => 1, 'comment_count' => 1],
                 ['id' => 7, 'title' => 'one closed primary tag',  'user_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],
                 ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],
                 ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p></p></t>'],

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -41,6 +41,7 @@
         "dflydev/fig-cookies": "^3.0",
         "doctrine/dbal": "^3.6",
         "dragonmantank/cron-expression": "*",
+        "fakerphp/faker": "^1.9.1",
         "franzl/whoops-middleware": "2.0",
         "guzzlehttp/guzzle": "^7.7",
         "illuminate/bus": "^10.0",

--- a/framework/core/src/Api/ApiKey.php
+++ b/framework/core/src/Api/ApiKey.php
@@ -12,6 +12,7 @@ namespace Flarum\Api;
 use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
 use Flarum\User\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
 
@@ -27,6 +28,8 @@ use Illuminate\Support\Str;
  */
 class ApiKey extends AbstractModel
 {
+    use HasFactory;
+
     protected $casts = [
         'id' => 'integer',
         'user_id' => 'integer',

--- a/framework/core/src/Api/ApiKeyFactory.php
+++ b/framework/core/src/Api/ApiKeyFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Flarum\Api;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ApiKeyFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'key' => $this->faker->sha256,
+            'allowed_ips' => null,
+            'scopes' => null,
+            'user_id' => null,
+            'created_at' => Carbon::now(),
+            'last_activity_at' => null,
+        ];
+    }
+}

--- a/framework/core/src/Api/ApiKeyFactory.php
+++ b/framework/core/src/Api/ApiKeyFactory.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Api;
 
 use Carbon\Carbon;

--- a/framework/core/src/Discussion/Discussion.php
+++ b/framework/core/src/Discussion/Discussion.php
@@ -24,6 +24,7 @@ use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -60,6 +61,7 @@ class Discussion extends AbstractModel
 {
     use EventGeneratorTrait;
     use ScopeVisibilityTrait;
+    use HasFactory;
 
     /**
      * An array of posts that have been modified during this request.

--- a/framework/core/src/Discussion/DiscussionFactory.php
+++ b/framework/core/src/Discussion/DiscussionFactory.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Discussion;
 
 use Carbon\Carbon;

--- a/framework/core/src/Discussion/DiscussionFactory.php
+++ b/framework/core/src/Discussion/DiscussionFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Flarum\Discussion;
+
+use Carbon\Carbon;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DiscussionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence,
+            'comment_count' => 1,
+            'participant_count' => 1,
+            'created_at' => Carbon::now(),
+            'user_id' => User::factory(),
+            'first_post_id' => null,
+            'last_posted_at' => null,
+            'last_posted_user_id' => null,
+            'last_post_id' => null,
+            'last_post_number' => null,
+            'hidden_at' => null,
+            'hidden_user_id' => null,
+            'slug' => $this->faker->slug,
+            'is_private' => 0
+        ];
+    }
+}

--- a/framework/core/src/Group/Group.php
+++ b/framework/core/src/Group/Group.php
@@ -16,6 +16,7 @@ use Flarum\Group\Event\Created;
 use Flarum\Group\Event\Deleted;
 use Flarum\Group\Event\Renamed;
 use Flarum\User\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -33,6 +34,7 @@ class Group extends AbstractModel
 {
     use EventGeneratorTrait;
     use ScopeVisibilityTrait;
+    use HasFactory;
 
     const ADMINISTRATOR_ID = 1;
     const GUEST_ID = 2;

--- a/framework/core/src/Group/GroupFactory.php
+++ b/framework/core/src/Group/GroupFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Flarum\Group;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GroupFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name_singular' => $singular = $this->faker->word,
+            'name_plural' => $singular . '(s)',
+            'color' => $this->faker->hexColor,
+            'icon' => null,
+            'is_hidden' => false,
+        ];
+    }
+}

--- a/framework/core/src/Group/GroupFactory.php
+++ b/framework/core/src/Group/GroupFactory.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Group;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -10,7 +17,7 @@ class GroupFactory extends Factory
     {
         return [
             'name_singular' => $singular = $this->faker->word,
-            'name_plural' => $singular . '(s)',
+            'name_plural' => $singular.'(s)',
             'color' => $this->faker->hexColor,
             'icon' => null,
             'is_hidden' => false,

--- a/framework/core/src/Http/AccessToken.php
+++ b/framework/core/src/Http/AccessToken.php
@@ -14,6 +14,7 @@ use Flarum\Database\AbstractModel;
 use Flarum\Database\ScopeVisibilityTrait;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -34,6 +35,7 @@ use Psr\Http\Message\ServerRequestInterface;
 class AccessToken extends AbstractModel
 {
     use ScopeVisibilityTrait;
+    use HasFactory;
 
     protected $table = 'access_tokens';
 
@@ -70,6 +72,8 @@ class AccessToken extends AbstractModel
      * will update the attribute on the DB. Measured in seconds.
      */
     private const LAST_ACTIVITY_UPDATE_DIFF = 90;
+
+    public ?array $uniqueKeys = ['token'];
 
     /**
      * Generate an access token for the specified user.

--- a/framework/core/src/Http/AccessTokenFactory.php
+++ b/framework/core/src/Http/AccessTokenFactory.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Http;
 
 use Carbon\Carbon;

--- a/framework/core/src/Http/AccessTokenFactory.php
+++ b/framework/core/src/Http/AccessTokenFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Flarum\Http;
+
+use Carbon\Carbon;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class AccessTokenFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'token' => Str::random(40),
+            'user_id' => User::factory(),
+            'last_activity_at' => null,
+            'type' => 'developer',
+            'title' => $this->faker->sentence,
+            'last_ip_address' => null,
+            'last_user_agent' => null,
+            'created_at' => Carbon::now(),
+        ];
+    }
+}

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -17,6 +17,7 @@ use Flarum\Notification\Notification;
 use Flarum\Post\Event\Deleted;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Expression;
 use Staudenmeir\EloquentEagerLimit\HasEagerLimit;
@@ -45,6 +46,7 @@ class Post extends AbstractModel
     use EventGeneratorTrait;
     use ScopeVisibilityTrait;
     use HasEagerLimit;
+    use HasFactory;
 
     protected $table = 'posts';
 

--- a/framework/core/src/Post/PostFactory.php
+++ b/framework/core/src/Post/PostFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Flarum\Post;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PostFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'discussion_id' => Discussion::factory(),
+            'number' => null,
+            'created_at' => Carbon::now(),
+            'user_id' => User::factory(),
+            'type' => CommentPost::$type,
+            'content' => $this->faker->paragraph,
+            'edited_at' => null,
+            'edited_user_id' => null,
+            'hidden_at' => null,
+            'hidden_user_id' => null,
+            'ip_address' => null,
+            'is_private' => 0
+        ];
+    }
+}

--- a/framework/core/src/Post/PostFactory.php
+++ b/framework/core/src/Post/PostFactory.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Post;
 
 use Carbon\Carbon;

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -35,6 +35,7 @@ use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
@@ -72,6 +73,7 @@ class User extends AbstractModel
     use EventGeneratorTrait;
     use ScopeVisibilityTrait;
     use HasEagerLimit;
+    use HasFactory;
 
     protected $casts = [
         'id' => 'integer',

--- a/framework/core/src/User/UserFactory.php
+++ b/framework/core/src/User/UserFactory.php
@@ -1,8 +1,14 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\User;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class UserFactory extends Factory

--- a/framework/core/src/User/UserFactory.php
+++ b/framework/core/src/User/UserFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Flarum\User;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'username' => $this->faker->userName,
+            'email' => $this->faker->safeEmail,
+            'is_email_confirmed' => 1,
+            'password' => $this->faker->password,
+            'avatar_url' => $this->faker->imageUrl,
+            'preferences' => [],
+            'joined_at' => null,
+            'last_seen_at' => null,
+            'marked_all_as_read_at' => null,
+            'read_notifications_at' => null,
+            'discussion_count' => 0,
+            'comment_count' => 0,
+        ];
+    }
+}

--- a/framework/core/tests/integration/admin/IndexTest.php
+++ b/framework/core/tests/integration/admin/IndexTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\admin;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class IndexTest extends TestCase
 {
@@ -22,7 +23,7 @@ class IndexTest extends TestCase
     protected function setUp(): void
     {
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser()
             ]
         ]);

--- a/framework/core/tests/integration/api/access_tokens/AccessTokenLifecycleTest.php
+++ b/framework/core/tests/integration/api/access_tokens/AccessTokenLifecycleTest.php
@@ -27,7 +27,7 @@ class AccessTokenLifecycleTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'access_tokens' => [
+            AccessToken::class => [
                 ['token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
                 ['token' => 'b', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session_remember'],
                 ['token' => 'c', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],

--- a/framework/core/tests/integration/api/access_tokens/CreateTest.php
+++ b/framework/core/tests/integration/api/access_tokens/CreateTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\access_tokens;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class CreateTest extends TestCase
 {
@@ -24,11 +25,10 @@ class CreateTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'normal3', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'normal3@machine.local', 'is_email_confirmed' => 1]
             ],
-            'access_tokens' => [],
             'groups' => [
                 ['id' => 10, 'name_plural' => 'Acme', 'name_singular' => 'Acme']
             ],

--- a/framework/core/tests/integration/api/access_tokens/CreateTest.php
+++ b/framework/core/tests/integration/api/access_tokens/CreateTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tests\integration\api\access_tokens;
 
+use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -29,7 +30,7 @@ class CreateTest extends TestCase
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'normal3', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'normal3@machine.local', 'is_email_confirmed' => 1]
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 10, 'name_plural' => 'Acme', 'name_singular' => 'Acme']
             ],
             'group_user' => [

--- a/framework/core/tests/integration/api/access_tokens/DeleteTest.php
+++ b/framework/core/tests/integration/api/access_tokens/DeleteTest.php
@@ -16,6 +16,7 @@ use Flarum\Http\RememberAccessToken;
 use Flarum\Http\SessionAccessToken;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class DeleteTest extends TestCase
 {
@@ -29,12 +30,12 @@ class DeleteTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'normal3', 'email' => 'normal3@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'normal4', 'email' => 'normal4@machine.local', 'is_email_confirmed' => 1],
             ],
-            'access_tokens' => [
+            AccessToken::class => [
                 ['id' => 1, 'token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
                 ['id' => 2, 'token' => 'b', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session_remember'],
                 ['id' => 3, 'token' => 'c', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],

--- a/framework/core/tests/integration/api/access_tokens/DeleteTest.php
+++ b/framework/core/tests/integration/api/access_tokens/DeleteTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\api\access_tokens;
 
 use Carbon\Carbon;
+use Flarum\Group\Group;
 use Flarum\Http\AccessToken;
 use Flarum\Http\DeveloperAccessToken;
 use Flarum\Http\RememberAccessToken;
@@ -43,7 +44,7 @@ class DeleteTest extends TestCase
                 ['id' => 5, 'token' => 'e', 'user_id' => 2, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
                 ['id' => 6, 'token' => 'f', 'user_id' => 3, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 100, 'name_singular' => 'test', 'name_plural' => 'test']
             ],
             'group_user' => [

--- a/framework/core/tests/integration/api/access_tokens/ListTest.php
+++ b/framework/core/tests/integration/api/access_tokens/ListTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\api\access_tokens;
 
 use Carbon\Carbon;
+use Flarum\Group\Group;
 use Flarum\Http\AccessToken;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -41,7 +42,7 @@ class ListTest extends TestCase
                 ['id' => 5, 'token' => 'e', 'user_id' => 2, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],
                 ['id' => 6, 'token' => 'f', 'user_id' => 3, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 100, 'name_singular' => 'test', 'name_plural' => 'test']
             ],
             'group_user' => [

--- a/framework/core/tests/integration/api/access_tokens/ListTest.php
+++ b/framework/core/tests/integration/api/access_tokens/ListTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Http\AccessToken;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListTest extends TestCase
@@ -27,12 +28,12 @@ class ListTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'normal3', 'email' => 'normal3@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'normal4', 'email' => 'normal4@machine.local', 'is_email_confirmed' => 1],
             ],
-            'access_tokens' => [
+            AccessToken::class => [
                 ['id' => 1, 'token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
                 ['id' => 2, 'token' => 'b', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session_remember'],
                 ['id' => 3, 'token' => 'c', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],

--- a/framework/core/tests/integration/api/access_tokens/RemembererTest.php
+++ b/framework/core/tests/integration/api/access_tokens/RemembererTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\api\access_tokens;
 
 use Carbon\Carbon;
+use Flarum\Http\AccessToken;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 
@@ -25,7 +26,7 @@ class RemembererTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'access_tokens' => [
+            AccessToken::class => [
                 ['token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
                 ['token' => 'b', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session_remember'],
             ],

--- a/framework/core/tests/integration/api/authentication/WithApiKeyTest.php
+++ b/framework/core/tests/integration/api/authentication/WithApiKeyTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Api\ApiKey;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class WithApiKeyTest extends TestCase
 {
@@ -26,10 +27,10 @@ class WithApiKeyTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
-            'api_keys' => [
+            ApiKey::class => [
                 ['key' => 'mastertoken', 'user_id' => null, 'created_at' => Carbon::now()->toDateTimeString()],
                 ['key' => 'personaltoken', 'user_id' => 2, 'created_at' => Carbon::now()->toDateTimeString()],
             ]

--- a/framework/core/tests/integration/api/authentication/WithTokenTest.php
+++ b/framework/core/tests/integration/api/authentication/WithTokenTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\authentication;
 use Flarum\Http\AccessToken;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class WithTokenTest extends TestCase
 {
@@ -25,7 +26,7 @@ class WithTokenTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/csrf_protection/RequireCsrfTokenTest.php
+++ b/framework/core/tests/integration/api/csrf_protection/RequireCsrfTokenTest.php
@@ -9,6 +9,8 @@
 
 namespace Flarum\Tests\integration\api\csrf_protection;
 
+use Flarum\Api\ApiKey;
+use Flarum\Http\AccessToken;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 
@@ -24,7 +26,7 @@ class RequireCsrfTokenTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'api_keys' => [
+            ApiKey::class => [
                 ['user_id' => 1, 'key' => 'superadmin'],
             ]
         ]);
@@ -192,7 +194,7 @@ class RequireCsrfTokenTest extends TestCase
     public function access_token_does_not_need_csrf_token()
     {
         $this->database()->table('access_tokens')->insert(
-            ['token' => 'myaccesstoken', 'user_id' => 1, 'type' => 'developer']
+            AccessToken::factory()->raw(['token' => 'myaccesstoken', 'user_id' => 1, 'type' => 'developer'])
         );
 
         $response = $this->send(

--- a/framework/core/tests/integration/api/discussions/CreateTest.php
+++ b/framework/core/tests/integration/api/discussions/CreateTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\discussions;
 use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class CreateTest extends TestCase
@@ -26,7 +27,7 @@ class CreateTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/api/discussions/DeletionTest.php
+++ b/framework/core/tests/integration/api/discussions/DeletionTest.php
@@ -10,8 +10,11 @@
 namespace Flarum\Tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class DeletionTest extends TestCase
 {
@@ -25,13 +28,13 @@ class DeletionTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);
@@ -51,7 +54,7 @@ class DeletionTest extends TestCase
 
         $this->assertEquals(204, $response->getStatusCode());
 
-        // Ensure both the database and the corresponding post are deleted
+        // Ensure both the discussion and the corresponding post are deleted
         $this->assertNull($this->database()->table('discussions')->find(1), 'Discussion exists in the DB');
         $this->assertNull($this->database()->table('posts')->find(1), 'Post exists in the DB');
     }

--- a/framework/core/tests/integration/api/discussions/ListTest.php
+++ b/framework/core/tests/integration/api/discussions/ListTest.php
@@ -10,6 +10,8 @@
 namespace Flarum\Tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -27,19 +29,19 @@ class ListTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
                 ['id' => 2, 'title' => 'lightsail in title', 'created_at' => Carbon::createFromDate(1985, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(1985, 5, 21)->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
                 ['id' => 3, 'title' => 'not in title', 'created_at' => Carbon::createFromDate(1995, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(1995, 5, 21)->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
                 ['id' => 4, 'title' => 'hidden', 'created_at' => Carbon::createFromDate(2005, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(2005, 5, 21)->toDateTimeString(), 'hidden_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>'],
                 ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::createFromDate(1985, 5, 21)->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>not in text</p></t>'],
                 ['id' => 3, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1995, 5, 21)->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
                 ['id' => 4, 'discussion_id' => 4, 'created_at' => Carbon::createFromDate(2005, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
+++ b/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
@@ -10,6 +10,8 @@
 namespace Flarum\Tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -30,24 +32,24 @@ class ListWithFulltextSearchTest extends TestCase
         // We need to insert these outside of a transaction, because FULLTEXT indexing,
         // which is needed for search, doesn't happen in transactions.
         // We clean it up explcitly at the end.
-        $this->database()->table('discussions')->insert([
-            ['id' => 1, 'title' => 'lightsail in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
-            ['id' => 2, 'title' => 'lightsail in title too', 'created_at' => Carbon::createFromDate(2020, 01, 01)->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
-            ['id' => 3, 'title' => 'not in title either', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
-            ['id' => 4, 'title' => 'not in title or text', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
-            ['id' => 5, 'title' => 'తెలుగు', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
-            ['id' => 6, 'title' => '支持中文吗', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
-        ]);
+        $this->database()->table('discussions')->insert($this->rowsThroughFactory(Discussion::class, [
+            ['id' => 1, 'title' => 'lightsail in title', 'user_id' => 1],
+            ['id' => 2, 'title' => 'lightsail in title too', 'created_at' => Carbon::createFromDate(2020, 01, 01)->toDateTimeString(), 'user_id' => 1],
+            ['id' => 3, 'title' => 'not in title either', 'user_id' => 1],
+            ['id' => 4, 'title' => 'not in title or text', 'user_id' => 1],
+            ['id' => 5, 'title' => 'తెలుగు', 'user_id' => 1],
+            ['id' => 6, 'title' => '支持中文吗', 'user_id' => 1],
+        ]));
 
-        $this->database()->table('posts')->insert([
-            ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>not in text</p></t>'],
-            ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
-            ['id' => 3, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>another lightsail for discussion 2!</p></t>'],
-            ['id' => 4, 'discussion_id' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>just one lightsail for discussion 3.</p></t>'],
-            ['id' => 5, 'discussion_id' => 4, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>not in title or text</p></t>'],
-            ['id' => 6, 'discussion_id' => 4, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>తెలుగు</p></t>'],
-            ['id' => 7, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>支持中文吗</p></t>'],
-        ]);
+        $this->database()->table('posts')->insert($this->rowsThroughFactory(Post::class, [
+            ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'content' => '<t><p>not in text</p></t>'],
+            ['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'content' => '<t><p>lightsail in text</p></t>'],
+            ['id' => 3, 'discussion_id' => 2, 'user_id' => 1, 'content' => '<t><p>another lightsail for discussion 2!</p></t>'],
+            ['id' => 4, 'discussion_id' => 3, 'user_id' => 1, 'content' => '<t><p>just one lightsail for discussion 3.</p></t>'],
+            ['id' => 5, 'discussion_id' => 4, 'user_id' => 1, 'content' => '<t><p>not in title or text</p></t>'],
+            ['id' => 6, 'discussion_id' => 4, 'user_id' => 1, 'content' => '<t><p>తెలుగు</p></t>'],
+            ['id' => 7, 'discussion_id' => 2, 'user_id' => 1, 'content' => '<t><p>支持中文吗</p></t>'],
+        ]));
 
         // We need to call these again, since we rolled back the transaction started by `::app()`.
         $this->database()->beginTransaction();

--- a/framework/core/tests/integration/api/discussions/ShowTest.php
+++ b/framework/core/tests/integration/api/discussions/ShowTest.php
@@ -10,8 +10,11 @@
 namespace Flarum\Tests\integration\api\discussions;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ShowTest extends TestCase
@@ -26,17 +29,17 @@ class ShowTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Empty discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 0],
                 ['id' => 2, 'title' => 'Discussion with post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
                 ['id' => 3, 'title' => 'Private discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 1],
                 ['id' => 4, 'title' => 'Discussion with hidden post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 1, 'is_private' => 0],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>a normal reply - too-obscure</p></t>'],
                 ['id' => 2, 'discussion_id' => 4, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>a hidden reply - too-obscure</p></t>', 'hidden_at' => Carbon::now()->toDateTimeString()],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/api/forum/ShowTest.php
+++ b/framework/core/tests/integration/api/forum/ShowTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\forum;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ShowTest extends TestCase
@@ -25,7 +26,7 @@ class ShowTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/api/groups/CreateTest.php
+++ b/framework/core/tests/integration/api/groups/CreateTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\groups;
 use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class CreateTest extends TestCase
@@ -26,7 +27,7 @@ class CreateTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/groups/ListTest.php
+++ b/framework/core/tests/integration/api/groups/ListTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tests\integration\api\groups;
 
+use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -25,7 +26,7 @@ class ListTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'groups' => [
+            Group::class => [
                 $this->hiddenGroup(),
             ],
         ]);

--- a/framework/core/tests/integration/api/groups/ShowTest.php
+++ b/framework/core/tests/integration/api/groups/ShowTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tests\integration\api\groups;
 
+use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -25,7 +26,7 @@ class ShowTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'groups' => [
+            Group::class => [
                 $this->hiddenGroup(),
             ],
         ]);

--- a/framework/core/tests/integration/api/notifications/DeleteTest.php
+++ b/framework/core/tests/integration/api/notifications/DeleteTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\api\notifications;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -26,20 +27,20 @@ class DeleteTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Test Discussion', 'user_id' => 2, 'comment_count' => 1],
                 ['id' => 2, 'title' => 'Test Discussion', 'user_id' => 2, 'comment_count' => 1],
                 ['id' => 3, 'title' => 'Test Discussion', 'user_id' => 1, 'comment_count' => 1],
                 ['id' => 4, 'title' => 'Test Discussion', 'user_id' => 1, 'comment_count' => 1],
             ],
             'notifications' => [
-                ['id' => 1, 'user_id' => 1, 'type' => 'discussionRenamed', 'subject_id' => 1, 'from_user_id' => 2, 'read_at' => Carbon::now()],
-                ['id' => 2, 'user_id' => 1, 'type' => 'discussionRenamed', 'subject_id' => 2, 'from_user_id' => 2, 'read_at' => null],
-                ['id' => 3, 'user_id' => 2, 'type' => 'discussionRenamed', 'subject_id' => 3, 'from_user_id' => 1, 'read_at' => Carbon::now()],
-                ['id' => 4, 'user_id' => 2, 'type' => 'discussionRenamed', 'subject_id' => 4, 'from_user_id' => 1, 'read_at' => null],
+                ['id' => 1, 'user_id' => 1, 'type' => 'discussionRenamed', 'subject_id' => 1, 'from_user_id' => 2, 'read_at' => Carbon::now(), 'created_at' => Carbon::now()],
+                ['id' => 2, 'user_id' => 1, 'type' => 'discussionRenamed', 'subject_id' => 2, 'from_user_id' => 2, 'read_at' => null, 'created_at' => Carbon::now()],
+                ['id' => 3, 'user_id' => 2, 'type' => 'discussionRenamed', 'subject_id' => 3, 'from_user_id' => 1, 'read_at' => Carbon::now(), 'created_at' => Carbon::now()],
+                ['id' => 4, 'user_id' => 2, 'type' => 'discussionRenamed', 'subject_id' => 4, 'from_user_id' => 1, 'read_at' => null, 'created_at' => Carbon::now()],
             ],
         ]);
     }

--- a/framework/core/tests/integration/api/notifications/ListTest.php
+++ b/framework/core/tests/integration/api/notifications/ListTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\notifications;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class ListTest extends TestCase
 {
@@ -24,7 +25,7 @@ class ListTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/posts/CreateTest.php
+++ b/framework/core/tests/integration/api/posts/CreateTest.php
@@ -10,9 +10,12 @@
 namespace Flarum\Tests\integration\api\posts;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class CreateTest extends TestCase
 {
@@ -26,15 +29,15 @@ class CreateTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1],
                 // Discussion with deleted first post.
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::now()->subDay()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'restricted', 'email' => 'restricted@machine.local', 'is_email_confirmed' => 1],
             ],

--- a/framework/core/tests/integration/api/posts/CreateTest.php
+++ b/framework/core/tests/integration/api/posts/CreateTest.php
@@ -41,7 +41,7 @@ class CreateTest extends TestCase
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'restricted', 'email' => 'restricted@machine.local', 'is_email_confirmed' => 1],
             ],
-            'groups' => [
+            Group::class => [
                 ['id' => 40, 'name_singular' => 'tess', 'name_plural' => 'tess'],
             ],
             'group_user' => [

--- a/framework/core/tests/integration/api/posts/DeleteTest.php
+++ b/framework/core/tests/integration/api/posts/DeleteTest.php
@@ -10,9 +10,12 @@
 namespace Flarum\Tests\integration\api\posts;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Discussion\UserState;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class DeleteTest extends TestCase
 {
@@ -26,14 +29,14 @@ class DeleteTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'acme2', 'email' => 'acme2@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 5, 'last_post_number' => 5, 'last_post_id' => 10],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 5, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 1],
                 ['id' => 6, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 2],
                 ['id' => 7, 'discussion_id' => 3, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>', 'number' => 3],

--- a/framework/core/tests/integration/api/posts/ListTest.php
+++ b/framework/core/tests/integration/api/posts/ListTest.php
@@ -10,8 +10,11 @@
 namespace Flarum\Tests\integration\api\posts;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListTest extends TestCase
@@ -23,18 +26,18 @@ class ListTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2],
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>something</p></t>'],
                 ['id' => 2, 'number' => 1, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>something</p></t>'],
                 ['id' => 3, 'number' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>something</p></t>'],
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>something</p></t>'],
                 ['id' => 5, 'number' => 3, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2, 'type' => 'discussionRenamed', 'content' => '<t><p>something</p></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/posts/ShowTest.php
+++ b/framework/core/tests/integration/api/posts/ShowTest.php
@@ -10,8 +10,11 @@
 namespace Flarum\Tests\integration\api\posts;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class ShowTest extends TestCase
 {
@@ -25,14 +28,14 @@ class ShowTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Discussion with post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>valid</p></t>'],
                 ['id' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<tMALFORMED'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/api/settings/SetTest.php
+++ b/framework/core/tests/integration/api/settings/SetTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\settings;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class SetTest extends TestCase
 {
@@ -24,7 +25,7 @@ class SetTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/users/DeleteTest.php
+++ b/framework/core/tests/integration/api/users/DeleteTest.php
@@ -22,7 +22,7 @@ class DeleteTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'ken', 'is_email_confirmed' => 1],
             ],

--- a/framework/core/tests/integration/api/users/GroupSearchTest.php
+++ b/framework/core/tests/integration/api/users/GroupSearchTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\users;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class GroupSearchTest extends TestCase
 {
@@ -21,7 +22,7 @@ class GroupSearchTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);
@@ -243,7 +244,7 @@ class GroupSearchTest extends TestCase
     private function createMultipleUsersAndGroups()
     {
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 [
                     'id' => 4,
                     'username' => 'normal4',
@@ -300,7 +301,7 @@ class GroupSearchTest extends TestCase
     private function createHiddenUser()
     {
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 [
                     'id' => 3,
                     'username' => 'normal2',

--- a/framework/core/tests/integration/api/users/GroupSearchTest.php
+++ b/framework/core/tests/integration/api/users/GroupSearchTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tests\integration\api\users;
 
+use Flarum\Group\Group;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -267,7 +268,7 @@ class GroupSearchTest extends TestCase
                     'is_email_confirmed' => 1,
                 ],
             ],
-            'groups' => [
+            Group::class => [
                 [
                     'id' => 5,
                     'name_singular' => 'test1 user',
@@ -310,7 +311,7 @@ class GroupSearchTest extends TestCase
                     'is_email_confirmed' => 1,
                 ],
             ],
-            'groups' => [
+            Group::class => [
                 [
                     'id' => 99,
                     'name_singular' => 'hidden user',

--- a/framework/core/tests/integration/api/users/ListTest.php
+++ b/framework/core/tests/integration/api/users/ListTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\users;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 class ListTest extends TestCase
@@ -25,7 +26,7 @@ class ListTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
+++ b/framework/core/tests/integration/api/users/PasswordEmailTokensTest.php
@@ -13,6 +13,7 @@ use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\EmailToken;
 use Flarum\User\PasswordToken;
+use Flarum\User\User;
 
 class PasswordEmailTokensTest extends TestCase
 {
@@ -23,7 +24,7 @@ class PasswordEmailTokensTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/users/SendActivationEmailTest.php
+++ b/framework/core/tests/integration/api/users/SendActivationEmailTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\users;
 use Carbon\Carbon;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\Throttler\EmailActivationThrottler;
+use Flarum\User\User;
 
 class SendActivationEmailTest extends TestCase
 {
@@ -20,7 +21,7 @@ class SendActivationEmailTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 [
                     'id' => 3,
                     'username' => 'normal2',

--- a/framework/core/tests/integration/api/users/SendPasswordResetEmailTest.php
+++ b/framework/core/tests/integration/api/users/SendPasswordResetEmailTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\users;
 use Carbon\Carbon;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\Throttler\PasswordResetThrottler;
+use Flarum\User\User;
 
 class SendPasswordResetEmailTest extends TestCase
 {
@@ -20,7 +21,7 @@ class SendPasswordResetEmailTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 [
                     'id' => 3,
                     'username' => 'normal2',

--- a/framework/core/tests/integration/api/users/ShowTest.php
+++ b/framework/core/tests/integration/api/users/ShowTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\users;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class ShowTest extends TestCase
 {
@@ -24,7 +25,7 @@ class ShowTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);

--- a/framework/core/tests/integration/api/users/UpdateTest.php
+++ b/framework/core/tests/integration/api/users/UpdateTest.php
@@ -27,7 +27,7 @@ class UpdateTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 [
                     'id' => 3,

--- a/framework/core/tests/integration/extenders/ApiControllerTest.php
+++ b/framework/core/tests/integration/extenders/ApiControllerTest.php
@@ -41,15 +41,15 @@ class ApiControllerTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser()
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
                 ['id' => 2, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 3, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
                 ['id' => 3, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'discussionRenamed', 'content' => '<t><p>can i haz relationz?</p></t>'],
                 ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'discussionRenamed', 'content' => '<t><p>can i haz relationz?</p></t>'],
                 ['id' => 3, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'discussionRenamed', 'content' => '<t><p>can i haz relationz?</p></t>'],
@@ -306,7 +306,7 @@ class ApiControllerTest extends TestCase
                 ->setSerializer(CustomPostSerializer::class, CustomApiControllerInvokableClass::class)
         );
         $this->prepareDatabase([
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>'],
             ],
         ]);

--- a/framework/core/tests/integration/extenders/ApiSerializerTest.php
+++ b/framework/core/tests/integration/extenders/ApiSerializerTest.php
@@ -36,15 +36,15 @@ class ApiSerializerTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser()
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
                 ['id' => 2, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
                 ['id' => 3, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'discussionRenamed', 'content' => '<t><p>can i haz relationz?</p></t>'],
             ],
         ]);

--- a/framework/core/tests/integration/extenders/FrontendTitleTest.php
+++ b/framework/core/tests/integration/extenders/FrontendTitleTest.php
@@ -9,11 +9,14 @@
 
 namespace Flarum\Tests\integration\extenders;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Extend\Frontend;
 use Flarum\Frontend\Document;
 use Flarum\Frontend\Driver\TitleDriverInterface;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 use Psr\Http\Message\ServerRequestInterface;
 
 class FrontendTitleTest extends TestCase
@@ -23,13 +26,13 @@ class FrontendTitleTest extends TestCase
     protected function setUp(): void
     {
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Test Discussion', 'user_id' => 1, 'first_post_id' => 1]
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>can i haz potat?</p></t>'],
             ],
         ]);
@@ -59,9 +62,9 @@ class FrontendTitleTest extends TestCase
     {
         $response = $this->send($this->request('GET', '/d/1'));
 
-        preg_match('/\<title\>(?<title>[^<]+)\<\/title\>/m', $response->getBody()->getContents(), $matches);
+        preg_match('/\<title\>(?<title>[^<]+)\<\/title\>/m', $body = $response->getBody()->getContents(), $matches);
 
-        $this->assertEquals($title, $matches['title']);
+        $this->assertEquals($title, $matches['title'] ?? null, $body);
     }
 }
 

--- a/framework/core/tests/integration/extenders/ModelTest.php
+++ b/framework/core/tests/integration/extenders/ModelTest.php
@@ -33,7 +33,7 @@ class ModelTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
         ]);
@@ -42,10 +42,10 @@ class ModelTest extends TestCase
     protected function prepPostsHierarchy()
     {
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Discussion with post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'discussionRenamed', 'content' => '<t><p>can i haz relationz?</p></t>'],
             ],
         ]);
@@ -164,7 +164,7 @@ class ModelTest extends TestCase
         );
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1]
             ]
         ]);
@@ -310,7 +310,7 @@ class ModelTest extends TestCase
         $group2 = new Group;
 
         $this->assertEquals(1, $group1->counter);
-        $this->assertEquals(2, $group2->counter);
+        $this->assertEquals(3, $group2->counter);
     }
 
     /**

--- a/framework/core/tests/integration/extenders/ModelUrlTest.php
+++ b/framework/core/tests/integration/extenders/ModelUrlTest.php
@@ -33,7 +33,7 @@ class ModelUrlTest extends TestCase
         $this->setting("slug_driver_$userClass", 'testDriver');
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/extenders/ModelVisibilityTest.php
+++ b/framework/core/tests/integration/extenders/ModelVisibilityTest.php
@@ -32,16 +32,16 @@ class ModelVisibilityTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Empty discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 0],
                 ['id' => 2, 'title' => 'Discussion with post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
                 ['id' => 3, 'title' => 'Private discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1, 'is_private' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>a normal reply - too-obscure</p></t>'],
                 ['id' => 2, 'discussion_id' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>private!</p></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/extenders/NotificationTest.php
+++ b/framework/core/tests/integration/extenders/NotificationTest.php
@@ -144,7 +144,7 @@ class NotificationTest extends TestCase
         );
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'hani']
             ],

--- a/framework/core/tests/integration/extenders/PolicyTest.php
+++ b/framework/core/tests/integration/extenders/PolicyTest.php
@@ -36,13 +36,13 @@ class PolicyTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Unrelated Discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>a normal reply - too-obscure</p></t>'],
             ]
         ]);

--- a/framework/core/tests/integration/extenders/SearchDriverTest.php
+++ b/framework/core/tests/integration/extenders/SearchDriverTest.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Tests\integration\extenders;
 
-use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Discussion\Search\Filter\UnreadFilter;

--- a/framework/core/tests/integration/extenders/SearchDriverTest.php
+++ b/framework/core/tests/integration/extenders/SearchDriverTest.php
@@ -14,6 +14,7 @@ use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Discussion\Search\Filter\UnreadFilter;
 use Flarum\Extend;
+use Flarum\Post\Post;
 use Flarum\Search\AbstractFulltextFilter;
 use Flarum\Search\Database\DatabaseSearchDriver;
 use Flarum\Search\Database\DatabaseSearchState;
@@ -37,13 +38,13 @@ class SearchDriverTest extends TestCase
         // which is needed for search, doesn't happen in transactions.
         // We clean it up explcitly at the end.
         $this->database()->table('discussions')->insert([
-            ['id' => 1, 'title' => 'DISCUSSION 1', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
-            ['id' => 2, 'title' => 'DISCUSSION 2', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'comment_count' => 1],
+            Discussion::factory()->raw(['id' => 1, 'title' => 'DISCUSSION 1', 'user_id' => 1]),
+            Discussion::factory()->raw(['id' => 2, 'title' => 'DISCUSSION 2', 'user_id' => 1]),
         ]);
 
         $this->database()->table('posts')->insert([
-            ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>not in text</p></t>'],
-            ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
+            Post::factory()->raw(['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'content' => '<t><p>not in text</p></t>']),
+            Post::factory()->raw(['id' => 2, 'discussion_id' => 2, 'user_id' => 1, 'content' => '<t><p>lightsail in text</p></t>']),
         ]);
 
         // We need to call these again, since we rolled back the transaction started by `::app()`.

--- a/framework/core/tests/integration/extenders/SearchIndexTest.php
+++ b/framework/core/tests/integration/extenders/SearchIndexTest.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Post\CommentPost;
+use Flarum\Post\Post;
 use Flarum\Search\IndexerInterface;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -27,11 +28,11 @@ class SearchIndexTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'DISCUSSION 1', 'created_at' => Carbon::now()->subDays(1)->toDateTimeString(), 'hidden_at' => null, 'comment_count' => 1, 'user_id' => 1, 'first_post_id' => 1],
                 ['id' => 2, 'title' => 'DISCUSSION 2', 'created_at' => Carbon::now()->subDays(2)->toDateTimeString(), 'hidden_at' => Carbon::now(), 'comment_count' => 1, 'user_id' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p>content</p></r>', 'hidden_at' => null],
                 ['id' => 2, 'number' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p>content</p></r>', 'hidden_at' => Carbon::now()],
             ],

--- a/framework/core/tests/integration/extenders/SettingsTest.php
+++ b/framework/core/tests/integration/extenders/SettingsTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\extenders;
 use Flarum\Extend;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class SettingsTest extends TestCase
 {
@@ -25,7 +26,7 @@ class SettingsTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser()
             ]
         ]);

--- a/framework/core/tests/integration/extenders/ThrottleApiTest.php
+++ b/framework/core/tests/integration/extenders/ThrottleApiTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\extenders;
 use Flarum\Extend;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class ThrottleApiTest extends TestCase
 {
@@ -25,7 +26,7 @@ class ThrottleApiTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/extenders/UserTest.php
+++ b/framework/core/tests/integration/extenders/UserTest.php
@@ -28,7 +28,7 @@ class UserTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/forum/DefaultRouteTest.php
+++ b/framework/core/tests/integration/forum/DefaultRouteTest.php
@@ -10,8 +10,10 @@
 namespace Flarum\Tests\integration\forum;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\integration\TestCase;
 
@@ -25,10 +27,10 @@ class DefaultRouteTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'foo bar', 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'last_posted_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::createFromDate(1975, 5, 21)->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>']
             ]
         ]);

--- a/framework/core/tests/integration/forum/GlobalLogoutTest.php
+++ b/framework/core/tests/integration/forum/GlobalLogoutTest.php
@@ -16,6 +16,7 @@ use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\EmailToken;
 use Flarum\User\PasswordToken;
+use Flarum\User\User;
 
 class GlobalLogoutTest extends TestCase
 {
@@ -33,10 +34,10 @@ class GlobalLogoutTest extends TestCase
         );
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser()
             ],
-            'access_tokens' => [
+            AccessToken::class => [
                 ['id' => 1, 'token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
                 ['id' => 2, 'token' => 'b', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session_remember'],
                 ['id' => 3, 'token' => 'c', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],

--- a/framework/core/tests/integration/forum/IndexTest.php
+++ b/framework/core/tests/integration/forum/IndexTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\forum;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class IndexTest extends TestCase
 {
@@ -22,7 +23,7 @@ class IndexTest extends TestCase
     protected function setUp(): void
     {
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser()
             ]
         ]);

--- a/framework/core/tests/integration/forum/LoginTest.php
+++ b/framework/core/tests/integration/forum/LoginTest.php
@@ -13,6 +13,7 @@ use Flarum\Extend;
 use Flarum\Http\AccessToken;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
 
 class LoginTest extends TestCase
 {
@@ -28,7 +29,7 @@ class LoginTest extends TestCase
         );
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser()
             ]
         ]);

--- a/framework/core/tests/integration/notification/NotificationSyncerTest.php
+++ b/framework/core/tests/integration/notification/NotificationSyncerTest.php
@@ -11,10 +11,12 @@ namespace Flarum\Tests\integration\notification;
 
 use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
+use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Notification;
 use Flarum\Notification\NotificationSyncer;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -28,16 +30,16 @@ class NotificationSyncerTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'Receiver', 'email' => 'receiver@machine.local', 'is_email_confirmed' => 1],
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Public discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0, 'last_post_number' => 2],
 
                 ['id' => 2, 'title' => 'Private discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 3, 'comment_count' => 2, 'is_private' => 1, 'last_post_number' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>', 'is_private' => 0],
                 ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'created_at' => Carbon::parse('2021-11-01 13:00:03')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>', 'is_private' => 1],
 

--- a/framework/core/tests/integration/policy/DiscussionPolicyTest.php
+++ b/framework/core/tests/integration/policy/DiscussionPolicyTest.php
@@ -14,6 +14,7 @@ use Flarum\Bus\Dispatcher;
 use Flarum\Discussion\Discussion;
 use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Post\Command\PostReply;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -31,16 +32,16 @@ class DiscussionPolicyTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Editable discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0, 'last_post_number' => 1, 'participant_count' => 1],
                 ['id' => 2, 'title' => 'Editable discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 2, 'is_private' => 0, 'last_post_number' => 2, 'participant_count' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
                 ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'created_at' => Carbon::parse('2021-11-01 13:00:03')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
                 ['id' => 3, 'discussion_id' => 2, 'number' => 2, 'created_at' => Carbon::parse('2021-11-01 13:00:03')->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/policy/PostPolicyTest.php
+++ b/framework/core/tests/integration/policy/PostPolicyTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\policy;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -27,14 +28,14 @@ class PostPolicyTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 1, 'title' => 'Editable discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0, 'last_post_number' => 2],
             ],
-            'posts' => [
+            Post::class => [
                 ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
                 ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'created_at' => Carbon::parse('2021-11-01 13:00:03')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
             ],
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ]
         ]);

--- a/framework/core/tests/integration/slugger/SlugDriverTest.php
+++ b/framework/core/tests/integration/slugger/SlugDriverTest.php
@@ -25,10 +25,10 @@ class SlugDriverTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-            'users' => [
+            User::class => [
                 $this->normalUser(),
             ],
-            'discussions' => [
+            Discussion::class => [
                 ['id' => 20, 'title' => 'Empty discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 0],
                 ['id' => 21, 'title' => 'తెలుగు', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 0],
                 ['id' => 22, 'title' => '支持中文吗', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 0],

--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -181,7 +181,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected array $databaseContent = [];
 
     /**
-     * @var array<string|class-string<Model>, array[]> $tableData
+     * @var array<string|class-string<Model>, array[]>
      */
     protected function prepareDatabase(array $tableData): void
     {


### PR DESCRIPTION
**Please ignore the failing PHPStan and Frontend tests, those have been fixed in other PRs that are still open**

**Changes proposed in this pull request:**
This PR introduces some eloquent factories for some models. The primary reason for introducing this is the following use case within tests:

We have a very large number of tests, in most tests we declare the data we need in the database like so:

```php
$this->prepareDatabase([
    'discussions' => [
        ['id' => 1, 'title' => 'no tags', 'user_id' => 1, 'comment_count' => 1],
        ['id' => 2, 'title' => 'has tags where mods can view discussions but not flags', 'user_id' => 1, 'comment_count' => 1],
        ['id' => 3, 'title' => 'has tags where mods can view flags but not discussions', 'user_id' => 1, 'comment_count' => 1],
        ['id' => 4, 'title' => 'has tags where mods can view discussions and flags', 'user_id' => 1, 'comment_count' => 1],
        ['id' => 5, 'title' => 'has unrestricted tag', 'user_id' => 1, 'comment_count' => 1],
    ],
]);
```

We set `comment_count' to 1 almost always rather than not, so that we are certain the discussions are visible. The problem is that when you introduce a new column that requires you to similarly always give it a value, you have to go through all the data in all the tests and make changes accordingly.. Which is very inconvenient.

By introducing factories, each model has a default template of fake data that can be edited, and the data specified in the tests is passed to the model factory to generate the final data.

So with this PR, it becomes as follows:

```php
$this->prepareDatabase([
    Discussion::class => [
        ['id' => 1, 'title' => 'no tags', 'user_id' => 1],
        ['id' => 2, 'title' => 'has tags where mods can view discussions but not flags', 'user_id' => 1],
        ['id' => 3, 'title' => 'has tags where mods can view flags but not discussions', 'user_id' => 1],
        ['id' => 4, 'title' => 'has tags where mods can view discussions and flags', 'user_id' => 1],
        ['id' => 5, 'title' => 'has unrestricted tag', 'user_id' => 1],
    ],
]);

// each row will be passed to the model factory like so internally:
$row = $modelClass::factory()->raw($row);

// The factory will have the default fake value needed.
class DiscussionFactory extends Factory
{
    public function definition(): array
    {
        return [
            'title' => $this->faker->sentence,
            'comment_count' => 1,
            ...
        ];
    }
}
```

To implement a factory class, the model must use the `HasFactory` trait, and the factory class which extends `Illuminate\Database\Eloquent\Factories\Factory` can exist in the same namespace as the model class. Otherwise the model may specify the class of the factory through the static `newFactory` method.

More on factories here: https://laravel.com/docs/10.x/eloquent-factories.

Additionally, factories are useful for other features the ecosystem may build (an example can involve a previewing feature of sorts).

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
