### PR TITLE
[2.x] fix: prevent search modal from opening when clear button is clicked

### DIFF
--- a/framework/core/js/src/common/components/Input.tsx
+++ b/framework/core/js/src/common/components/Input.tsx
@@ -52,7 +52,10 @@ export default class Input<CustomAttrs extends IInputAttrs = IInputAttrs> extend
         {this.attrs.clearable && value && !this.attrs.loading ? (
           <Button
             className="Input-clear Button Button--icon Button--link"
-            onclick={this.clear.bind(this)}
+            onclick={(e: MouseEvent) => {
+              e.stopPropagation();
+              this.clear();
+            }}
             aria-label={this.attrs.clearLabel || app.translator.trans('core.lib.input.clear_button')}
             type="button"
             icon="fas fa-times-circle"


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4593**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

The `.Search` div in `AbstractGlobalSearch` has an `onclick` handler that opens the search modal. When the clear button inside the `Input` component is clicked, the event bubbles up to this handler, causing the search modal to open immediately after clearing the value.

~~This PR adds a guard in the `onclick` handler to check if the click originated from within the `.Input-clear` element and short-circuit before opening the modal.~~

Found a better solution
This PR modifies the Input component to call `e.stopPropagation()` inside the clear button's onclick handler. This will prevent the click from bubbling up to any parent container.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Before:

https://github.com/user-attachments/assets/23c8a7af-fd30-4555-a475-74e632ff619f

After:

https://github.com/user-attachments/assets/dd61b8ea-0c1a-423a-bf61-5daf5e222436


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
