### PR TITLE
[2.x] fix(nicknames): cast min/max settings to int before passing to Schema\Str

### DIFF
--- a/extensions/nicknames/src/Api/UserResourceFields.php
+++ b/extensions/nicknames/src/Api/UserResourceFields.php
@@ -32,6 +32,13 @@ class UserResourceFields
             $regex = "/$regex/";
         }
 
+        // Settings are always returned as strings from the DB. Coerce and only
+        // apply the length constraint when the admin has configured a non-zero
+        // value; an empty field saved from the admin panel would otherwise be
+        // stored as '' and cast to 0, making maxLength(0) reject every value.
+        $min = (int) $this->settings->get('flarum-nicknames.min');
+        $max = (int) $this->settings->get('flarum-nicknames.max');
+
         return [
             Schema\Str::make('nickname')
                 ->visible(false)
@@ -43,8 +50,8 @@ class UserResourceFields
                 // may render as hyperlinks in notification emails.
                 ->rule('not_regex:/[\[\]()<>]/')
                 ->regex($regex ?? '', ! empty($regex))
-                ->minLength($this->settings->get('flarum-nicknames.min'))
-                ->maxLength($this->settings->get('flarum-nicknames.max'))
+                ->minLength($min, $min > 0)
+                ->maxLength($max, $max > 0)
                 ->unique('users', 'nickname', true, (bool) $this->settings->get('flarum-nicknames.unique'))
                 ->unique('users', 'username', true, (bool) $this->settings->get('flarum-nicknames.unique'))
                 ->validationMessages([

--- a/extensions/nicknames/tests/integration/api/EditUserTest.php
+++ b/extensions/nicknames/tests/integration/api/EditUserTest.php
@@ -178,4 +178,45 @@ class EditUserTest extends TestCase
             'html attribute inject' => ['"><img src=x>'],
         ];
     }
+
+    // Regression test for the TypeError raised by UserResourceFields when an
+    // admin saves the nicknames config form with an empty min or max field —
+    // the empty string is persisted to the settings table and then passed
+    // straight to Schema\Str::minLength(int)/maxLength(int), which rejects
+    // non-numeric strings under PHP's default type coercion rules.
+    //
+    //   TypeError: Str::maxLength(): Argument #1 ($length) must be of type int, string given
+    //
+    // Numeric strings like '3' coerce silently, so the bug only surfaces when
+    // a field is cleared. The int defaults from the Settings extender mask it
+    // until the admin saves once.
+    #[Test]
+    public function request_succeeds_when_min_or_max_setting_is_empty_string(): void
+    {
+        $this->setting('flarum-nicknames.min', '');
+        $this->setting('flarum-nicknames.max', '');
+
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'user.editOwnNickname', 'group_id' => Group::MEMBER_ID],
+            ],
+        ]);
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/2', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'type' => 'users',
+                        'attributes' => [
+                            'nickname' => 'jane.smith',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+        $this->assertEquals('jane.smith', User::find(2)->nickname);
+    }
 }


### PR DESCRIPTION
**Fixes the TypeError reported against 2.x nightly:**

```
TypeError: Flarum\Api\Schema\Str::maxLength(): Argument #1 ($length) must be of type int, string given,
  called in .../nicknames/src/Api/UserResourceFields.php on line 47
```

### Root cause

`UserResourceFields` passed the raw result of `$this->settings->get('flarum-nicknames.min' / '.max')` to `Schema\Str::minLength(int)` / `maxLength(int)`. Settings are always returned as strings from `DatabaseSettingsRepository::get()`.

Two separate failure modes on top of that:

1. **Empty string → TypeError.** PHP's default weak type coercion accepts numeric strings (`'3'` → `3`), but an empty `''` triggers a `TypeError`. That's the production symptom — the admin cleared the min or max field and saved the nicknames config form.
2. **Naive cast reveals a second bug.** `(int) ''` is `0`, so `minLength(0)` / `maxLength(0)` are applied unconditionally. `maxLength(0)` rejects *every* nickname with `"must not be greater than 0 characters"`. A cast alone is worse than the TypeError — it turns a hard error into a confusing validation failure.

Fresh installs haven't been affected because the `Extend\Settings()->default('…', 1 | 150)` defaults only kick in when the key isn't in the DB. As soon as an admin saves the nicknames config, values are persisted as strings and the code path breaks.

### Fix

Cast the settings to int *and* gate the constraint on a positive value:

```php
$min = (int) $this->settings->get('flarum-nicknames.min');
$max = (int) $this->settings->get('flarum-nicknames.max');

// …
->minLength($min, $min > 0)
->maxLength($max, $max > 0)
```

An empty or zero setting now means "no length constraint" — which is the intuitive behaviour for a cleared admin field.

### Verifying the repro

Local integration test `request_succeeds_when_min_or_max_setting_is_empty_string`:

- Persists `''` for both settings via `$this->setting(...)`.
- Sends `PATCH /api/users/2` with a valid nickname.
- Before the fix: 500, exact production stack trace.
- After the fix: 200, nickname saved.

### Tangential observation (not fixed here)

`Schema\Str::minLength(int $length)` gives no clean way to express "no constraint" without a guard at the call site. That's a framework-level ergonomic gap — arguably `minLength` should no-op when `$length <= 0`, or accept a nullable. Keeping the local guard for this RC; happy to open a follow-up if there's appetite.

### Necessity

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension? (Extension-only change.)
- [x] Are we willing to maintain this for years / potentially forever?

### Confirmed

- [x] Frontend changes: N/A.
- [x] Backend changes: tests are green — full nicknames integration suite (21 tests) passes locally, and CI green across all 10 PHP×DB matrix jobs + PHPStan + StyleCI.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

### Required changes

- [ ] Related documentation PR: none — internal.