### PR TITLE
[2.x] style: hide search clear button when collapsed in tablet mode

### DIFF
--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -306,6 +306,9 @@
     &:not(.active) input {
       padding-right: 0;
     }
+    input:not(:focus) ~ .Input-clear {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4593**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

In tablet mode, if the search state retains a value, the Input component still renders the `.Input-clear` button, causing it to visually overlap with the search prefix icon.

This PR adds a CSS rule using the sibling selector `input:not(:focus) ~ .Input-clear` within the existing tablet media query to hide the clear button when the input is collapsed.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

Before:

https://github.com/user-attachments/assets/fa99dcbe-9be3-4741-9f7b-25f645e66eb8

After:

https://github.com/user-attachments/assets/40b59994-3c63-428a-b1a4-850558c7ddac

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
