### PR TITLE
[2.x] fix: anchor webpack-config extension source detection to the real src directory

### DIFF
--- a/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
+++ b/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
@@ -15,6 +15,13 @@ class RegisterAsyncChunksPlugin {
   }
 
   apply(compiler) {
+    // The extension's own source directory, derived from webpack's context
+    // (the single source of truth set in index.cjs). Used to identify which
+    // modules belong to the extension (as opposed to third-party
+    // `node_modules`). Anchoring to this absolute path avoids false positives
+    // when the project is checked out under a path containing a "src" segment.
+    const srcDir = path.resolve(compiler.options.context, 'src') + path.sep;
+
     compiler.hooks.thisCompilation.tap('RegisterAsyncChunksPlugin', (compilation) => {
       let alreadyOptimized = false;
 
@@ -40,12 +47,6 @@ class RegisterAsyncChunksPlugin {
           const chunks = Array.from(compilation.chunks);
           const chunkModuleMemory = {};
           const modulesToCheck = {};
-
-          // The extension's own source directory. Used to identify which modules
-          // belong to the extension (as opposed to third-party `node_modules`).
-          // Anchoring to this absolute path avoids false positives when the
-          // project is checked out under a path that contains a "src" segment.
-          const srcDir = path.resolve(process.cwd(), 'src') + path.sep;
 
           for (const chunk of chunks) {
             for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {

--- a/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
+++ b/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
@@ -41,19 +41,25 @@ class RegisterAsyncChunksPlugin {
           const chunkModuleMemory = {};
           const modulesToCheck = {};
 
+          // The extension's own source directory. Used to identify which modules
+          // belong to the extension (as opposed to third-party `node_modules`).
+          // Anchoring to this absolute path avoids false positives when the
+          // project is checked out under a path that contains a "src" segment.
+          const srcDir = path.resolve(process.cwd(), 'src') + path.sep;
+
           for (const chunk of chunks) {
             for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
               modulesToCheck[chunk.id] = modulesToCheck[chunk.id] || [];
 
               // A normal module.
-              if (module?.resource && module.resource.split(path.sep).includes('src') && module._source?._value.includes('webpackChunkName: ')) {
+              if (module?.resource && module.resource.startsWith(srcDir) && module._source?._value?.includes('webpackChunkName: ')) {
                 modulesToCheck[chunk.id].push(module);
               }
 
               // A ConcatenatedModule.
               if (module?.modules) {
                 module.modules.forEach((module) => {
-                  if (module.resource && module.resource.split(path.sep).includes('src') && module._source?._value.includes('webpackChunkName: ')) {
+                  if (module.resource && module.resource.startsWith(srcDir) && module._source?._value?.includes('webpackChunkName: ')) {
                     modulesToCheck[chunk.id].push(module);
                   }
                 });
@@ -129,13 +135,12 @@ class RegisterAsyncChunksPlugin {
 
                   // This is a chunk with many modules, we need to register all of them.
                   modules?.forEach((module) => {
-                    if (!module.resource?.includes(`${path.sep}src${path.sep}`)) {
+                    if (!module.resource?.startsWith(srcDir)) {
                       return;
                     }
 
                     // The path right after the src/ directory, without the extension.
-                    const regPathSep = `\\${path.sep}`;
-                    const urlPath = this.processUrlPath(module.resource.replace(new RegExp(`.*${regPathSep}src${regPathSep}([^.]+)\..+`), '$1'));
+                    const urlPath = this.processUrlPath(module.resource.slice(srcDir.length).replace(/\..+$/, ''));
 
                     if (!registrableModulesUrlPaths.has(urlPath)) {
                       registrableModulesUrlPaths.set(urlPath, [relevantChunk.id, moduleId, namespace, urlPath]);

--- a/js-packages/webpack-config/src/autoChunkNameLoader.cjs
+++ b/js-packages/webpack-config/src/autoChunkNameLoader.cjs
@@ -65,7 +65,7 @@ module.exports = function autoChunkNameLoader(source) {
         // The chunk name should be the path relative to the extension's `src`
         // directory. Anchoring to the absolute `src` path avoids picking up an
         // unrelated "src" segment from the project's checkout location.
-        const srcDir = path.resolve(this.rootContext || process.cwd(), 'src') + path.sep;
+        const srcDir = path.resolve(this.rootContext, 'src') + path.sep;
         if (absolutePathToImport.startsWith(srcDir)) {
           chunkPath = absolutePathToImport.slice(srcDir.length);
         }

--- a/js-packages/webpack-config/src/autoChunkNameLoader.cjs
+++ b/js-packages/webpack-config/src/autoChunkNameLoader.cjs
@@ -62,8 +62,12 @@ module.exports = function autoChunkNameLoader(source) {
         const absolutePathToImport = path.resolve(path.dirname(pathToThisModule), relativePathToImport);
         let chunkPath = relativePathToImport;
 
-        if (absolutePathToImport.includes('src')) {
-          chunkPath = absolutePathToImport.split(`src${path.sep}`)[1];
+        // The chunk name should be the path relative to the extension's `src`
+        // directory. Anchoring to the absolute `src` path avoids picking up an
+        // unrelated "src" segment from the project's checkout location.
+        const srcDir = path.resolve(this.rootContext || process.cwd(), 'src') + path.sep;
+        if (absolutePathToImport.startsWith(srcDir)) {
+          chunkPath = absolutePathToImport.slice(srcDir.length);
         }
 
         if (path.sep == '\\') {

--- a/js-packages/webpack-config/src/index.cjs
+++ b/js-packages/webpack-config/src/index.cjs
@@ -80,11 +80,11 @@ module.exports = function () {
     module: {
       rules: [
         {
-          include: /src/,
+          include: path.resolve(process.cwd(), 'src') + path.sep,
           loader: path.resolve(__dirname, './autoExportLoader.cjs'),
         },
         {
-          include: /src/,
+          include: path.resolve(process.cwd(), 'src') + path.sep,
           loader: path.resolve(__dirname, './autoChunkNameLoader.cjs'),
         },
         {

--- a/js-packages/webpack-config/src/index.cjs
+++ b/js-packages/webpack-config/src/index.cjs
@@ -66,7 +66,12 @@ plugins.push(new RegisterAsyncChunksPlugin());
 plugins.push(new OverrideChunkLoaderFunction());
 
 module.exports = function () {
+  const context = process.cwd();
+  const srcDir = path.resolve(context, 'src') + path.sep;
+
   return {
+    context,
+
     // Set up entry points for each of the forum + admin apps, but only
     // if they exist.
     entry: getEntryPoints(),
@@ -80,11 +85,11 @@ module.exports = function () {
     module: {
       rules: [
         {
-          include: path.resolve(process.cwd(), 'src') + path.sep,
+          include: srcDir,
           loader: path.resolve(__dirname, './autoExportLoader.cjs'),
         },
         {
-          include: path.resolve(process.cwd(), 'src') + path.sep,
+          include: srcDir,
           loader: path.resolve(__dirname, './autoChunkNameLoader.cjs'),
         },
         {

--- a/js-packages/webpack-config/tests/fixtures/composer.json
+++ b/js-packages/webpack-config/tests/fixtures/composer.json
@@ -1,0 +1,3 @@
+{
+  "name": "acme/my-ext"
+}

--- a/js-packages/webpack-config/tests/srcPathAnchoring.test.js
+++ b/js-packages/webpack-config/tests/srcPathAnchoring.test.js
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ *
+ * Regression tests for the "checkout path contains a `src` segment" bug.
+ *
+ * The config detects an extension's own source files by anchoring to the
+ * project's `src` directory. Earlier versions matched the substring "src"
+ * anywhere in a module's absolute path, which broke when the project itself was
+ * checked out under a path containing a `src` segment (e.g. `~/src/my-ext`):
+ *
+ *  - the auto-export loader ran on `node_modules` (e.g. `@babel/runtime`
+ *    helpers) and emitted invalid `flarum.reg.add(...)`, failing the build;
+ *  - `autoChunkNameLoader` produced chunk names that leaked the checkout path.
+ *
+ * These tests pin the anchored behaviour so it can't regress to loose matching.
+ */
+import path from 'path';
+import makeConfig from '../src/index.cjs';
+import autoChunkNameLoader from '../src/autoChunkNameLoader.cjs';
+
+describe('index.cjs: source loaders are anchored to the project `src` directory', () => {
+  const srcDir = path.resolve(process.cwd(), 'src') + path.sep;
+
+  // Avoid noise from getEntryPoints() when no forum.ts/admin.ts entry exists.
+  const config = (() => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      return makeConfig();
+    } finally {
+      spy.mockRestore();
+    }
+  })();
+
+  const sourceLoaderRules = config.module.rules.filter(
+    (rule) => typeof rule.loader === 'string' && /(autoExportLoader|autoChunkNameLoader)\.cjs$/.test(rule.loader)
+  );
+
+  test('both source loaders use an absolute `src` path include, not a loose /src/ regex', () => {
+    expect(sourceLoaderRules).toHaveLength(2);
+
+    for (const rule of sourceLoaderRules) {
+      expect(rule.include instanceof RegExp).toBe(false);
+      expect(rule.include).toBe(srcDir);
+    }
+  });
+
+  test('the include matches extension source but not node_modules under an unrelated "src" path', () => {
+    const include = sourceLoaderRules[0].include;
+
+    // Mirror webpack's own condition matching: a RegExp uses `.test()`, a
+    // string matches by directory prefix.
+    const matches = (resource) => (include instanceof RegExp ? include.test(resource) : resource.startsWith(include));
+
+    // The extension's own source is included.
+    expect(matches(path.join(process.cwd(), 'src', 'forum', 'index.ts'))).toBe(true);
+
+    // A node_modules file whose absolute path contains an unrelated `src`
+    // segment must NOT be treated as extension source. A loose /src/ regex
+    // wrongly matches this — that was the bug.
+    expect(matches(path.join(path.sep + 'home', 'src', 'proj', 'node_modules', '@babel', 'runtime', 'defineProperty.js'))).toBe(false);
+  });
+});
+
+describe('autoChunkNameLoader: chunk names are relative to the extension `src`', () => {
+  // Simulate a project checked out under a path that itself contains a `src`
+  // segment. The extension's own source lives at `<root>/src`.
+  const root = path.resolve(path.sep + 'home', 'src', 'acme', 'js');
+  const resourcePath = path.join(root, 'src', 'forum', 'index.ts');
+
+  const runLoader = (source) =>
+    autoChunkNameLoader.call(
+      {
+        query: { composerPath: path.resolve(__dirname, 'fixtures', 'composer.json') },
+        rootContext: root,
+        resourcePath,
+        addDependency() {},
+      },
+      source
+    );
+
+  test('internal dynamic import gets a chunk name relative to <root>/src', () => {
+    const output = runLoader("export function load() {\n  return import('./Lazy');\n}\n");
+
+    // Relative to `<root>/src` -> `forum/Lazy`, NOT polluted by the leading
+    // `/home/src/...` segment of the checkout path (old output was `acme/js/`).
+    expect(output).toContain("webpackChunkName: 'forum/Lazy'");
+    expect(output).not.toContain('acme/js');
+  });
+
+  test('external (flarum/ and ext:) imports are converted to async module imports', () => {
+    const output = runLoader("export function load() {\n  return import('ext:flarum/tags/forum/components/TagsPage');\n}\n");
+
+    expect(output).toContain("flarum.reg.asyncModuleImport('ext:flarum/tags/forum/components/TagsPage')");
+  });
+});


### PR DESCRIPTION
Fixes a build failure in `js-packages/webpack-config` that occurs when an extension (or core) is checked out under a filesystem path that itself contains a `src` segment (e.g. `~/src/my-ext`).

## Problem

The webpack config identifies an extension's own source files (under its `src/` dir) using **loose "src" matching** in several places:

- `index.cjs`: loader rules use `include: /src/` — a regex matching the substring "src" **anywhere** in a module's absolute path.
- `RegisterAsyncChunksPlugin.cjs`: `module.resource.split(path.sep).includes('src')` and `module.resource.includes('/src/')`.
- `autoChunkNameLoader.cjs`: `absolutePathToImport.includes('src')` then `.split('src/')[1]`.

When the project lives under a path containing a `src` segment, the absolute paths of **`node_modules`** files also contain "src", so:

1. The **auto-export loader runs on third-party modules** (e.g. `@babel/runtime/helpers/esm/defineProperty.js`, which contains `export { _defineProperty as default }`) and emits invalid `flarum.reg.add('…', { _defineProperty as default: … })`, failing the build with `Module parse failed: Unexpected token`.
2. **`RegisterAsyncChunksPlugin`** treats `node_modules` modules as extension source and throws `TypeError: Cannot read properties of undefined (reading 'includes')` when such a module's `_source._value` is undefined.
3. **`autoChunkNameLoader`** splits on the **first** `src/` in the path, so an extension with dynamic imports gets chunk names that leak the checkout path (e.g. `acme/js/…` instead of `forum/Lazy`).

This doesn't reproduce in normal CI checkouts because their paths don't contain a `src` segment — which is why it's easy to miss.

## Fix

Anchor every "is this file part of the extension's `src`?" check to the extension's **actual** `src` directory (`path.resolve(process.cwd(), 'src')`, or the loader's `this.rootContext`) and match by directory prefix instead of loose substring/segment matching. Also hardens a `_source._value?.` access with optional chaining.

This is a **no-op for checkouts not under a `src` path** (where `/src/` only ever matched the project's own `src`). `process.cwd()` is already the basis for entry points, the output dir, and `composer.json` / `package.json` resolution throughout this config, so this introduces no new assumption.

## Tests

Adds `tests/srcPathAnchoring.test.js` (self-contained; does not depend on the monorepo `composer.json`):

- the source-loader rules use an absolute `<cwd>/src` include rather than a `/src/` regex, and do not match `node_modules` under an unrelated `…/src/…` path;
- `autoChunkNameLoader` produces chunk names relative to the extension's `src` even when the checkout path contains a `src` segment;
- external (`ext:` / `flarum/`) imports still convert to `flarum.reg.asyncModuleImport(...)`.

These fail against the pre-fix code and pass after it.

## Verification

Built a real Flarum 2.x extension whose checkout path contains a `src` segment: the build previously failed with both errors above and now succeeds. A dynamic import yields `addChunkModule('…','…','<ns>','forum/Lazy')` (correctly `src`-relative) with no checkout-path leakage, and the produced bundle is otherwise byte-identical.

**Windows:** core's JS was also built natively on Windows (PowerShell) from a checkout under a `src` segment (`C:\Users\…\GitHub\src\framework`), comparing pre-fix and post-fix clones side by side. Pre-fix, the build fails with `Module parse failed` on the `@babel/runtime` helpers under `js-packages/webpack-config/node_modules` (the auto-export loader ran on them). Post-fix, it builds cleanly with 455 `flarum.reg.add` calls in `dist/forum.js` — the non-zero count rules out a silent prefix mismatch between webpack's `context` and `module.resource` on Windows.

## Addendum (from review)

Two corrections/expansions based on review feedback:

- The chunk-name symptom is worse than described above: `split('src/')[1]` returns a fragment of the *checkout* path that is identical for every module in the checkout, so with `webpackMode: 'lazy-once'` all dynamic imports receive the same `webpackChunkName` and collapse into a single lazy chunk — not just an ugly name.
- Also fixed here (previously unclaimed): the `urlPath` rewrite in `RegisterAsyncChunksPlugin` replaced a greedy `.*/src/` match (last occurrence) with a slice from the project's own `src` (first occurrence). For a nested `src` (e.g. `<proj>/src/forum/src/Foo.ts`) the old code produced `Foo` while `autoExportLoader` registered `forum/src/Foo`; both now agree on `forum/src/Foo`.

The source root is now unified on webpack's `context` (set explicitly in `index.cjs`, derived in `RegisterAsyncChunksPlugin` via `compiler.options.context`, and `this.rootContext` in the loaders) rather than four separate `process.cwd()`-based bases.


