### PR TITLE
[2.x] fix(phpstan): recognize conditional model casts

### DIFF
--- a/php-packages/phpstan/src/Extender/Resolver.php
+++ b/php-packages/phpstan/src/Extender/Resolver.php
@@ -11,7 +11,10 @@ namespace Flarum\PHPStan\Extender;
 
 use Flarum\PHPStan\Extender\MethodCall as ExtenderMethodCall;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\Namespace_;
@@ -21,6 +24,13 @@ use PHPStan\Parser\ParserErrorsException;
 
 class Resolver
 {
+    private const CONDITIONAL_EXTENDER_ARGUMENTS = [
+        'when' => 1,
+        'whenExtensionDisabled' => 1,
+        'whenExtensionEnabled' => 1,
+        'whenSetting' => 2,
+    ];
+
     /** @var Extender[] */
     private $cachedExtenders = [];
     /** @var FilesProvider */
@@ -90,31 +100,83 @@ class Resolver
                 $expression = $statement->expr;
 
                 if ($expression instanceof Array_) {
-                    foreach ($expression->items as $item) {
-                        if ($item->value instanceof MethodCall) {
-                            // Conditional extenders
-                            if ($item->value->name->toString() === 'whenExtensionEnabled') {
-                                $conditionalExtenders = $item->value->args[1] ?? null;
-
-                                if ($conditionalExtenders->value instanceof Array_) {
-                                    foreach ($conditionalExtenders->value->items as $conditionalExtender) {
-                                        if ($conditionalExtender->value instanceof MethodCall) {
-                                            $extenders[] = $this->resolveExtender($conditionalExtender->value);
-                                        }
-                                    }
-                                }
-                            }
-                            // Normal extenders
-                            else {
-                                $extenders[] = $this->resolveExtender($item->value);
-                            }
-                        }
-                    }
+                    $extenders = array_merge($extenders, $this->resolveExtendersFromArray($expression));
                 }
             }
         }
 
         return $extenders;
+    }
+
+    /**
+     * @return Extender[]
+     */
+    private function resolveExtendersFromArray(Array_ $array): array
+    {
+        $extenders = [];
+
+        foreach ($array->items as $item) {
+            if (! $item?->value instanceof MethodCall) {
+                continue;
+            }
+
+            $extender = $this->resolveExtender($item->value);
+
+            if ($extender->isExtender('Conditional')) {
+                $extenders = array_merge($extenders, $this->resolveConditionalExtenders($item->value));
+            } else {
+                $extenders[] = $extender;
+            }
+        }
+
+        return $extenders;
+    }
+
+    /**
+     * @return Extender[]
+     */
+    private function resolveConditionalExtenders(MethodCall $methodCall): array
+    {
+        $extenders = [];
+
+        do {
+            $methodName = $methodCall->name->toString();
+            $argumentIndex = self::CONDITIONAL_EXTENDER_ARGUMENTS[$methodName] ?? null;
+
+            if ($argumentIndex !== null) {
+                $expression = $methodCall->args[$argumentIndex]->value ?? null;
+                $array = $this->resolveConditionalExtenderArray($expression);
+
+                if ($array !== null) {
+                    $extenders = array_merge($extenders, $this->resolveExtendersFromArray($array));
+                }
+            }
+
+            $methodCall = $methodCall->var instanceof MethodCall ? $methodCall->var : null;
+        } while ($methodCall !== null);
+
+        return $extenders;
+    }
+
+    private function resolveConditionalExtenderArray(?Expr $expression): ?Array_
+    {
+        if ($expression instanceof Array_) {
+            return $expression;
+        }
+
+        if ($expression instanceof ArrowFunction) {
+            return $expression->expr instanceof Array_ ? $expression->expr : null;
+        }
+
+        if ($expression instanceof Closure) {
+            foreach ($expression->stmts as $statement) {
+                if ($statement instanceof Return_ && $statement->expr instanceof Array_) {
+                    return $statement->expr;
+                }
+            }
+        }
+
+        return null;
     }
 
     private function resolveExtenderNew(New_ $var, array $methodCalls = []): Extender

--- a/php-packages/phpstan/tests/fixtures/conditional-model-cast/check.php
+++ b/php-packages/phpstan/tests/fixtures/conditional-model-cast/check.php
@@ -1,0 +1,11 @@
+<?php
+
+use Flarum\User\User;
+
+function setConditionalCasts(User $user): void
+{
+    $user->enabled_extension_cast = true;
+    $user->disabled_extension_cast = true;
+    $user->setting_cast = true;
+    $user->generic_condition_cast = true;
+}

--- a/php-packages/phpstan/tests/fixtures/conditional-model-cast/check.php
+++ b/php-packages/phpstan/tests/fixtures/conditional-model-cast/check.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 use Flarum\User\User;
 
 function setConditionalCasts(User $user): void

--- a/php-packages/phpstan/tests/fixtures/conditional-model-cast/extend.php
+++ b/php-packages/phpstan/tests/fixtures/conditional-model-cast/extend.php
@@ -1,0 +1,26 @@
+<?php
+
+use Flarum\Extend;
+use Flarum\User\User;
+
+return [
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-tags', fn () => [
+            (new Extend\Model(User::class))
+                ->cast('enabled_extension_cast', 'boolean'),
+        ])
+        ->whenExtensionDisabled('flarum-tags', function () {
+            return [
+                (new Extend\Model(User::class))
+                    ->cast('disabled_extension_cast', 'boolean'),
+            ];
+        })
+        ->whenSetting('theme', 'dark', fn () => [
+            (new Extend\Model(User::class))
+                ->cast('setting_cast', 'boolean'),
+        ])
+        ->when(true, fn () => [
+            (new Extend\Model(User::class))
+                ->cast('generic_condition_cast', 'boolean'),
+        ]),
+];

--- a/php-packages/phpstan/tests/fixtures/conditional-model-cast/extend.php
+++ b/php-packages/phpstan/tests/fixtures/conditional-model-cast/extend.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 use Flarum\Extend;
 use Flarum\User\User;
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -41,6 +41,8 @@ parameters:
 	  - extensions/messages/extend.php
 	  - extensions/gdpr/extend.php
 	  - extensions/gdpr/src
+	  - php-packages/phpstan/tests/fixtures/conditional-model-cast/extend.php
+	  - php-packages/phpstan/tests/fixtures/conditional-model-cast/check.php
 	excludePaths:
 		- *.blade.php
 	databaseMigrationsPath: ['framework/core/migrations']


### PR DESCRIPTION
## Changes

- inspect the callable arrays returned by all `Conditional` extender methods
- support both arrow functions and closure return bodies without executing them
- add end-to-end PHPStan fixtures for extension, setting, and generic conditions

## Why

`Conditional` moved from direct extender arrays to `callable|string`, but the
PHPStan resolver still looked only for a direct array on
`whenExtensionEnabled()`. Valid model casts nested in the current callable API
were therefore reported as undefined properties.

Fixes #4808

## Testing

- Failing-first fixture reproduced `property.notFound` on unchanged `2.x`
- Full `vendor/bin/phpstan analyse -c phpstan.neon --no-progress --error-format=table --memory-limit=2G`
- PHP syntax checks for the resolver and both fixtures
- `composer validate --no-check-publish` (valid; existing dependency-constraint warnings only)
