### PR TITLE
[2.x] feat: option to sort the discussion list by title

### DIFF
--- a/framework/core/js/src/forum/states/DiscussionListState.ts
+++ b/framework/core/js/src/forum/states/DiscussionListState.ts
@@ -75,6 +75,8 @@ export default class DiscussionListState<P extends DiscussionListParams = Discus
     map.top = '-commentCount';
     map.newest = '-createdAt';
     map.oldest = 'createdAt';
+    map.az = 'title';
+    map.za = '-title';
 
     return map;
   }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -655,12 +655,14 @@ core:
 
     # These translations are used by the sorting control above the discussion list.
     index_sort:
+      az_button: Title (A–Z)
       latest_button: Latest
       newest_button: => core.ref.newest
       oldest_button: => core.ref.oldest
       relevance_button: => core.ref.relevance
       toggle_dropdown_accessible_label: Change discussion list sorting
       top_button: Top
+      za_button: Title (Z–A)
 
     # These translations are used in the Log In modal dialog.
     log_in:

--- a/framework/core/migrations/2026_08_12_000000_add_title_index_to_discussions.php
+++ b/framework/core/migrations/2026_08_12_000000_add_title_index_to_discussions.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            // Supports sorting the discussion list by title, which the A-Z and
+            // Z-A options in the sort dropdown do.
+            //
+            // There is already an index on this column, but it is a FULLTEXT
+            // one: an inverted list of the words each title contains, which
+            // answers "which discussions mention coffee" and has no idea where
+            // a whole title falls alphabetically. MySQL will not consider it
+            // for ORDER BY at all — the plan comes back as a full table scan
+            // with a filesort, and stays that way however large the forum
+            // grows. On 200,000 discussions that is the difference between
+            // roughly 300ms and 2ms for a single page.
+            //
+            // One index covers both directions: the descending sort is served
+            // by reading the same index backwards.
+            $table->index('title');
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->dropIndex(['title']);
+        });
+    }
+];

--- a/framework/core/src/Api/Resource/DiscussionResource.php
+++ b/framework/core/src/Api/Resource/DiscussionResource.php
@@ -271,6 +271,9 @@ class DiscussionResource extends AbstractDatabaseResource
             SortColumn::make('createdAt')
                 ->ascendingAlias('oldest')
                 ->descendingAlias('newest'),
+            SortColumn::make('title')
+                ->ascendingAlias('az')
+                ->descendingAlias('za'),
         ];
     }
 

--- a/framework/core/tests/integration/api/discussions/ListSortedByTitleTest.php
+++ b/framework/core/tests/integration/api/discussions/ListSortedByTitleTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\discussions;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Sorting discussions by title, exposed as the `az` and `za` aliases.
+ *
+ * How text orders is the database's decision, not ours, and the four supported
+ * backends do not agree on it. MySQL, MariaDB and PostgreSQL fold case and
+ * accents through the column's collation, so `Apple`, `apple` and `Ápple` sort
+ * together. SQLite compares raw bytes, which puts every capitalised title ahead
+ * of every lowercase one, and accented titles after Z.
+ *
+ * These tests assert only what holds everywhere: that the sort exists, that it
+ * orders titles that differ in their first letter, and that descending is the
+ * reverse of ascending. Case and accent handling is deliberately left to the
+ * database and documented rather than asserted, since a test that passed on
+ * SQLite would have to contradict one that passed on MySQL.
+ */
+class ListSortedByTitleTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                // Titles chosen to differ in their first letter and to share a
+                // case, so that the expected order is the same on every backend.
+                $this->discussion(1, 'banana'),
+                $this->discussion(2, 'apricot'),
+                $this->discussion(3, 'cherry'),
+                $this->discussion(4, 'damson'),
+            ],
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    protected function discussion(int $id, string $title): array
+    {
+        return [
+            'id' => $id,
+            'title' => $title,
+            'created_at' => Carbon::createFromDate(2020, 1, $id)->toDateTimeString(),
+            'last_posted_at' => Carbon::createFromDate(2020, 1, $id)->toDateTimeString(),
+            'user_id' => 1,
+            'comment_count' => 1,
+        ];
+    }
+
+    /**
+     * @return string[] The titles returned, in the order the API returned them.
+     */
+    protected function titles(string $sort): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['sort' => $sort])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn ($d) => $d['attributes']['title'], $body['data']);
+    }
+
+    #[Test]
+    public function discussions_can_be_sorted_by_title_ascending()
+    {
+        $this->assertEquals(
+            ['apricot', 'banana', 'cherry', 'damson'],
+            $this->titles('title')
+        );
+    }
+
+    #[Test]
+    public function discussions_can_be_sorted_by_title_descending()
+    {
+        $this->assertEquals(
+            ['damson', 'cherry', 'banana', 'apricot'],
+            $this->titles('-title')
+        );
+    }
+
+    #[Test]
+    public function the_aliases_are_published_for_the_frontend()
+    {
+        // `az` and `za` are what appear in the URL and in the sort dropdown.
+        // They are translated to the real sort before the API is called, so
+        // the API itself never sees them — what matters is that the resource
+        // publishes the mapping.
+        $sortMap = $this->app()->getContainer()
+            ->make(\Flarum\Api\Resource\DiscussionResource::class)
+            ->sortMap();
+
+        $this->assertArrayHasKey('az', $sortMap);
+        $this->assertArrayHasKey('za', $sortMap);
+        $this->assertEquals('title', $sortMap['az']);
+        $this->assertEquals('-title', $sortMap['za']);
+    }
+
+    #[Test]
+    public function descending_is_the_reverse_of_ascending()
+    {
+        $this->assertEquals(
+            array_reverse($this->titles('title')),
+            $this->titles('-title')
+        );
+    }
+
+    #[Test]
+    public function an_unknown_sort_is_rejected_rather_than_ignored()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['sort' => 'nonsense'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+}

--- a/framework/core/tests/integration/database/DiscussionTitleIndexTest.php
+++ b/framework/core/tests/integration/database/DiscussionTitleIndexTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\database;
+
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The discussion list can be sorted by title, and that sort is only usable
+ * because the column carries an ordinary index.
+ *
+ * This is worth asserting because losing the index breaks nothing visibly. The
+ * sort keeps returning correct results; it just stops using an index and reads
+ * the whole table instead, which stays unnoticeable on a small forum and is
+ * felt on every page of a large one. A test is the only thing standing between
+ * that and a migration someone tidies away later.
+ *
+ * Note that MySQL and MariaDB already carry a FULLTEXT index on this column for
+ * search. That one cannot order rows — it is a list of the words each title
+ * contains — so its presence says nothing about whether sorting works.
+ */
+class DiscussionTitleIndexTest extends TestCase
+{
+    protected function schema()
+    {
+        return $this->app()
+            ->getContainer()
+            ->make('db')
+            ->getSchemaBuilder();
+    }
+
+    #[Test]
+    public function the_title_column_is_indexed_for_sorting()
+    {
+        // Matched on the column rather than the index name, which varies with
+        // the table prefix a site has configured.
+        $this->assertTrue(
+            $this->schema()->hasIndex('discussions', ['title']),
+            'discussions.title has no index, so sorting by title reads the whole table.'
+        );
+    }
+
+    #[Test]
+    public function the_sorting_index_is_not_the_fulltext_one()
+    {
+        $indexes = collect($this->schema()->getIndexes('discussions'))
+            ->filter(fn (array $index) => $index['columns'] === ['title']);
+
+        $this->assertTrue(
+            $indexes->contains(fn (array $index) => $index['type'] !== 'fulltext'),
+            'The only index on discussions.title is a FULLTEXT one, which cannot satisfy ORDER BY.'
+        );
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

Adds A-Z and Z-A to the discussion list sort dropdown, alongside Latest, Top, Newest and Oldest.

**Changes proposed in this pull request:**

* `DiscussionResource::sorts()` gains `title`, with `az` and `za` aliases for the URL and the dropdown.
* `DiscussionListState::sortMap()` and two locale strings expose it in the frontend.
* A migration adds an ordinary index on `discussions.title`.

**On the index**

There is already an index on that column, but it is a `FULLTEXT` one — a record of which words appear in each title, which is what search needs and says nothing about where a whole title falls alphabetically. MySQL will not consider it for `ORDER BY` at all; the plan comes back `ALL` with `Using filesort`.

Measured at 200,000 discussions, one page of `sort=title`:

| | plan | time |
| --- | --- | --- |
| without the index | `ALL` + `Using filesort` | 315–610ms |
| with the index | `index` + `Using index` | 0.8–2.6ms |

PostgreSQL (13.3ms → 0.14ms) and SQLite (17.7ms → 0.2ms) improve too, though less dramatically. One index serves both directions, since the descending sort reads it backwards. The FULLTEXT index is unaffected — I checked that `MATCH ... AGAINST` still selects it afterwards.

**On ordering**

How titles actually order is the database's decision. MySQL, MariaDB and PostgreSQL fold case and accents through the column's collation, so `Apple`, `apple` and `Ápple` sort together. SQLite compares raw bytes, so every capitalised title sorts ahead of every lowercase one.

No query-level fix reconciles all four: `COLLATE` syntax is per-driver, SQLite's `NOCASE` only folds ASCII, and PostgreSQL's ordering depends on the server locale. Making them agree would mean sorting on a separate normalised column, which is not worth the write cost for a sort option. It is documented instead.

**Reviewers should focus on:**

* The tests assert only what every backend agrees on — lowercase titles differing in their first letter. Anything tighter would pass on one driver and fail on another, which is what the CI matrix is for here.
* `DiscussionTitleIndexTest` also asserts the index is not the FULLTEXT one. Without that check it would pass on MySQL and MariaDB on the strength of an index that cannot sort.
* Sticky discussions still filesort when sorted by title, since the composite indexes lead with `is_sticky`. Left alone here; worth looking at separately.

**Screenshot**

<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [x] Related documentation PR: https://github.com/flarum/docs/pull/574
