### PR TITLE
ci: allow custom actions runner to be defined

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -45,6 +45,12 @@ on:
         required: false
         default: error_reporting=E_ALL
 
+      runner_type:
+        description: The type of runner to use for the jobs. This should be one of the types supported by the `runs-on` keyword.
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+
     secrets:
       composer_auth:
         description: The Composer auth tokens to use for private packages.
@@ -57,7 +63,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_type }}
 
     strategy:
       matrix:
@@ -166,7 +172,7 @@ jobs:
           COMPOSER_PROCESS_TIMEOUT: 600
 
   phpstan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_type }}
 
     strategy:
       matrix:

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -86,6 +86,12 @@ on:
         type: string
         required: false
 
+      runner_type:
+        description: The type of runner to use for the jobs. This should be one of the types supported by the `runs-on` keyword.
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+
     secrets:
       bundlewatch_github_token:
         description: The GitHub token to use for Bundlewatch.
@@ -103,7 +109,7 @@ env:
 jobs:
   build:
     name: Checks & Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_type }}
 
     if: >-
       ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Companion of #3988 

**Changes proposed in this pull request:**
Allow custom GitHub Actions runner to be defined in the reusable frontend & backend workflows. This allows third-party vendors to optionally pass a new input `runner_type` which specifies on which machine the jobs are being run (be it a custom GitHub-hosted runner or a self-hosted one). 

Hypothetical example of a calling workflow:

```
name: ACME Foobar PHP

on: [workflow_dispatch, push, pull_request]

jobs:
  run:
    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@1.x
    with:
      enable_backend_testing: true
      enable_phpstan: true
      php_versions: '["8.0", "8.1", "8.2", "8.3"]'
      runner_type: self-hosted

      backend_directory: . 
```
It's important to note that this new input is **optional** and will default to `ubuntu-latest` if not defined by the calling workflow. 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
