### PR TITLE
feat: add option for filtering read stickied on all discussions page

### DIFF
--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -60,4 +60,8 @@ return [
 
     (new Extend\SimpleFlarumSearch(DiscussionSearcher::class))
         ->addGambit(StickyFilterGambit::class),
+
+    (new Extend\Settings())
+        ->default('flarum-sticky.filter_read_from_stickied', true)
+        ->serializeToForum('filterReadFromStickied', 'flarum-sticky.filter_read_from_stickied', 'boolval'),
 ];

--- a/extensions/sticky/js/src/admin/index.js
+++ b/extensions/sticky/js/src/admin/index.js
@@ -10,4 +10,12 @@ app.initializers.add('flarum-sticky', () => {
     'moderate',
     95
   );
+
+  app.extensionData.for('flarum-sticky')
+    .registerSetting({
+      setting: 'flarum-sticky.filter_read_from_stickied',
+      name: 'filterReadFromStickied',
+      type: 'boolean',
+      label: app.translator.trans('flarum-sticky.admin.settings.filter_read_from_stickied_label'),
+    });
 });

--- a/extensions/sticky/locale/en.yml
+++ b/extensions/sticky/locale/en.yml
@@ -6,6 +6,8 @@ flarum-sticky:
 
   # Translations in this namespace are used by the admin interface.
   admin:
+    settings:
+      filter_read_from_stickied_label: Filter read from stickied on All Discussions page
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -99,6 +99,40 @@ class ListDiscussionsTest extends TestCase
     }
 
     /** @test */
+    public function list_discussions_sticky_first_all_read_as_user_filter_read_off()
+    {
+        $this->setting('flarum-sticky.filter_read_from_stickied', false);
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 3
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals([3, 1, 2, 4], Arr::pluck($data['data'], 'id'));
+    }
+
+    /** @test */
+    public function list_discussions_sticky_first_all_read_as_user_filter_read_on()
+    {
+        $this->setting('flarum-sticky.filter_read_from_stickied', true);
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 3
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
+    }
+
+    /** @test */
     public function list_discussions_shows_stick_first_on_a_tag()
     {
         $response = $this->send(


### PR DESCRIPTION
**Changes proposed in this pull request:**
Firstly, apologies if you are not taking PR's for 1.x or if this is just not something that would be considered. I can create a third party extension if that is a better option.

As per discussion on Flarum Discuss - https://discuss.flarum.org/d/34607-flarum-do-perform-some-automated-update
For some, the stickied posts dropping down the order on "All Discusisons" like a non-stickied post when the discussion has been read is not an expected behaviour. I have added a simple on/off option which defaults to the existing behaviour. With the switch on, the read discussions on "All Discussions" are not treated as stickied. With the switch off, all stickied posts remain stickied on "All Discussions" regardless of their read status.

**Reviewers should focus on:**
n/a

**Screenshot**
Settings
![Settings page](https://i.ibb.co/b6091wk/sticky-settings-page.png)

Default/turned on
![Settings page](https://i.ibb.co/cD5rTbV/sticky-default-on.png)

Turned off
![Settings page](https://i.ibb.co/6m9Dn9g/sticky-option-off.png)


**QA**
1. On a forum with a heap of discussions, sticky a few random ones
2. Mark some at the top as "read" - refresh "All Discussions" page to see those discussions drop down the list
3. Switch the option `Filter read from stickied on All Discussions` page off
4. See all stickied discussions at the top of "All Discussions" page

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
 
**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
