### PR TITLE
fix: setting key `safe_mode_extensions` not exists

### DIFF
--- a/framework/core/src/Admin/WhenSavingSettings.php
+++ b/framework/core/src/Admin/WhenSavingSettings.php
@@ -36,14 +36,18 @@ class WhenSavingSettings
     {
         if (array_key_exists('safe_mode_extensions', $event->settings)) {
             $safeModeExtensions = json_decode($event->settings['safe_mode_extensions'] ?? '[]', true);
+            $sorted = [];
 
-            $extensions = $this->extensions->getExtensions()->filter(function ($extension) use ($safeModeExtensions) {
-                return in_array($extension->getId(), $safeModeExtensions);
-            });
+            if ($safeModeExtensions) {
+                $extensions = $this->extensions->getExtensions()->filter(function ($extension) use ($safeModeExtensions) {
+                    return in_array($extension->getId(), $safeModeExtensions);
+                });
 
-            $sorted = array_map(fn (Extension $e) => $e->getId(), $this->extensions->sortDependencies($extensions->all()));
+                $sorted = array_map(fn (Extension $e) => $e->getId(), $this->extensions->sortDependencies($extensions->all()));
+                $sorted = array_values($sorted);
+            }
 
-            $event->settings['safe_mode_extensions'] = json_encode(array_values($sorted));
+            $event->settings['safe_mode_extensions'] = json_encode($sorted);
         }
     }
 

--- a/framework/core/src/Foundation/Config.php
+++ b/framework/core/src/Foundation/Config.php
@@ -65,7 +65,7 @@ class Config implements ArrayAccess
 
     public function safeModeExtensions(): ?array
     {
-        return $this->data['safe_mode_extensions'];
+        return $this->data['safe_mode_extensions'] ?? null;
     }
 
     private function requireKeys(mixed ...$keys): void


### PR DESCRIPTION
Fix setting key `safe_mode_extensions` not exists

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
