### PR TITLE
[suspend][core] [1.x] fix: suspended users can remove avatar

### DIFF
--- a/extensions/suspend/extend.php
+++ b/extensions/suspend/extend.php
@@ -19,6 +19,7 @@ use Flarum\Suspend\Notification\UserSuspendedBlueprint;
 use Flarum\Suspend\Notification\UserUnsuspendedBlueprint;
 use Flarum\Suspend\Query\SuspendedFilterGambit;
 use Flarum\Suspend\RevokeAccessFromSuspendedUsers;
+use Flarum\User\Event\AvatarDeleting;
 use Flarum\User\Event\Saving;
 use Flarum\User\Filter\UserFilterer;
 use Flarum\User\Search\UserSearcher;
@@ -50,7 +51,8 @@ return [
     (new Extend\Event())
         ->listen(Saving::class, Listener\SaveSuspensionToDatabase::class)
         ->listen(Suspended::class, Listener\SendNotificationWhenUserIsSuspended::class)
-        ->listen(Unsuspended::class, Listener\SendNotificationWhenUserIsUnsuspended::class),
+        ->listen(Unsuspended::class, Listener\SendNotificationWhenUserIsUnsuspended::class)
+        ->listen(AvatarDeleting::class, Listener\PreventAvatarDeletionBySuspendedUser::class),
 
     (new Extend\Policy())
         ->modelPolicy(User::class, UserPolicy::class),

--- a/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
+++ b/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Suspend\Listener;
 
 use Flarum\User\Exception\PermissionDeniedException;

--- a/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
+++ b/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Flarum\Suspend\Listener;
+
+use Flarum\User\Exception\PermissionDeniedException;
+
+class PreventAvatarDeletionBySuspendedUser
+{
+    public function handle($event)
+    {
+        $actor = $event->actor;
+        $user = $event->user;
+
+        if ($actor->id === $user->id && $user->suspended_until) {
+            throw new PermissionDeniedException();
+        }
+    }
+}

--- a/extensions/suspend/tests/integration/api/users/RemoveAvatarTest.php
+++ b/extensions/suspend/tests/integration/api/users/RemoveAvatarTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Suspend\Tests\integration\api\users;
 
 use Carbon\Carbon;

--- a/extensions/suspend/tests/integration/api/users/RemoveAvatarTest.php
+++ b/extensions/suspend/tests/integration/api/users/RemoveAvatarTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Flarum\Suspend\Tests\integration\api\users;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class RemoveAvatarTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-suspend');
+
+        $this->prepareDatabase([
+            'users' => [
+                ['id' => 1, 'username' => 'Muralf', 'email' => 'muralf@machine.local', 'is_email_confirmed' => 1],
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->addDay(), 'suspend_message' => 'You have been suspended.', 'suspend_reason' => 'Suspended for acme reasons.'],
+                ['id' => 4, 'username' => 'acme4', 'email' => 'acme4@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'acme5', 'email' => 'acme5@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->subDay(), 'suspend_message' => 'You have been suspended.', 'suspend_reason' => 'Suspended for acme reasons.'],
+            ],
+            'groups' => [
+                ['id' => 5, 'name_singular' => 'can_edit_users', 'name_plural' => 'can_edit_users', 'is_hidden' => 0]
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => 5]
+            ],
+            'group_permission' => [
+                ['permission' => 'user.edit', 'group_id' => 5],
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     * @dataProvider allowedToRemoveAvatar
+     */
+    public function can_remove_avatar_if_allowed(?int $authenticatedAs, int $targetUserId)
+    {
+        $response = $this->sendRemoveAvatarRequest($authenticatedAs, $targetUserId);
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+    }
+
+    /**
+     * @test
+     * @dataProvider notAllowedToRemoveAvatar
+     */
+    public function cannot_remove_avatar_if_not_allowed(?int $authenticatedAs, int $targetUserId)
+    {
+        $response = $this->sendRemoveAvatarRequest($authenticatedAs, $targetUserId);
+
+        $this->assertEquals(403, $response->getStatusCode(), $response->getBody()->getContents());
+    }
+
+    public function allowedToRemoveAvatar(): array
+    {
+        return [
+            [1, 4, 'Admin can remove avatar of normal user'],
+            [4, 4, 'Normal user can remove their own avatar'],
+            [1, 3, 'Admin can remove avatar of suspended user'],
+            [2, 3, 'Normal user with permission can remove avatar of suspended user'],
+        ];
+    }
+
+    public function notAllowedToRemoveAvatar(): array
+    {
+        return [
+            [4, 2, 'Normal user cannot remove avatar of another user'],
+            [4, 3, 'Normal user cannot remove avatar of suspended user'],
+            [3, 3, 'Suspended user cannot remove their own avatar'],
+        ];
+    }
+
+    protected function sendRemoveAvatarRequest(?int $authenticatedAs, int $targetUserId): ResponseInterface
+    {
+        return $this->send(
+            $this->request('DELETE', "/api/users/$targetUserId/avatar", [
+                'authenticatedAs' => $authenticatedAs,
+            ])
+        );
+    }
+}

--- a/framework/core/src/User/Command/DeleteAvatarHandler.php
+++ b/framework/core/src/User/Command/DeleteAvatarHandler.php
@@ -56,11 +56,11 @@ class DeleteAvatarHandler
             $actor->assertCan('edit', $user);
         }
 
-        $this->uploader->remove($user);
-
         $this->events->dispatch(
             new AvatarDeleting($user, $actor)
         );
+
+        $this->uploader->remove($user);
 
         $user->save();
 


### PR DESCRIPTION
Reported https://discuss.flarum.org/d/32899-flarum-v180-released/83 and following on from https://github.com/flarum/framework/pull/3890

**Changes proposed in this pull request:**
Dispatch `AvatarDeleting` before beginning the avatar deletion process, add a listener to `flarum/suspend` to prevent a suspended user from removing their avatar. Admins and other users with permission may still remove the avatar of the suspended user if required.

New tests for this scenario are included. Happy to make the same change against the `2.x` branch if required, please let me know.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
- [X] Core developer confirmed locally this works as intended.
- [X] Tests have been added, or are not appropriate here.

