### PR TITLE
[2.x] feat: configurable session and token lifetimes

### DIFF
--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -98,6 +98,18 @@ export interface AdminApplicationData extends ApplicationData {
   knownQueues: string[];
   schedulerStatus: string;
   sessionDriver: string;
+
+  sessionByConfig: boolean;
+  sessionLifetime: number;
+  sessionCookieExpiresOnClose: boolean;
+  accessTokenLifetimes: AccessTokenLifetime[];
+}
+
+export interface AccessTokenLifetime {
+  /** The type the token class declares, e.g. `session` or `session_remember`. */
+  type: string;
+  /** How long tokens of this type last, in seconds. Zero means they never expire. */
+  lifetime: number;
 }
 
 export default class AdminApplication extends Application {

--- a/framework/core/js/src/admin/components/AdvancedPage.tsx
+++ b/framework/core/js/src/admin/components/AdvancedPage.tsx
@@ -14,6 +14,8 @@ import Switch from '../../common/components/Switch';
 import classList from '../../common/utils/classList';
 import ExtensionBisect from './ExtensionBisect';
 import { DatabaseDriver } from '../AdminApplication';
+import type { AccessTokenLifetime } from '../AdminApplication';
+import { DURATION_UNITS, toDuration, toSeconds, type DurationUnit } from '../../common/utils/duration';
 
 export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends AdminPage<CustomAttrs> {
   searchDriverOptions: Record<string, Record<string, string>> = {};
@@ -79,7 +81,163 @@ export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> e
 
     items.add('queue', this.queue(), 70);
 
+    items.add('sessions', this.sessions(), 60);
+
     return items;
+  }
+
+  sessions() {
+    return <FormSection label={app.translator.trans('core.admin.advanced.sessions.section_label')}>{this.sessionItems().toArray()}</FormSection>;
+  }
+
+  sessionItems() {
+    const items = new ItemList<Mithril.Children>();
+
+    // Pinned in config.php, so an administrator can be shown what the lengths
+    // are without being able to loosen them from here.
+    if (app.data.sessionByConfig) {
+      items.add('content', this.sessionConfigOverride(), 100);
+
+      return items;
+    }
+
+    items.add('lifetime', this.sessionLifetime(), 100);
+
+    const tokens = this.sessionTokenLifetimes();
+    if (tokens) items.add('tokens', tokens, 90);
+
+    items.add('cookie', this.sessionCookieControl(), 80);
+
+    return items;
+  }
+
+  sessionConfigOverride() {
+    const tokens = app.data.accessTokenLifetimes || [];
+
+    return (
+      <div className="Form-group">
+        <label>{app.translator.trans('core.admin.advanced.sessions.config_override.label')}</label>
+        <p className="helpText">{app.translator.trans('core.admin.advanced.sessions.config_override.help')}</p>
+        <ul className="SessionLifetimes-summary">
+          <li>
+            <strong>{app.translator.trans('core.admin.advanced.sessions.lifetime_label')}</strong>{' '}
+            {this.durationLabel((app.data.sessionLifetime || 0) * 60)}
+          </li>
+          {tokens.map((token) => (
+            <li key={token.type}>
+              <strong>{this.tokenTypeLabel(token.type)}</strong> {this.durationLabel(token.lifetime)}
+            </li>
+          ))}
+          <li>
+            <strong>{app.translator.trans('core.admin.advanced.sessions.cookie_expires_on_close_label')}</strong>{' '}
+            {app.translator.trans(`core.admin.advanced.sessions.${app.data.sessionCookieExpiresOnClose ? 'enabled' : 'disabled'}`)}
+          </li>
+        </ul>
+      </div>
+    );
+  }
+
+  sessionLifetime() {
+    return (
+      <Form>
+        {this.buildSettingComponent({
+          type: 'number',
+          setting: 'session.lifetime',
+          label: app.translator.trans('core.admin.advanced.sessions.lifetime_label'),
+          help: app.translator.trans('core.admin.advanced.sessions.lifetime_help'),
+          placeholder: '120',
+          min: 1,
+        })}
+      </Form>
+    );
+  }
+
+  /**
+   * One control per registered token type, so a type added by an extension is
+   * configured here alongside the ones core ships.
+   */
+  sessionTokenLifetimes() {
+    const tokens = app.data.accessTokenLifetimes || [];
+
+    if (!tokens.length) return null;
+
+    return <Form>{tokens.map((token) => this.tokenLifetimeControl(token))}</Form>;
+  }
+
+  tokenLifetimeControl(token: AccessTokenLifetime) {
+    const setting = this.setting(`session.tokens.${token.type}`, String(token.lifetime));
+    const current = toDuration(Number(setting()) || token.lifetime);
+
+    const update = (value: number, unit: DurationUnit) => setting(String(toSeconds(value, unit)));
+
+    return (
+      <div className="Form-group SessionLifetime" key={token.type}>
+        <label>{this.tokenTypeLabel(token.type)}</label>
+        <p className="helpText">{this.tokenTypeHelp(token.type)}</p>
+        <div className="SessionLifetime-input">
+          <input
+            className="FormControl SessionLifetime-value"
+            type="number"
+            min="0"
+            value={current.value}
+            aria-label={app.translator.trans('core.admin.advanced.sessions.duration_value_label')}
+            oninput={(e: InputEvent) => update(Number((e.target as HTMLInputElement).value), current.unit)}
+          />
+          <select
+            className="FormControl SessionLifetime-unit"
+            value={current.unit}
+            aria-label={app.translator.trans('core.admin.advanced.sessions.duration_unit_label')}
+            onchange={(e: InputEvent) => update(current.value, (e.target as HTMLSelectElement).value as DurationUnit)}
+          >
+            {DURATION_UNITS.map(({ unit }) => (
+              <option key={unit} value={unit}>
+                {app.translator.trans(`core.admin.advanced.sessions.units.${unit}`)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    );
+  }
+
+  sessionCookieControl() {
+    return (
+      <Form>
+        {this.buildSettingComponent({
+          type: 'switch',
+          setting: 'session.cookie_expires_on_close',
+          label: app.translator.trans('core.admin.advanced.sessions.cookie_expires_on_close_label'),
+          help: app.translator.trans('core.admin.advanced.sessions.cookie_expires_on_close_help'),
+        })}
+      </Form>
+    );
+  }
+
+  /**
+   * A name for a token type. Types core knows about are named properly; one
+   * added by an extension falls back to its own identifier rather than going
+   * unlabelled.
+   */
+  tokenTypeLabel(type: string): string {
+    const key = `core.admin.advanced.sessions.token_types.${type}.label`;
+    const translated = extractText(app.translator.trans(key));
+
+    return translated === key ? type : translated;
+  }
+
+  tokenTypeHelp(type: string): Mithril.Children {
+    const key = `core.admin.advanced.sessions.token_types.${type}.help`;
+    const translated = extractText(app.translator.trans(key));
+
+    return translated === key ? null : translated;
+  }
+
+  durationLabel(seconds: number): string {
+    const { value, unit } = toDuration(seconds);
+
+    if (!seconds) return extractText(app.translator.trans('core.admin.advanced.sessions.never_expires'));
+
+    return `${value} ${extractText(app.translator.trans(`core.admin.advanced.sessions.units.${unit}`))}`;
   }
 
   searchDrivers() {

--- a/framework/core/js/src/common/utils/duration.ts
+++ b/framework/core/js/src/common/utils/duration.ts
@@ -1,0 +1,56 @@
+export type DurationUnit = 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'years';
+
+export interface Duration {
+  value: number;
+  unit: DurationUnit;
+}
+
+/**
+ * The units a duration can be expressed in, largest first.
+ *
+ * A year here is 365 days and a week is 7 of those: these are for reading a
+ * stored number of seconds back as something a person would recognise, not for
+ * calendar arithmetic.
+ */
+export const DURATION_UNITS: { unit: DurationUnit; seconds: number }[] = [
+  { unit: 'years', seconds: 31536000 },
+  { unit: 'weeks', seconds: 604800 },
+  { unit: 'days', seconds: 86400 },
+  { unit: 'hours', seconds: 3600 },
+  { unit: 'minutes', seconds: 60 },
+  { unit: 'seconds', seconds: 1 },
+];
+
+/**
+ * Express a number of seconds in the largest unit that divides it exactly.
+ *
+ * Exactly is the important part: 90 minutes stays 90 minutes rather than
+ * becoming 1.5 hours, because a fraction cannot be typed back into a field
+ * expecting whole units and would be lost on the next save.
+ */
+export function toDuration(seconds: number): Duration {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return { value: 0, unit: 'seconds' };
+  }
+
+  const whole = Math.floor(seconds);
+
+  for (const { unit, seconds: size } of DURATION_UNITS) {
+    if (whole % size === 0) {
+      return { value: whole / size, unit };
+    }
+  }
+
+  return { value: whole, unit: 'seconds' };
+}
+
+/**
+ * Convert a value and unit back into the seconds that get stored.
+ */
+export function toSeconds(value: number, unit: DurationUnit): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+
+  const size = DURATION_UNITS.find((u) => u.unit === unit)?.seconds ?? 1;
+
+  return Math.floor(value * size);
+}

--- a/framework/core/js/tests/unit/common/utils/duration.test.ts
+++ b/framework/core/js/tests/unit/common/utils/duration.test.ts
@@ -1,0 +1,83 @@
+import { toDuration, toSeconds, DURATION_UNITS } from '../../../../src/common/utils/duration';
+
+describe('toDuration', () => {
+  it('picks the largest unit that divides exactly', () => {
+    expect(toDuration(3600)).toEqual({ value: 1, unit: 'hours' });
+    expect(toDuration(86400)).toEqual({ value: 1, unit: 'days' });
+    expect(toDuration(604800)).toEqual({ value: 1, unit: 'weeks' });
+  });
+
+  it('keeps a whole number rather than reaching for a bigger unit', () => {
+    // 90 minutes is not a whole number of hours, so minutes it stays — the
+    // alternative is showing 1.5 hours, which cannot be typed back in.
+    expect(toDuration(5400)).toEqual({ value: 90, unit: 'minutes' });
+  });
+
+  it('falls back to seconds when nothing else divides', () => {
+    expect(toDuration(90)).toEqual({ value: 90, unit: 'seconds' });
+    expect(toDuration(1)).toEqual({ value: 1, unit: 'seconds' });
+  });
+
+  it('describes the real-world defaults sensibly', () => {
+    expect(toDuration(60 * 60)).toEqual({ value: 1, unit: 'hours' });
+    expect(toDuration(5 * 365 * 24 * 60 * 60)).toEqual({ value: 5, unit: 'years' });
+    expect(toDuration(14 * 24 * 60 * 60)).toEqual({ value: 2, unit: 'weeks' });
+  });
+
+  it('treats zero as seconds rather than the largest unit', () => {
+    // Zero divides by everything, so without a special case it would come back
+    // as "0 years", which reads as a very long time rather than "never".
+    expect(toDuration(0)).toEqual({ value: 0, unit: 'seconds' });
+  });
+
+  it('never returns a negative duration', () => {
+    expect(toDuration(-60)).toEqual({ value: 0, unit: 'seconds' });
+  });
+});
+
+describe('toSeconds', () => {
+  it('converts each unit', () => {
+    expect(toSeconds(1, 'seconds')).toBe(1);
+    expect(toSeconds(1, 'minutes')).toBe(60);
+    expect(toSeconds(1, 'hours')).toBe(3600);
+    expect(toSeconds(1, 'days')).toBe(86400);
+    expect(toSeconds(1, 'weeks')).toBe(604800);
+    expect(toSeconds(1, 'years')).toBe(31536000);
+  });
+
+  it('multiplies the value', () => {
+    expect(toSeconds(14, 'days')).toBe(1209600);
+    expect(toSeconds(5, 'years')).toBe(157680000);
+  });
+
+  it('floors a fractional value rather than storing one', () => {
+    expect(toSeconds(1.5, 'hours')).toBe(5400);
+  });
+
+  it('clamps a negative value to zero', () => {
+    expect(toSeconds(-5, 'days')).toBe(0);
+  });
+
+  it('treats an unknown unit as seconds', () => {
+    expect(toSeconds(30, 'fortnights' as any)).toBe(30);
+  });
+});
+
+describe('round trip', () => {
+  it('survives conversion in both directions', () => {
+    const values = [0, 1, 60, 3600, 86400, 604800, 1209600, 31536000, 157680000, 90, 5400];
+
+    values.forEach((seconds) => {
+      const { value, unit } = toDuration(seconds);
+      expect(toSeconds(value, unit)).toBe(seconds);
+    });
+  });
+});
+
+describe('DURATION_UNITS', () => {
+  it('is ordered from largest to smallest', () => {
+    const sizes = DURATION_UNITS.map((u) => u.seconds);
+
+    expect(sizes).toEqual([...sizes].sort((a, b) => b - a));
+  });
+});

--- a/framework/core/less/admin/AdvancedPage.less
+++ b/framework/core/less/admin/AdvancedPage.less
@@ -99,3 +99,32 @@
   font-size: 15px;
   margin: 1rem 0 0;
 }
+
+// A duration is entered as a number and a unit together, so the two controls
+// read as one field rather than as two unrelated ones stacked up.
+.SessionLifetime-input {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.SessionLifetime-value {
+  flex: 0 1 8em;
+  min-width: 0;
+}
+
+.SessionLifetime-unit {
+  flex: 0 1 12em;
+  min-width: 0;
+}
+
+// The read-only summary shown when the lengths are pinned in config.php.
+.SessionLifetimes-summary {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  > li + li {
+    margin-top: 4px;
+  }
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -99,6 +99,39 @@ core:
         driver_options:
           default: Default database search
         no_other_drivers: No search drivers are available yet. Install a search driver extension to be able to configure it.
+      sessions:
+        section_label: Sessions
+        lifetime_label: Session Length (minutes)
+        lifetime_help: How long a session may sit idle before it is discarded. Default is 120 minutes.
+        cookie_expires_on_close_label: End sessions when the browser closes
+        cookie_expires_on_close_help: >-
+          Sign people out when they close their browser, rather than keeping them
+          signed in until their session expires. Useful on shared computers.
+        duration_value_label: Length
+        duration_unit_label: Unit
+        never_expires: Never expires
+        enabled: Enabled
+        disabled: Disabled
+        units:
+          seconds: seconds
+          minutes: minutes
+          hours: hours
+          days: days
+          weeks: weeks
+          years: years
+        token_types:
+          session:
+            label: Sign-in Length
+            help: How long someone stays signed in after signing in without choosing to be remembered.
+          session_remember:
+            label: "\"Remember me\" Length"
+            help: >-
+              How long someone stays signed in when they choose to be remembered.
+              This also covers signing in through another service, which is always
+              remembered.
+        config_override:
+          label: Configured in config.php
+          help: Session lengths are set in config.php and cannot be changed here.
       title: Advanced
 
     # These translations are used in the Appearance page.

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -17,6 +17,8 @@ use Flarum\Foundation\FontAwesome;
 use Flarum\Foundation\MaintenanceMode;
 use Flarum\Frontend\Document;
 use Flarum\Group\Permission;
+use Flarum\Http\AccessToken;
+use Flarum\Http\SessionConfig;
 use Flarum\Search\AbstractDriver;
 use Flarum\Search\SearcherInterface;
 use Flarum\Settings\Event\Deserializing;
@@ -57,8 +59,36 @@ class AdminPayload
         protected Config $config,
         protected ApplicationInfoProvider $appInfo,
         protected MaintenanceMode $maintenance,
-        protected FontAwesome $fontAwesome
+        protected FontAwesome $fontAwesome,
+        protected SessionConfig $sessionConfig
     ) {
+    }
+
+    /**
+     * The token types whose lifetime an administrator may change, with the
+     * lifetime each currently has.
+     *
+     * Built from the registry rather than a fixed list, so a type added by an
+     * extension is offered alongside the ones core ships.
+     *
+     * @return array<array{type: string, lifetime: int}>
+     */
+    protected function accessTokenLifetimes(): array
+    {
+        $types = [];
+
+        foreach (AccessToken::getModels() as $type => $model) {
+            if (! $model::hasConfigurableLifetime()) {
+                continue;
+            }
+
+            $types[] = [
+                'type' => $type,
+                'lifetime' => $model::lifetime(),
+            ];
+        }
+
+        return $types;
     }
 
     public function __invoke(Document $document, Request $request): void
@@ -124,6 +154,11 @@ class AdminPayload
         $document->payload['safeModeExtensionsConfig'] = $this->config->safeModeExtensions();
 
         $document->payload['announcementsDisabled'] = (bool) $this->config['flarum_announcements.disabled'];
+
+        $document->payload['sessionByConfig'] = $this->sessionConfig->configOverride();
+        $document->payload['sessionLifetime'] = $this->sessionConfig->lifetime();
+        $document->payload['sessionCookieExpiresOnClose'] = $this->sessionConfig->cookieExpiresOnClose();
+        $document->payload['accessTokenLifetimes'] = $this->accessTokenLifetimes();
 
         $document->payload['fontawesomeByConfig'] = $this->fontAwesome->configOverride();
 

--- a/framework/core/src/Extend/AccessToken.php
+++ b/framework/core/src/Extend/AccessToken.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Flarum\Http\AccessToken as AccessTokenModel;
+use Illuminate\Contracts\Container\Container;
+
+class AccessToken implements ExtenderInterface
+{
+    private array $types = [];
+
+    /**
+     * Add a type of access token.
+     *
+     * The class decides what its type is called, how long it lasts by default,
+     * and whether a site may change that — see `Flarum\Http\AccessToken`.
+     * Registering it here is what lets rows of that type be hydrated as the
+     * right class, and what puts its lifetime in front of an administrator
+     * alongside the types core ships.
+     *
+     * @param class-string<AccessTokenModel> $type: The ::class attribute of the token class,
+     *                                              which must extend \Flarum\Http\AccessToken.
+     */
+    public function type(string $type): self
+    {
+        $this->types[] = $type;
+
+        return $this;
+    }
+
+    public function extend(Container $container, ?Extension $extension = null): void
+    {
+        $container->extend('flarum.http.access_token_types', function (array $existing) {
+            return array_merge($existing, $this->types);
+        });
+    }
+}

--- a/framework/core/src/Foundation/Config.php
+++ b/framework/core/src/Foundation/Config.php
@@ -39,6 +39,61 @@ readonly class Config implements ArrayAccess
         return $this->data['queue']['driver'] ?? null;
     }
 
+    /**
+     * How long a token of the given type stays valid, in seconds.
+     *
+     * Keyed by the type each token class declares, so a type added by an
+     * extension is configured the same way the ones in core are.
+     *
+     * Zero is meaningful — it means the token never expires — so it is only
+     * values that cannot be honoured at all (negative, or not a number) that
+     * are discarded here in favour of whatever comes next.
+     */
+    public function accessTokenLifetime(string $type): ?int
+    {
+        $lifetime = $this->data['session']['tokens'][$type] ?? null;
+
+        if (! is_numeric($lifetime) || $lifetime < 0) {
+            return null;
+        }
+
+        return (int) $lifetime;
+    }
+
+    /**
+     * How long a session may sit idle before it is discarded, in minutes.
+     */
+    public function sessionLifetime(): ?int
+    {
+        $lifetime = $this->data['session']['lifetime'] ?? null;
+
+        if (! is_numeric($lifetime) || $lifetime <= 0) {
+            return null;
+        }
+
+        return (int) $lifetime;
+    }
+
+    /**
+     * Whether session cookies should be discarded when the browser closes,
+     * rather than lasting for the lifetime of the token behind them.
+     */
+    public function sessionCookieExpiresOnClose(): ?bool
+    {
+        $value = $this->data['session']['cookie_expires_on_close'] ?? null;
+
+        return is_bool($value) ? $value : null;
+    }
+
+    /**
+     * Whether session lifetimes are pinned in `config.php`, and so cannot be
+     * changed from the admin panel.
+     */
+    public function sessionConfigOverride(): bool
+    {
+        return isset($this->data['session']);
+    }
+
     public function inMaintenanceMode(): bool
     {
         return $this->inHighMaintenanceMode() || $this->inLowMaintenanceMode() || $this->inSafeMode();

--- a/framework/core/src/Foundation/Config.php
+++ b/framework/core/src/Foundation/Config.php
@@ -82,7 +82,14 @@ readonly class Config implements ArrayAccess
     {
         $value = $this->data['session']['cookie_expires_on_close'] ?? null;
 
-        return is_bool($value) ? $value : null;
+        if ($value === null) {
+            return null;
+        }
+
+        // Anything PHP would read as true or false is honoured, so a value
+        // arriving from the environment as the string "1" behaves the same way
+        // it does for the other switches in this file.
+        return (bool) $value;
     }
 
     /**

--- a/framework/core/src/Http/AccessToken.php
+++ b/framework/core/src/Http/AccessToken.php
@@ -63,9 +63,23 @@ class AccessToken extends AbstractModel
     /**
      * How long this access token should be valid from the time of last activity.
      * This value will be used in the validity and expiration checks.
+     *
+     * This is the default for the type, not the last word on it: a site can
+     * shorten or lengthen it from `config.php` or the admin panel. Read the
+     * resolved value with `lifetime()` rather than this property.
+     *
      * @var int Lifetime in seconds. Zero means it will never expire.
      */
     protected static int $lifetime = 0;
+
+    /**
+     * Whether a site may change this type's lifetime.
+     *
+     * Types whose whole purpose is to outlive a session — API tokens issued to
+     * a script, say — have nothing to gain from an expiry box in the admin
+     * panel, and would be broken by one set carelessly.
+     */
+    protected static bool $configurableLifetime = true;
 
     /**
      * Difference from the current `last_activity_at` attribute value before `updateLastSeen()`
@@ -150,24 +164,51 @@ class AccessToken extends AbstractModel
     }
 
     /**
+     * How long this type of token stays valid, in seconds, taking into account
+     * anything the site has configured. Zero means it never expires.
+     *
+     * Resolved rather than fixed: `config.php` wins, then the setting an admin
+     * can change, then the default the class declares. A site that configures
+     * nothing keeps the lifetime it has always had.
+     */
+    public static function lifetime(): int
+    {
+        if (! static::$configurableLifetime) {
+            return static::$lifetime;
+        }
+
+        $lifetime = resolve(SessionConfig::class)->tokenLifetime(static::$type);
+
+        return $lifetime ?? static::$lifetime;
+    }
+
+    /**
+     * Whether a site may change how long this type of token lasts.
+     */
+    public static function hasConfigurableLifetime(): bool
+    {
+        return static::$configurableLifetime;
+    }
+
+    /**
      * Filters which tokens are valid at the given date for this particular token type.
-     * Uses the static::$lifetime value by default, can be overridden by children classes.
+     * Uses the resolved lifetime by default, can be overridden by children classes.
      */
     protected static function scopeValid(Builder $query, Carbon $date): void
     {
-        if (static::$lifetime > 0) {
-            $query->where('last_activity_at', '>', $date->clone()->subSeconds(static::$lifetime));
+        if (($lifetime = static::lifetime()) > 0) {
+            $query->where('last_activity_at', '>', $date->clone()->subSeconds($lifetime));
         }
     }
 
     /**
      * Filters which tokens are expired at the given date and ready for garbage collection.
-     * Uses the static::$lifetime value by default, can be overridden by children classes.
+     * Uses the resolved lifetime by default, can be overridden by children classes.
      */
     protected static function scopeExpired(Builder $query, Carbon $date): void
     {
-        if (static::$lifetime > 0) {
-            $query->where('last_activity_at', '<', $date->clone()->subSeconds(static::$lifetime));
+        if (($lifetime = static::lifetime()) > 0) {
+            $query->where('last_activity_at', '<', $date->clone()->subSeconds($lifetime));
         } else {
             $query->whereRaw('FALSE');
         }

--- a/framework/core/src/Http/DeveloperAccessToken.php
+++ b/framework/core/src/Http/DeveloperAccessToken.php
@@ -14,4 +14,11 @@ class DeveloperAccessToken extends AccessToken
     public static string $type = 'developer';
 
     protected static int $lifetime = 0;
+
+    /**
+     * These are issued deliberately, to be used by a script or an integration
+     * for as long as it needs them. An expiry set from the admin panel would
+     * break those quietly, weeks later, so this type keeps its own answer.
+     */
+    protected static bool $configurableLifetime = false;
 }

--- a/framework/core/src/Http/HttpServiceProvider.php
+++ b/framework/core/src/Http/HttpServiceProvider.php
@@ -67,6 +67,14 @@ class HttpServiceProvider extends AbstractServiceProvider
         $this->container->bind(SlugManager::class, function (Container $container) {
             return new SlugManager($container->make('flarum.http.selectedSlugDrivers'));
         });
+
+        $this->container->singleton('flarum.http.access_token_types', function () {
+            return [
+                DeveloperAccessToken::class,
+                RememberAccessToken::class,
+                SessionAccessToken::class,
+            ];
+        });
     }
 
     public function boot(): void
@@ -78,13 +86,7 @@ class HttpServiceProvider extends AbstractServiceProvider
 
     protected function setAccessTokenTypes(): void
     {
-        $models = [
-            DeveloperAccessToken::class,
-            RememberAccessToken::class,
-            SessionAccessToken::class
-        ];
-
-        foreach ($models as $model) {
+        foreach ($this->container->make('flarum.http.access_token_types') as $model) {
             AccessToken::setModel($model::$type, $model);
         }
     }

--- a/framework/core/src/Http/Middleware/CollectGarbage.php
+++ b/framework/core/src/Http/Middleware/CollectGarbage.php
@@ -67,7 +67,7 @@ class CollectGarbage implements Middleware
         return mt_rand(1, 100) <= 2;
     }
 
-    private function getSessionLifetimeInSeconds(): float|int
+    private function getSessionLifetimeInSeconds(): int
     {
         // Read from the same place the session cookie does, so a shortened
         // session is actually swept rather than left on disk until the old

--- a/framework/core/src/Http/Middleware/CollectGarbage.php
+++ b/framework/core/src/Http/Middleware/CollectGarbage.php
@@ -11,6 +11,7 @@ namespace Flarum\Http\Middleware;
 
 use Carbon\Carbon;
 use Flarum\Http\AccessToken;
+use Flarum\Http\SessionConfig;
 use Flarum\User\EmailToken;
 use Flarum\User\PasswordToken;
 use Flarum\User\RegistrationToken;
@@ -27,7 +28,8 @@ class CollectGarbage implements Middleware
 
     public function __construct(
         protected SessionHandlerInterface $sessionHandler,
-        ConfigRepository $config
+        ConfigRepository $config,
+        protected SessionConfig $sessionLifetimes
     ) {
         $this->sessionConfig = (array) $config->get('session');
     }
@@ -67,6 +69,9 @@ class CollectGarbage implements Middleware
 
     private function getSessionLifetimeInSeconds(): float|int
     {
-        return $this->sessionConfig['lifetime'] * 60;
+        // Read from the same place the session cookie does, so a shortened
+        // session is actually swept rather than left on disk until the old
+        // two-hour default would have caught it.
+        return $this->sessionLifetimes->lifetime() * 60;
     }
 }

--- a/framework/core/src/Http/Middleware/StartSession.php
+++ b/framework/core/src/Http/Middleware/StartSession.php
@@ -11,6 +11,7 @@ namespace Flarum\Http\Middleware;
 
 use Dflydev\FigCookies\FigResponseCookies;
 use Flarum\Http\CookieFactory;
+use Flarum\Http\SessionConfig;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Session\Store;
@@ -28,7 +29,8 @@ class StartSession implements Middleware
     public function __construct(
         protected SessionHandlerInterface $handler,
         protected CookieFactory $cookie,
-        ConfigRepository $config
+        ConfigRepository $config,
+        protected SessionConfig $sessionConfig
     ) {
         $this->config = (array) $config->get('session');
     }
@@ -65,14 +67,21 @@ class StartSession implements Middleware
 
     private function withSessionCookie(Response $response, Session $session): Response
     {
+        // A cookie with no lifetime at all is what a browser discards when it
+        // closes. The session itself is unaffected — it stays valid server-side
+        // for its usual span; the browser simply stops offering it.
+        $maxAge = $this->sessionConfig->cookieExpiresOnClose()
+            ? null
+            : $this->getSessionLifetimeInSeconds();
+
         return FigResponseCookies::set(
             $response,
-            $this->cookie->make($session->getName(), $session->getId(), $this->getSessionLifetimeInSeconds())
+            $this->cookie->make($session->getName(), $session->getId(), $maxAge)
         );
     }
 
     private function getSessionLifetimeInSeconds(): int
     {
-        return $this->config['lifetime'] * 60;
+        return $this->sessionConfig->lifetime() * 60;
     }
 }

--- a/framework/core/src/Http/RememberAccessToken.php
+++ b/framework/core/src/Http/RememberAccessToken.php
@@ -19,9 +19,12 @@ class RememberAccessToken extends AccessToken
 
     /**
      * Just a helper method so we can re-use the lifetime value which is protected.
+     *
+     * @deprecated 2.1, use `lifetime()` instead, which answers the same question
+     *             but takes into account what the site has configured.
      */
     public static function rememberCookieLifeTime(): int
     {
-        return self::$lifetime;
+        return static::lifetime();
     }
 }

--- a/framework/core/src/Http/RememberAccessToken.php
+++ b/framework/core/src/Http/RememberAccessToken.php
@@ -20,7 +20,7 @@ class RememberAccessToken extends AccessToken
     /**
      * Just a helper method so we can re-use the lifetime value which is protected.
      *
-     * @deprecated 2.1, use `lifetime()` instead, which answers the same question
+     * @deprecated 2.0, use `lifetime()` instead, which answers the same question
      *             but takes into account what the site has configured.
      */
     public static function rememberCookieLifeTime(): int

--- a/framework/core/src/Http/Rememberer.php
+++ b/framework/core/src/Http/Rememberer.php
@@ -17,7 +17,8 @@ class Rememberer
     public const COOKIE_NAME = 'remember';
 
     public function __construct(
-        protected CookieFactory $cookie
+        protected CookieFactory $cookie,
+        protected SessionConfig $sessionConfig
     ) {
     }
 
@@ -28,8 +29,21 @@ class Rememberer
     {
         return FigResponseCookies::set(
             $response,
-            $this->cookie->make(self::COOKIE_NAME, $token->token, RememberAccessToken::rememberCookieLifeTime())
+            $this->cookie->make(self::COOKIE_NAME, $token->token, $this->cookieLifetime())
         );
+    }
+
+    /**
+     * How long the browser should keep the remember cookie, or `null` to keep
+     * it only until the browser closes.
+     */
+    protected function cookieLifetime(): ?int
+    {
+        if ($this->sessionConfig->cookieExpiresOnClose()) {
+            return null;
+        }
+
+        return RememberAccessToken::lifetime();
     }
 
     public function forget(ResponseInterface $response): ResponseInterface

--- a/framework/core/src/Http/SessionConfig.php
+++ b/framework/core/src/Http/SessionConfig.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Http;
+
+use Flarum\Foundation\Config;
+use Flarum\Settings\SettingsRepositoryInterface;
+
+/**
+ * How long sessions and the tokens behind them last.
+ *
+ * Every value here is answered the same way: `config.php` first, then the
+ * settings table, then the default that has always applied. Putting a value in
+ * `config.php` is therefore also a way to take it away from the admin panel —
+ * a site owner can pin session lengths where an administrator cannot loosen
+ * them, which is the point of keeping the option in a file rather than only in
+ * the database.
+ */
+class SessionConfig
+{
+    /**
+     * How long a session may sit idle before it is discarded, in minutes.
+     */
+    public const DEFAULT_LIFETIME = 120;
+
+    public function __construct(
+        protected Config $config,
+        protected SettingsRepositoryInterface $settings
+    ) {
+    }
+
+    /**
+     * How long tokens of the given type stay valid, in seconds, or `null` to
+     * leave the decision to the token class.
+     *
+     * Zero is a real answer rather than an absent one — it means the token
+     * never expires — so it has to survive the fall through the sources below.
+     */
+    public function tokenLifetime(string $type): ?int
+    {
+        $lifetime = $this->config->accessTokenLifetime($type);
+
+        if ($lifetime !== null) {
+            return $lifetime;
+        }
+
+        $lifetime = $this->settings->get("session.tokens.$type");
+
+        if (! is_numeric($lifetime) || $lifetime < 0) {
+            return null;
+        }
+
+        return (int) $lifetime;
+    }
+
+    /**
+     * How long a session may sit idle before it is discarded, in minutes.
+     */
+    public function lifetime(): int
+    {
+        $lifetime = $this->config->sessionLifetime();
+
+        if ($lifetime !== null) {
+            return $lifetime;
+        }
+
+        $lifetime = $this->settings->get('session.lifetime');
+
+        if (! is_numeric($lifetime) || $lifetime <= 0) {
+            return self::DEFAULT_LIFETIME;
+        }
+
+        return (int) $lifetime;
+    }
+
+    /**
+     * Whether session cookies should be discarded when the browser closes.
+     *
+     * This is about the cookie, not the token behind it: the session remains
+     * valid server-side for its lifetime, but the browser stops presenting it
+     * once the window is gone. Shared computers are the usual reason to want
+     * it.
+     */
+    public function cookieExpiresOnClose(): bool
+    {
+        $value = $this->config->sessionCookieExpiresOnClose();
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        return (bool) $this->settings->get('session.cookie_expires_on_close');
+    }
+
+    /**
+     * Whether any of this is pinned in `config.php`, and so cannot be changed
+     * from the admin panel.
+     */
+    public function configOverride(): bool
+    {
+        return $this->config->sessionConfigOverride();
+    }
+}

--- a/framework/core/tests/integration/api/access_tokens/AccessTokenLifetimeConfigTest.php
+++ b/framework/core/tests/integration/api/access_tokens/AccessTokenLifetimeConfigTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\access_tokens;
+
+use Carbon\Carbon;
+use Flarum\Http\AccessToken;
+use Flarum\Http\DeveloperAccessToken;
+use Flarum\Http\RememberAccessToken;
+use Flarum\Http\SessionAccessToken;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * How long a token stays valid is resolved rather than fixed: `config.php`
+ * first, then the settings table, then the lifetime the class itself declares.
+ *
+ * The order matters more than it looks. Sites that never configure anything
+ * must keep exactly the lifetimes they have today, and an admin must not be
+ * able to contradict a value the server owner has pinned in `config.php`.
+ */
+class AccessTokenLifetimeConfigTest extends TestCase
+{
+    #[Test]
+    public function session_tokens_last_an_hour_by_default()
+    {
+        $this->app();
+
+        $this->assertEquals(60 * 60, SessionAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function remember_tokens_last_five_years_by_default()
+    {
+        $this->app();
+
+        $this->assertEquals(5 * 365 * 24 * 60 * 60, RememberAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function developer_tokens_never_expire_by_default()
+    {
+        $this->app();
+
+        // Zero is not "expires immediately" but "no expiry at all", which is
+        // what the query scopes read it as.
+        $this->assertEquals(0, DeveloperAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function a_setting_overrides_the_class_default()
+    {
+        $this->setting('session.tokens.session', 1800);
+
+        $this->app();
+
+        $this->assertEquals(1800, SessionAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function config_overrides_a_setting()
+    {
+        $this->setting('session.tokens.session', 1800);
+        $this->config('session.tokens.session', 900);
+
+        $this->app();
+
+        $this->assertEquals(900, SessionAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function each_type_is_configured_independently()
+    {
+        $this->config('session.tokens.session', 900);
+
+        $this->app();
+
+        $this->assertEquals(900, SessionAccessToken::lifetime());
+        $this->assertEquals(5 * 365 * 24 * 60 * 60, RememberAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function a_configured_lifetime_decides_which_tokens_are_expired()
+    {
+        // Half an hour, so a token last used at 02:00 is expired by 02:45 —
+        // which the default hour would not be.
+        $this->config('session.tokens.session', 1800);
+
+        $this->prepareDatabase([
+            AccessToken::class => [
+                ['token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
+            ],
+        ]);
+
+        $this->populateDatabase();
+
+        $this->assertEquals([], AccessToken::whereExpired(Carbon::parse('2021-01-01 02:15:00'))->pluck('token')->all());
+        $this->assertEquals(['a'], AccessToken::whereExpired(Carbon::parse('2021-01-01 02:45:00'))->pluck('token')->all());
+    }
+
+    #[Test]
+    public function a_configured_lifetime_decides_which_tokens_are_valid()
+    {
+        $this->config('session.tokens.session', 1800);
+
+        $this->prepareDatabase([
+            AccessToken::class => [
+                ['token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
+            ],
+        ]);
+
+        $this->populateDatabase();
+
+        $this->assertEquals(['a'], AccessToken::whereValid(Carbon::parse('2021-01-01 02:15:00'))->pluck('token')->all());
+        $this->assertEquals([], AccessToken::whereValid(Carbon::parse('2021-01-01 02:45:00'))->pluck('token')->all());
+    }
+
+    #[Test]
+    public function a_lifetime_of_zero_means_no_expiry_rather_than_instant_expiry()
+    {
+        $this->config('session.tokens.session', 0);
+
+        $this->prepareDatabase([
+            AccessToken::class => [
+                ['token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
+            ],
+        ]);
+
+        $this->populateDatabase();
+
+        $this->assertEquals([], AccessToken::whereExpired(Carbon::parse('2030-01-01 00:00:00'))->pluck('token')->all());
+        $this->assertEquals(['a'], AccessToken::whereValid(Carbon::parse('2030-01-01 00:00:00'))->pluck('token')->all());
+    }
+
+    #[Test]
+    public function a_negative_lifetime_is_ignored_rather_than_expiring_everything()
+    {
+        // Nothing sensible can be done with a negative lifetime, and treating
+        // it as "already expired" would log everyone out over a typo.
+        $this->config('session.tokens.session', -60);
+
+        $this->app();
+
+        $this->assertEquals(60 * 60, SessionAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function a_non_numeric_lifetime_is_ignored()
+    {
+        $this->config('session.tokens.session', 'not a number');
+
+        $this->app();
+
+        $this->assertEquals(60 * 60, SessionAccessToken::lifetime());
+    }
+}

--- a/framework/core/tests/integration/api/access_tokens/SessionAdminPayloadTest.php
+++ b/framework/core/tests/integration/api/access_tokens/SessionAdminPayloadTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\access_tokens;
+
+use Flarum\Extend;
+use Flarum\Http\AccessToken;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class SessionAdminPayloadTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    protected function payload(): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/admin', ['authenticatedAs' => 1])
+        );
+
+        $body = (string) $response->getBody();
+
+        preg_match('/<script id="flarum-json-payload" type="application\/json">(.+?)<\/script>/s', $body, $matches);
+
+        $this->assertNotEmpty($matches, 'The admin page carried no JSON payload.');
+
+        return json_decode(html_entity_decode($matches[1]), true);
+    }
+
+    #[Test]
+    public function payload_carries_the_session_lifetime()
+    {
+        $this->assertEquals(120, $this->payload()['sessionLifetime']);
+    }
+
+    #[Test]
+    public function payload_carries_configurable_token_types()
+    {
+        $types = array_column($this->payload()['accessTokenLifetimes'], 'lifetime', 'type');
+
+        $this->assertArrayHasKey('session', $types);
+        $this->assertArrayHasKey('session_remember', $types);
+        $this->assertEquals(60 * 60, $types['session']);
+        $this->assertEquals(5 * 365 * 24 * 60 * 60, $types['session_remember']);
+    }
+
+    #[Test]
+    public function payload_leaves_out_types_that_cannot_be_configured()
+    {
+        $types = array_column($this->payload()['accessTokenLifetimes'], 'type');
+
+        $this->assertNotContains('developer', $types);
+    }
+
+    #[Test]
+    public function payload_includes_a_type_added_by_an_extension()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(PayloadTestToken::class)
+        );
+
+        $types = array_column($this->payload()['accessTokenLifetimes'], 'lifetime', 'type');
+
+        $this->assertArrayHasKey('payload_test', $types);
+        $this->assertEquals(450, $types['payload_test']);
+    }
+
+    #[Test]
+    public function payload_says_nothing_is_pinned_when_config_is_silent()
+    {
+        $this->assertFalse($this->payload()['sessionByConfig']);
+    }
+
+    #[Test]
+    public function payload_says_when_config_pins_the_values()
+    {
+        $this->config('session.lifetime', 30);
+
+        $payload = $this->payload();
+
+        $this->assertTrue($payload['sessionByConfig']);
+        $this->assertEquals(30, $payload['sessionLifetime']);
+    }
+
+    #[Test]
+    public function payload_reflects_a_configured_token_lifetime()
+    {
+        $this->config('session.tokens.session', 900);
+
+        $types = array_column($this->payload()['accessTokenLifetimes'], 'lifetime', 'type');
+
+        $this->assertEquals(900, $types['session']);
+    }
+}
+
+class PayloadTestToken extends AccessToken
+{
+    public static string $type = 'payload_test';
+
+    protected static int $lifetime = 450;
+}

--- a/framework/core/tests/integration/api/access_tokens/SessionCookieLifetimeTest.php
+++ b/framework/core/tests/integration/api/access_tokens/SessionCookieLifetimeTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\access_tokens;
+
+use Flarum\Http\SessionConfig;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Cookies carry two separate decisions: how long the server considers a session
+ * good for, and how long the browser agrees to keep presenting it. They are
+ * configured independently because they answer different worries — one is about
+ * session length, the other about walking away from a shared computer.
+ */
+class SessionCookieLifetimeTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    #[Test]
+    public function sessions_last_two_hours_by_default()
+    {
+        $this->app();
+
+        $this->assertEquals(120, $this->app()->getContainer()->make(SessionConfig::class)->lifetime());
+    }
+
+    #[Test]
+    public function session_lifetime_can_be_set_in_config()
+    {
+        $this->config('session.lifetime', 30);
+
+        $this->assertEquals(30, $this->app()->getContainer()->make(SessionConfig::class)->lifetime());
+    }
+
+    #[Test]
+    public function session_lifetime_can_be_set_in_settings()
+    {
+        $this->setting('session.lifetime', 45);
+
+        $this->assertEquals(45, $this->app()->getContainer()->make(SessionConfig::class)->lifetime());
+    }
+
+    #[Test]
+    public function config_wins_over_settings_for_session_lifetime()
+    {
+        $this->setting('session.lifetime', 45);
+        $this->config('session.lifetime', 30);
+
+        $this->assertEquals(30, $this->app()->getContainer()->make(SessionConfig::class)->lifetime());
+    }
+
+    #[Test]
+    public function an_unusable_session_lifetime_falls_back_to_the_default()
+    {
+        $this->config('session.lifetime', 0);
+
+        $this->assertEquals(120, $this->app()->getContainer()->make(SessionConfig::class)->lifetime());
+    }
+
+    #[Test]
+    public function cookies_outlive_the_browser_by_default()
+    {
+        $this->app();
+
+        $this->assertFalse($this->app()->getContainer()->make(SessionConfig::class)->cookieExpiresOnClose());
+    }
+
+    #[Test]
+    public function cookies_can_be_set_to_expire_when_the_browser_closes()
+    {
+        $this->config('session.cookie_expires_on_close', true);
+
+        $this->assertTrue($this->app()->getContainer()->make(SessionConfig::class)->cookieExpiresOnClose());
+    }
+
+    #[Test]
+    public function expiring_on_close_can_be_set_in_settings()
+    {
+        $this->setting('session.cookie_expires_on_close', true);
+
+        $this->assertTrue($this->app()->getContainer()->make(SessionConfig::class)->cookieExpiresOnClose());
+    }
+
+    #[Test]
+    public function the_session_cookie_carries_the_configured_lifetime()
+    {
+        $this->config('session.lifetime', 30);
+
+        $response = $this->send($this->request('GET', '/'));
+
+        $cookie = $this->sessionCookie($response);
+
+        // Max-Age is in seconds; the setting is in minutes.
+        $this->assertStringContainsString('Max-Age=1800', $cookie);
+    }
+
+    #[Test]
+    public function the_session_cookie_becomes_a_browser_session_cookie_when_configured()
+    {
+        $this->config('session.cookie_expires_on_close', true);
+
+        $response = $this->send($this->request('GET', '/'));
+
+        $cookie = $this->sessionCookie($response);
+
+        // No Max-Age and no Expires is what makes a browser drop a cookie when
+        // it closes, so their absence is the assertion.
+        $this->assertStringNotContainsString('Max-Age=', $cookie);
+        $this->assertStringNotContainsString('Expires=', $cookie);
+    }
+
+    #[Test]
+    public function config_pins_the_settings_out_of_reach()
+    {
+        $this->config('session.lifetime', 30);
+
+        $this->assertTrue($this->app()->getContainer()->make(SessionConfig::class)->configOverride());
+    }
+
+    #[Test]
+    public function nothing_is_pinned_when_config_says_nothing()
+    {
+        $this->app();
+
+        $this->assertFalse($this->app()->getContainer()->make(SessionConfig::class)->configOverride());
+    }
+
+    protected function sessionCookie($response): string
+    {
+        foreach ($response->getHeader('Set-Cookie') as $cookie) {
+            if (str_starts_with($cookie, 'flarum_session=')) {
+                return $cookie;
+            }
+        }
+
+        $this->fail('No session cookie was set on the response.');
+    }
+}

--- a/framework/core/tests/integration/api/access_tokens/SessionCookieLifetimeTest.php
+++ b/framework/core/tests/integration/api/access_tokens/SessionCookieLifetimeTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tests\integration\api\access_tokens;
 
+use Flarum\Http\SessionAccessToken;
 use Flarum\Http\SessionConfig;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -87,6 +88,35 @@ class SessionCookieLifetimeTest extends TestCase
         $this->setting('session.cookie_expires_on_close', true);
 
         $this->assertTrue($this->app()->getContainer()->make(SessionConfig::class)->cookieExpiresOnClose());
+    }
+
+    #[Test]
+    public function values_arriving_as_strings_are_understood()
+    {
+        // Environment variables reach config.php as strings unless they are
+        // literally "true" or "false", so a switch set from the environment has
+        // to be read the same way the other switches in config.php are.
+        $this->config('session.cookie_expires_on_close', '1');
+
+        $this->assertTrue($this->app()->getContainer()->make(SessionConfig::class)->cookieExpiresOnClose());
+    }
+
+    #[Test]
+    public function a_lifetime_arriving_as_a_string_is_understood()
+    {
+        $this->config('session.lifetime', '30');
+
+        $this->assertEquals(30, $this->app()->getContainer()->make(SessionConfig::class)->lifetime());
+    }
+
+    #[Test]
+    public function a_token_lifetime_arriving_as_a_string_is_understood()
+    {
+        $this->config('session.tokens.session', '900');
+
+        $this->app();
+
+        $this->assertEquals(900, SessionAccessToken::lifetime());
     }
 
     #[Test]

--- a/framework/core/tests/integration/api/access_tokens/SessionSettingsTest.php
+++ b/framework/core/tests/integration/api/access_tokens/SessionSettingsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\access_tokens;
+
+use Flarum\Http\RememberAccessToken;
+use Flarum\Http\SessionAccessToken;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The admin panel writes these as ordinary settings, so what it saves has to be
+ * what the token classes read back.
+ */
+class SessionSettingsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function an_admin_can_save_a_token_lifetime()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'session.tokens.session' => 1800,
+                ],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(1800, SessionAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function a_saved_lifetime_applies_to_the_type_it_names_only()
+    {
+        $this->send(
+            $this->request('POST', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'session.tokens.session' => 1800,
+                ],
+            ])
+        );
+
+        $this->assertEquals(5 * 365 * 24 * 60 * 60, RememberAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function a_normal_user_cannot_save_session_settings()
+    {
+        // User 2 is the non-admin seeded in setUp().
+        $response = $this->send(
+            $this->request('POST', '/api/settings', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'session.tokens.session' => 60,
+                ],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(60 * 60, SessionAccessToken::lifetime());
+    }
+
+    #[Test]
+    public function config_still_wins_over_a_saved_setting()
+    {
+        $this->config('session.tokens.session', 900);
+
+        $this->send(
+            $this->request('POST', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'session.tokens.session' => 1800,
+                ],
+            ])
+        );
+
+        // The setting is stored, but the pinned value is what applies.
+        $this->assertEquals(900, SessionAccessToken::lifetime());
+    }
+}

--- a/framework/core/tests/integration/extenders/AccessTokenTest.php
+++ b/framework/core/tests/integration/extenders/AccessTokenTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Carbon\Carbon;
+use Flarum\Extend;
+use Flarum\Http\AccessToken;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AccessTokenTest extends TestCase
+{
+    #[Test]
+    public function token_types_are_registered_without_the_extender()
+    {
+        $this->app();
+
+        $this->assertArrayHasKey('session', AccessToken::getModels());
+        $this->assertArrayHasKey('session_remember', AccessToken::getModels());
+        $this->assertArrayHasKey('developer', AccessToken::getModels());
+    }
+
+    #[Test]
+    public function extender_registers_a_new_type()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(SecondFactorToken::class)
+        );
+
+        $this->app();
+
+        $this->assertArrayHasKey('second_factor', AccessToken::getModels());
+        $this->assertEquals(SecondFactorToken::class, AccessToken::getModels()['second_factor']);
+    }
+
+    #[Test]
+    public function a_registered_type_is_hydrated_as_its_own_class()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(SecondFactorToken::class)
+        );
+
+        $this->prepareDatabase([
+            AccessToken::class => [
+                ['token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::now(), 'type' => 'second_factor'],
+            ],
+        ]);
+
+        $this->populateDatabase();
+
+        $this->assertInstanceOf(SecondFactorToken::class, AccessToken::query()->where('token', 'a')->first());
+    }
+
+    #[Test]
+    public function a_registered_type_takes_its_lifetime_from_config()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(SecondFactorToken::class)
+        );
+
+        $this->config('session.tokens.second_factor', 60);
+
+        $this->app();
+
+        $this->assertEquals(60, SecondFactorToken::lifetime());
+    }
+
+    #[Test]
+    public function a_registered_type_takes_its_lifetime_from_settings()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(SecondFactorToken::class)
+        );
+
+        $this->setting('session.tokens.second_factor', 120);
+
+        $this->app();
+
+        $this->assertEquals(120, SecondFactorToken::lifetime());
+    }
+
+    #[Test]
+    public function a_registered_type_keeps_its_own_default_when_nothing_is_configured()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(SecondFactorToken::class)
+        );
+
+        $this->app();
+
+        $this->assertEquals(300, SecondFactorToken::lifetime());
+    }
+
+    #[Test]
+    public function a_registered_lifetime_decides_expiry()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(SecondFactorToken::class)
+        );
+
+        $this->config('session.tokens.second_factor', 60);
+
+        $this->prepareDatabase([
+            AccessToken::class => [
+                ['token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'second_factor'],
+            ],
+        ]);
+
+        $this->populateDatabase();
+
+        $this->assertEquals([], AccessToken::whereExpired(Carbon::parse('2021-01-01 02:00:30'))->pluck('token')->all());
+        $this->assertEquals(['a'], AccessToken::whereExpired(Carbon::parse('2021-01-01 02:02:00'))->pluck('token')->all());
+    }
+
+    #[Test]
+    public function a_type_can_opt_out_of_being_configured()
+    {
+        $this->extend(
+            (new Extend\AccessToken())
+                ->type(FixedLifetimeToken::class)
+        );
+
+        $this->config('session.tokens.fixed', 60);
+
+        $this->app();
+
+        $this->assertFalse(FixedLifetimeToken::hasConfigurableLifetime());
+        $this->assertEquals(900, FixedLifetimeToken::lifetime());
+    }
+
+    #[Test]
+    public function core_types_that_opt_out_cannot_be_configured()
+    {
+        // Developer tokens are meant to outlive sessions; an expiry set in the
+        // admin panel would break integrations rather than tighten security.
+        $this->config('session.tokens.developer', 60);
+
+        $this->app();
+
+        $this->assertEquals(0, \Flarum\Http\DeveloperAccessToken::lifetime());
+    }
+}
+
+class SecondFactorToken extends AccessToken
+{
+    public static string $type = 'second_factor';
+
+    protected static int $lifetime = 300;
+}
+
+class FixedLifetimeToken extends AccessToken
+{
+    public static string $type = 'fixed';
+
+    protected static int $lifetime = 900;
+
+    protected static bool $configurableLifetime = false;
+}


### PR DESCRIPTION
How long people stay signed in is currently fixed: one hour for a normal sign-in, five years for "remember me", and a two hour server-side session. The only way to change any of it is to redefine a core class, because the lifetime lives in a `protected static` property.

This makes all three configurable, in `config.php` or from the admin panel, with `config.php` taking precedence. Nothing changes for a forum that configures nothing.

**Token lifetimes are resolved rather than fixed.** `AccessToken::lifetime()` checks `config.php`, then the settings table, then the value the class declares. The two query scopes that decide validity and expiry use it. `$lifetime` stays as the default, so subclasses that set it keep working.

**Every registered token type is configurable, not a fixed list of two.** The admin panel builds its controls from `AccessToken::getModels()`, so a type added by an extension gets a lifetime control with no core change. A type can opt out with `$configurableLifetime = false` — `DeveloperAccessToken` does, since those are issued to scripts deliberately and an expiry set in the admin panel would break them quietly weeks later.

**New `Extend\AccessToken` extender** replaces calling `AccessToken::setModel()` from a service provider, which was undiscoverable and had no way to declare anything about the type.

**OAuth is covered by this.** `Forum\Auth\ResponseFactory` mints a `RememberAccessToken`, so every login through another service inherits the remember lifetime. Right now that means OAuth users get a five year session whether they wanted one or not, and a forum with a shorter session policy can't apply it to them at all.

Also adds a session-cookie option to expire on browser close, for shared computers. That's about the cookie only — the session stays valid server-side.

`CollectGarbage` now reads the same session lifetime as the cookie does. It previously used the hardcoded 120 minutes independently, so a shortened session would have been left on disk until the old default caught up.

`RememberAccessToken::rememberCookieLifeTime()` still works, delegating to `lifetime()`, and is marked deprecated.

### Config

```php
'session' => [
    'lifetime' => 120,
    'cookie_expires_on_close' => false,
    'tokens' => [
        'session' => 3600,
        'session_remember' => 157680000,
    ],
],
```

Anything set here is shown read-only in the admin panel, so session lengths can be pinned where an administrator can't loosen them.

<img width="890" height="1322" alt="image" src="https://github.com/user-attachments/assets/1efdcc65-60c0-40a9-a7ae-6ccb74e39637" />


Docs: https://github.com/flarum/docs/pull/573
