### PR TITLE
[1.x] ci(testing): pin composer to 2.2 in split repo workflow

### DIFF
--- a/php-packages/testing/.github/workflows/test.yml
+++ b/php-packages/testing/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           extensions: curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip
-          tools: phpunit, composer:v2
+          tools: phpunit, composer:2.2
 
       # The authentication alter is necessary because newer mysql versions use the `caching_sha2_password` driver,
       # which isn't supported prior to PHP7.4


### PR DESCRIPTION
## Problem

CI on the split [flarum/testing](https://github.com/flarum/testing) repo (`main` = 1.x) fails at the **Install Composer dependencies** step:

```
Root composer.json requires flarum/core ^0.1.0@dev, found flarum/core[v0.1.0-beta, ..., v0.1.0-beta.16]
but these were not loaded, because they are affected by security advisories
("PKSA-4s1v-jz1f-4jpx", "PKSA-wm5r-h6h3-m2pf", "PKSA-t2c9-4b54-wr9g",
 "PKSA-gy61-rznj-1v67", "PKSA-vdnx-r1qz-p9z5", "PKSA-c9jx-2v6m-svqv").
```

Failed runs: [27550925105](https://github.com/flarum/testing/actions/runs/27550925105), [20711252296](https://github.com/flarum/testing/actions/runs/20711252296)

`php-packages/testing` ships its own standalone workflow rather than using `REUSABLE_backend.yml`, so it was missed when Composer was pinned to `2.2` elsewhere in this repo. Its floating `composer:v2` now resolves to Composer 2.9.x, which filters advisory-affected packages out of the **dependency solver** — resolution fails outright.

Note that `COMPOSER_NO_AUDIT: 1` is already set in that workflow and does **not** help: it only suppresses the post-install audit *report*, not solver-level advisory filtering (a separate `audit.block-insecure` / `policy.advisories.block` switch).

## Change

Pin `composer:v2` → `composer:2.2`, matching the existing pins at `REUSABLE_backend.yml:154`, `:209` and `REUSABLE_frontend.yml:155`. Composer 2.2 is LTS and predates solver-level advisory blocking.

Verified locally against Composer 2.2.25 and 2.9.5:

| Constraint | Composer 2.9.5 | Composer 2.2.25 |
| --- | --- | --- |
| `^0.1.0@dev` | blocked, 6 × `PKSA-*` | resolves → `v0.1.0-beta.6` |
| `^1.0` | resolves → `v1.8.17` | — |
