### PR TITLE
feat: add option for filtering read stickied on all discussions page

### DIFF
--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -59,6 +59,6 @@ return [
         ->addMutator(DiscussionSearcher::class, PinStickiedDiscussionsToTop::class),
 
     (new Extend\Settings())
-        ->default('flarum-sticky.filter_read_from_stickied', true)
-        ->serializeToForum('filterReadFromStickied', 'flarum-sticky.filter_read_from_stickied', 'boolval'),
+        ->default('flarum-sticky.only_sticky_unread_discussions', true)
+        ->serializeToForum('onlyStickyUnreadDiscussions', 'flarum-sticky.only_sticky_unread_discussions', 'boolval'),
 ];

--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -57,4 +57,8 @@ return [
     (new Extend\SearchDriver(DatabaseSearchDriver::class))
         ->addFilter(DiscussionSearcher::class, StickyFilter::class)
         ->addMutator(DiscussionSearcher::class, PinStickiedDiscussionsToTop::class),
+
+    (new Extend\Settings())
+        ->default('flarum-sticky.filter_read_from_stickied', true)
+        ->serializeToForum('filterReadFromStickied', 'flarum-sticky.filter_read_from_stickied', 'boolval'),
 ];

--- a/extensions/sticky/js/src/admin/index.js
+++ b/extensions/sticky/js/src/admin/index.js
@@ -15,11 +15,11 @@ app.initializers.add('flarum-sticky', () => {
 
   app.extensionData.for('flarum-sticky').registerSetting(
     {
-      setting: 'flarum-sticky.filter_read_from_stickied',
-      name: 'filterReadFromStickied',
+      setting: 'flarum-sticky.only_sticky_unread_discussions',
+      name: 'onlyStickyUnreadDiscussions',
       type: 'boolean',
-      label: app.translator.trans('flarum-sticky.admin.settings.filter_read_from_stickied_label'),
-      help: app.translator.trans('flarum-sticky.admin.settings.filter_read_from_stickied_help'),
+      label: app.translator.trans('flarum-sticky.admin.settings.only_sticky_unread_discussions_label'),
+      help: app.translator.trans('flarum-sticky.admin.settings.only_sticky_unread_discussions_help'),
     }
   );
 });

--- a/extensions/sticky/js/src/admin/index.js
+++ b/extensions/sticky/js/src/admin/index.js
@@ -12,4 +12,14 @@ app.initializers.add('flarum-sticky', () => {
     'moderate',
     95
   );
+
+  app.extensionData.for('flarum-sticky').registerSetting(
+    {
+      setting: 'flarum-sticky.filter_read_from_stickied',
+      name: 'filterReadFromStickied',
+      type: 'boolean',
+      label: app.translator.trans('flarum-sticky.admin.settings.filter_read_from_stickied_label'),
+      help: app.translator.trans('flarum-sticky.admin.settings.filter_read_from_stickied_help'),
+    }
+  );
 });

--- a/extensions/sticky/locale/en.yml
+++ b/extensions/sticky/locale/en.yml
@@ -7,8 +7,8 @@ flarum-sticky:
   # Translations in this namespace are used by the admin interface.
   admin:
     settings:
-      filter_read_from_stickied_label: Filter read stickied (All Discussions)
-      filter_read_from_stickied_help: If a discussion is read, it will not be considered stickied on the All Discussions page
+      only_sticky_unread_discussions_label: Only sticky unread discussions
+      only_sticky_unread_discussions_help: On the All Discussions page, unread sticky discussions pin to the top, while read sticky discussions follow the regular order.
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:

--- a/extensions/sticky/locale/en.yml
+++ b/extensions/sticky/locale/en.yml
@@ -6,6 +6,9 @@ flarum-sticky:
 
   # Translations in this namespace are used by the admin interface.
   admin:
+    settings:
+      filter_read_from_stickied_label: Filter read stickied (All Discussions)
+      filter_read_from_stickied_help: If a discussion is read, it will not be considered stickied on the All Discussions page
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:

--- a/extensions/sticky/src/PinStickiedDiscussionsToTop.php
+++ b/extensions/sticky/src/PinStickiedDiscussionsToTop.php
@@ -16,22 +16,20 @@ use Flarum\Tags\Search\Filter\TagFilter;
 
 class PinStickiedDiscussionsToTop
 {
-    protected SettingsRepositoryInterface $settings;
-
-    public function __construct(SettingsRepositoryInterface $settings)
-    {
-        $this->settings = $settings;
+    public function __construct(
+        protected SettingsRepositoryInterface $settings
+    ) {
     }
 
     public function __invoke(DatabaseSearchState $state, SearchCriteria $criteria): void
     {
         if ($criteria->sortIsDefault && ! $state->isFulltextSearch()) {
             $query = $state->getQuery();
-            $filterRead = $this->settings->get('flarum-sticky.filter_read_from_stickied');
+            $onlyStickyUnread = $this->settings->get('flarum-sticky.only_sticky_unread_discussions');
 
-            // If filter read from stickied is disabled, then pin all stickied
+            // If only sticky unread discussions is disabled, then pin all stickied
             // discussions to the top whether they are read or not.
-            if (! $filterRead) {
+            if (! $onlyStickyUnread) {
                 $this->pinStickiedToTop($query);
 
                 return;

--- a/extensions/sticky/src/PinStickiedDiscussionsToTop.php
+++ b/extensions/sticky/src/PinStickiedDiscussionsToTop.php
@@ -31,7 +31,7 @@ class PinStickiedDiscussionsToTop
 
             // If filter read from stickied is disabled, then pin all stickied
             // discussions to the top whether they are read or not.
-            if (!$filterRead) {
+            if (! $filterRead) {
                 $this->pinStickiedToTop($query);
 
                 return;
@@ -92,7 +92,7 @@ class PinStickiedDiscussionsToTop
      */
     protected function pinStickiedToTop($query): void
     {
-        if (!is_array($query->orders)) {
+        if (! is_array($query->orders)) {
             $query->orders = [];
         }
 

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -104,7 +104,7 @@ class ListDiscussionsTest extends TestCase
     /** @test */
     public function list_discussions_sticky_first_all_read_as_user_filter_read_off()
     {
-        $this->setting('flarum-sticky.filter_read_from_stickied', false);
+        $this->setting('flarum-sticky.only_sticky_unread_discussions', false);
         $response = $this->send(
             $this->request('GET', '/api/discussions', [
                 'authenticatedAs' => 3
@@ -121,7 +121,7 @@ class ListDiscussionsTest extends TestCase
     /** @test */
     public function list_discussions_sticky_first_all_read_as_user_filter_read_on()
     {
-        $this->setting('flarum-sticky.filter_read_from_stickied', true);
+        $this->setting('flarum-sticky.only_sticky_unread_discussions', true);
         $response = $this->send(
             $this->request('GET', '/api/discussions', [
                 'authenticatedAs' => 3

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -101,6 +101,42 @@ class ListDiscussionsTest extends TestCase
         $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
     }
 
+
+    /** @test */
+    public function list_discussions_sticky_first_all_read_as_user_filter_read_off()
+    {
+        $this->setting('flarum-sticky.filter_read_from_stickied', false);
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 3
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals([3, 1, 2, 4], Arr::pluck($data['data'], 'id'));
+    }
+
+    /** @test */
+    public function list_discussions_sticky_first_all_read_as_user_filter_read_on()
+    {
+        $this->setting('flarum-sticky.filter_read_from_stickied', true);
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 3
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
+    }
+
+
     /** @test */
     public function list_discussions_shows_stick_first_on_a_tag()
     {

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -101,7 +101,6 @@ class ListDiscussionsTest extends TestCase
         $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
     }
 
-
     /** @test */
     public function list_discussions_sticky_first_all_read_as_user_filter_read_off()
     {
@@ -135,7 +134,6 @@ class ListDiscussionsTest extends TestCase
 
         $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
     }
-
 
     /** @test */
     public function list_discussions_shows_stick_first_on_a_tag()


### PR DESCRIPTION
**Changes proposed in this pull request:**
This is an updated PR from the previous one that was pointing to 1.x. I've set up 2.x (as much as I could) locally and have tested this one - I have a bit less test data this time as I was unable to get the fake-data extension to install on 2.x.

As per discussion on Flarum Discuss - https://discuss.flarum.org/d/34607-flarum-do-perform-some-automated-update
For some, the stickied posts dropping down the order on "All Discusisons" like a non-stickied post when the discussion has been read is not an expected behaviour. I have added a simple on/off option which defaults to the existing behaviour. With the switch on, the read discussions on "All Discussions" are not treated as stickied. With the switch off, all stickied posts remain stickied on "All Discussions" regardless of their read status.

**Reviewers should focus on:**
n/a

**Screenshot**
Settings
![Settings page](https://i.ibb.co/vBhDgwh/sticky-settings-page.png)

Default/turned on
![Settings page](https://i.ibb.co/6vz63YF/sticky-default-on.png)

Turned off
![Settings page](https://i.ibb.co/0JMJp0Y/sticky-option-off.png)


**QA**
1. On a forum with a heap of discussions, sticky a few random ones
2. Mark some at the top as "read" - refresh "All Discussions" page to see those discussions drop down the list
3. Switch the option `Filter read from stickied on All Discussions` page off
4. See all stickied discussions at the top of "All Discussions" page

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, ~~or are not appropriate here.~~
 
**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
