### PR TITLE
refactor: unify frontend initializers naming

### DIFF
--- a/extensions/lock/js/src/admin/index.js
+++ b/extensions/lock/js/src/admin/index.js
@@ -2,7 +2,7 @@ import app from 'flarum/admin/app';
 
 export { default as extend } from './extend';
 
-app.initializers.add('lock', () => {
+app.initializers.add('flarum-lock', () => {
   app.extensionData.for('flarum-lock').registerPermission(
     {
       icon: 'fas fa-lock',

--- a/extensions/mentions/js/src/admin/index.js
+++ b/extensions/mentions/js/src/admin/index.js
@@ -1,6 +1,6 @@
 import app from 'flarum/admin/app';
 
-app.initializers.add('flarum-mentions', function () {
+app.initializers.add('flarum-mentions', () => {
   app.extensionData
     .for('flarum-mentions')
     .registerSetting({

--- a/extensions/mentions/js/src/forum/index.js
+++ b/extensions/mentions/js/src/forum/index.js
@@ -17,7 +17,7 @@ app.mentionFormats = new MentionFormats();
 
 export { default as extend } from './extend';
 
-app.initializers.add('flarum-mentions', function () {
+app.initializers.add('flarum-mentions', () => {
   // For every mention of a post inside a post's content, set up a hover handler
   // that shows a preview of the mentioned post.
   addPostMentionPreviews();

--- a/extensions/nicknames/js/src/admin/index.js
+++ b/extensions/nicknames/js/src/admin/index.js
@@ -5,7 +5,7 @@ import BasicsPage from 'flarum/admin/components/BasicsPage';
 import extractText from 'flarum/common/utils/extractText';
 import { extend } from 'flarum/common/extend';
 
-app.initializers.add('flarum/nicknames', () => {
+app.initializers.add('flarum-nicknames', () => {
   app.extensionData
     .for('flarum-nicknames')
     .registerSetting(function () {

--- a/extensions/nicknames/js/src/forum/index.js
+++ b/extensions/nicknames/js/src/forum/index.js
@@ -7,7 +7,7 @@ import NickNameModal from './components/NicknameModal';
 
 export { default as extend } from './extend';
 
-app.initializers.add('flarum/nicknames', () => {
+app.initializers.add('flarum-nicknames', () => {
   extend('flarum/forum/components/SettingsPage', 'accountItems', function (items) {
     if (app.forum.attribute('displayNameDriver') !== 'nickname') return;
 

--- a/extensions/subscriptions/js/src/forum/index.js
+++ b/extensions/subscriptions/js/src/forum/index.js
@@ -8,7 +8,7 @@ import addSubscriptionSettings from './addSubscriptionSettings';
 
 export { default as extend } from './extend';
 
-app.initializers.add('subscriptions', function () {
+app.initializers.add('flarum-subscriptions', function () {
   addSubscriptionBadge();
   addSubscriptionControls();
   addSubscriptionFilter();

--- a/extensions/subscriptions/js/src/forum/index.js
+++ b/extensions/subscriptions/js/src/forum/index.js
@@ -8,7 +8,7 @@ import addSubscriptionSettings from './addSubscriptionSettings';
 
 export { default as extend } from './extend';
 
-app.initializers.add('flarum-subscriptions', function () {
+app.initializers.add('flarum-subscriptions', () => {
   addSubscriptionBadge();
   addSubscriptionControls();
   addSubscriptionFilter();

--- a/extensions/tags/js/src/forum/index.ts
+++ b/extensions/tags/js/src/forum/index.ts
@@ -10,7 +10,7 @@ import addTagComposer from './addTagComposer';
 
 export { default as extend } from './extend';
 
-app.initializers.add('flarum-tags', function () {
+app.initializers.add('flarum-tags', () => {
   app.tagList = new TagListState();
 
   addTagList();


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Use consistent naming for frontend initializers (and slightly change syntax), as the current best practice seems to be `acme-foobar`. Some bundled extensions were still initialized like this: `acme/foobar` or `foobar`.

**Reviewers should focus on:**
Seems like no bundled extension does any check in the frontend if another extension is initialized, for example:

```
if (app.initializers.has('flarum-tags')) {
    ...
}
```

So, as far as I can tell, the changes introduced in the PR should work standalone.  But please double-check that I've not missed anything else for this to work out of the box (I have not yet setup 2.x for local development..)

Extension developers need to refactor their frontend initializer checks when upgrading their extensions for `2.x`, so this must be included in the upgrade guide and potentially also noted as a breaking change.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
