### PR TITLE
chore: simplify variable assignment using null coalescing operator

### DIFF
--- a/extensions/package-manager/src/Composer/ComposerAdapter.php
+++ b/extensions/package-manager/src/Composer/ComposerAdapter.php
@@ -36,7 +36,7 @@ class ComposerAdapter
     {
         $this->application->resetComposer();
 
-        $this->output = $this->output ?? new BufferedOutput();
+        $this->output ??= new BufferedOutput();
 
         // This hack is necessary so that relative path repositories are resolved properly.
         $currDir = getcwd();

--- a/framework/core/src/Install/Steps/EnableBundledExtensions.php
+++ b/framework/core/src/Install/Steps/EnableBundledExtensions.php
@@ -123,7 +123,7 @@ class EnableBundledExtensions implements Step
 
     private function getMigrator(): Migrator
     {
-        return $this->migrator = $this->migrator ?? new Migrator(
+        return $this->migrator ??= new Migrator(
             new DatabaseMigrationRepository($this->database, 'migrations'),
             $this->database,
             new \Illuminate\Filesystem\Filesystem


### PR DESCRIPTION
Simplify variable assignment using null coalescing operator

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
