### PR TITLE
fix: cannot install without db prefix

### DIFF
--- a/framework/core/src/Database/Migrator.php
+++ b/framework/core/src/Database/Migrator.php
@@ -262,7 +262,7 @@ class Migrator
 
             $statement = str_replace(
                 'db_prefix_',
-                $this->connection->getTablePrefix(),
+                $this->connection->getTablePrefix() ?? '',
                 $statement
             );
             $this->connection->statement($statement);

--- a/framework/core/src/Install/DatabaseConfig.php
+++ b/framework/core/src/Install/DatabaseConfig.php
@@ -21,7 +21,7 @@ class DatabaseConfig implements Arrayable
         private string $database,
         private readonly ?string $username,
         private readonly ?string $password,
-        private readonly string $prefix
+        private readonly ?string $prefix
     ) {
         $this->validate();
     }


### PR DESCRIPTION
Database prefix and database password can be empty.

Caused by the rewrite in https://github.com/flarum/framework/commit/6f11e044a7c18c14793c7d98e99a83a6ade5ae97, as a consequence some settings of the database config are now incorrectly enforced/required.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
