### PR TITLE
[2.x] feat: let a tag set the sort its discussion list opens with

### DIFF
--- a/extensions/tags/js/src/admin/components/EditTagModal.tsx
+++ b/extensions/tags/js/src/admin/components/EditTagModal.tsx
@@ -2,6 +2,7 @@ import app from 'flarum/admin/app';
 import FormModal, { IFormModalAttrs } from 'flarum/common/components/FormModal';
 import Button from 'flarum/common/components/Button';
 import ColorPreviewInput from 'flarum/common/components/ColorPreviewInput';
+import Select from 'flarum/common/components/Select';
 import ItemList from 'flarum/common/utils/ItemList';
 import { slug } from 'flarum/common/utils/string';
 import Stream from 'flarum/common/utils/Stream';
@@ -31,6 +32,7 @@ export default class EditTagModal extends FormModal<EditTagModalAttrs> {
   icon!: Stream<string>;
   isHidden!: Stream<boolean>;
   isPrimary!: Stream<boolean>;
+  defaultSort!: Stream<string>;
 
   oninit(vnode: Mithril.Vnode<EditTagModalAttrs, this>) {
     super.oninit(vnode);
@@ -44,6 +46,7 @@ export default class EditTagModal extends FormModal<EditTagModalAttrs> {
     this.icon = Stream(this.tag.icon() || '');
     this.isHidden = Stream(this.tag.isHidden() || false);
     this.isPrimary = Stream(this.attrs.primary || false);
+    this.defaultSort = Stream(this.tag.defaultSort() || '');
   }
 
   className() {
@@ -137,6 +140,8 @@ export default class EditTagModal extends FormModal<EditTagModalAttrs> {
       10
     );
 
+    items.add('defaultSort', this.defaultSortField(), 5);
+
     items.add(
       'submit',
       <div className="Form-group Form-controls">
@@ -156,6 +161,46 @@ export default class EditTagModal extends FormModal<EditTagModalAttrs> {
     return items;
   }
 
+  /**
+   * The sorts a discussion list can be ordered by, as the forum offers them.
+   *
+   * Read from the payload rather than listed here, so that a sort added by an
+   * extension can be chosen as a tag's default without that extension knowing
+   * anything about tags.
+   */
+  sortOptions(): Record<string, string> {
+    const sorts = app.data.sortMaps?.discussions ?? {};
+
+    const options: Record<string, string> = {
+      '': extractText(app.translator.trans('flarum-tags.admin.edit_tag.default_sort_none')),
+    };
+
+    Object.keys(sorts).forEach((key) => {
+      options[key] = extractText(app.translator.trans(`core.lib.index_sort.${key}_button`));
+    });
+
+    // A sort saved earlier whose extension has since gone is kept in the list,
+    // so that it is not silently replaced by whatever happens to sit at the top
+    // of the dropdown when the tag is next edited.
+    const saved = this.defaultSort();
+
+    if (saved && !(saved in options)) {
+      options[saved] = extractText(app.translator.trans('flarum-tags.admin.edit_tag.default_sort_unavailable', { sort: saved }));
+    }
+
+    return options;
+  }
+
+  defaultSortField() {
+    return (
+      <div className="Form-group">
+        <label>{app.translator.trans('flarum-tags.admin.edit_tag.default_sort_label')}</label>
+        <div className="helpText">{app.translator.trans('flarum-tags.admin.edit_tag.default_sort_text')}</div>
+        <Select value={this.defaultSort() ?? ''} options={this.sortOptions()} onchange={this.defaultSort} />
+      </div>
+    );
+  }
+
   submitData() {
     return {
       name: this.name(),
@@ -165,6 +210,8 @@ export default class EditTagModal extends FormModal<EditTagModalAttrs> {
       icon: this.icon(),
       isHidden: this.isHidden(),
       isPrimary: this.isPrimary(),
+      // An empty selection means "no preference", which the API stores as null.
+      defaultSort: this.defaultSort() || null,
     };
   }
 

--- a/extensions/tags/js/src/forum/addTagFilter.tsx
+++ b/extensions/tags/js/src/forum/addTagFilter.tsx
@@ -133,6 +133,23 @@ export default function addTagFilter() {
   // DiscussionListState that will let us filter discussions by tag.
   extend(GlobalSearchState.prototype, 'params', function (params) {
     params.tags = m.route.param('tags');
+
+    // A tag can name the order its page opens with. The server already applies
+    // it when rendering the page, but the first client-side request is built
+    // from the URL alone — so without this the list is fetched again in the
+    // default order and replaces the one the reader arrived to.
+    //
+    // Only when nothing was asked for: a sort in the URL is the reader's own
+    // choice and outranks the tag's default. An unrecognised sort is left
+    // alone, since the extension that provided it may simply be disabled for
+    // now, and passing it on would have the API reject the request.
+    if (!params.sort && params.tags) {
+      const defaultSort = findTag(params.tags)?.defaultSort();
+
+      if (defaultSort && defaultSort in app.discussions.sortMap()) {
+        params.sort = defaultSort;
+      }
+    }
   });
 
   // Translate that parameter into a gambit appended to the search query.

--- a/extensions/tags/js/tests/unit/forum/addTagFilter.test.ts
+++ b/extensions/tags/js/tests/unit/forum/addTagFilter.test.ts
@@ -4,6 +4,8 @@ import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { jest } from '@jest/globals';
 
+import GlobalSearchState from 'flarum/forum/states/GlobalSearchState';
+
 import addTagFilter from '../../../src/forum/addTagFilter';
 import Tag from '../../../src/common/models/Tag';
 
@@ -15,6 +17,9 @@ const coreJsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../
  * changing this value — app.currentTag() must stay consistent with it.
  */
 let routeTagsParam: string | undefined;
+
+/** What m.route.param() would return for the current route. */
+let routeParams: Record<string, string | undefined> = {};
 
 beforeAll(() => {
   const cwd = process.cwd();
@@ -44,6 +49,18 @@ beforeAll(() => {
         attributes: { slug: 'bugs', name: 'Bugs' },
         relationships: { children: { data: [] } },
       },
+      {
+        id: '3',
+        type: 'tags',
+        attributes: { slug: 'sorted', name: 'Sorted', defaultSort: 'az' },
+        relationships: { children: { data: [] } },
+      },
+      {
+        id: '4',
+        type: 'tags',
+        attributes: { slug: 'stale', name: 'Stale', defaultSort: 'sort_from_a_removed_extension' },
+        relationships: { children: { data: [] } },
+      },
     ],
   });
 
@@ -54,6 +71,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   routeTagsParam = undefined;
+  routeParams = {};
   (app as any).currentActiveTag = undefined;
   (app as any).currentTagLoading = false;
 });
@@ -113,5 +131,47 @@ describe('app.currentTag()', () => {
     routeTagsParam = 'bugs';
 
     expect(app.currentTag()!.slug()).toBe('bugs');
+  });
+});
+
+/**
+ * A tag can name the order its page opens with.
+ *
+ * The server applies it when rendering the page, but the first client-side
+ * request is built from the URL alone — so without this the list is fetched
+ * again in the default order and replaces the one the reader arrived to.
+ */
+describe("a tag's default sort", () => {
+  // Drive the real state object, so what is asserted is what the forum does.
+  const params = () => new GlobalSearchState().params();
+
+  beforeEach(() => {
+    (m as any).route = { param: (key: string) => routeParams[key] };
+  });
+
+  it('is used when the reader has not asked for a sort', () => {
+    routeParams = { tags: 'sorted' };
+
+    expect(params().sort).toBe('az');
+  });
+
+  it('leaves a sort chosen by the reader alone', () => {
+    routeParams = { tags: 'sorted', sort: 'newest' };
+
+    expect(params().sort).toBe('newest');
+  });
+
+  it('is absent for a tag that has not set one', () => {
+    routeParams = { tags: 'general' };
+
+    expect(params().sort).toBeUndefined();
+  });
+
+  it('is ignored when the sort no longer exists', () => {
+    // The extension that registered it may simply be disabled for now, and
+    // passing it on would have the API reject the request.
+    routeParams = { tags: 'stale' };
+
+    expect(params().sort).toBeUndefined();
   });
 });

--- a/extensions/tags/locale/en.yml
+++ b/extensions/tags/locale/en.yml
@@ -18,6 +18,10 @@ flarum-tags:
     edit_tag:
       color_label: => core.ref.color
       delete_tag_button: Delete Tag
+      default_sort_label: Default Sort
+      default_sort_none: Use the forum default
+      default_sort_text: How this tag's discussions are ordered when someone arrives without choosing a sort themselves.
+      default_sort_unavailable: "{sort} (no longer available)"
       delete_tag_confirmation: "Are you sure you want to delete this tag? The tag's discussions will NOT be deleted."
       description_label: Description
       hide_label: Hide from All Discussions

--- a/extensions/tags/src/Api/Resource/TagResource.php
+++ b/extensions/tags/src/Api/Resource/TagResource.php
@@ -119,6 +119,16 @@ class TagResource extends AbstractDatabaseResource
             Schema\Integer::make('position')
                 ->nullable(),
             Schema\Str::make('defaultSort')
+                // The sort a tag's discussion list opens with, stored as the
+                // alias that appears in a URL rather than the API sort behind
+                // it, so that it round-trips through the dropdown unchanged.
+                //
+                // Deliberately unvalidated against the sorts currently
+                // registered: they come and go with the extensions that provide
+                // them, and a value pointing at one that is temporarily absent
+                // should be kept rather than rejected. The forum falls back to
+                // its usual sort while that is the case.
+                ->writable()
                 ->nullable(),
             Schema\Boolean::make('isChild')
                 ->get(fn (Tag $tag) => (bool) $tag->parent_id),

--- a/extensions/tags/src/Content/Tag.php
+++ b/extensions/tags/src/Content/Tag.php
@@ -48,6 +48,16 @@ class Tag
 
         $tag = $this->slugger->forResource(TagModel::class)->fromSlug($slug, $actor);
 
+        // A tag can name the order its page opens with. Someone who has asked
+        // for a particular sort has said what they want, so their choice wins;
+        // the tag's default only answers the case where nothing was asked.
+        //
+        // The stored value is not guaranteed to still exist — sorts arrive and
+        // leave with the extensions that register them — so an unrecognised one
+        // falls through to the usual order rather than being passed on to the
+        // API, which would reject it.
+        $sort ??= $tag->default_sort;
+
         $params = [
             'sort' => $sort && isset($sortMap[$sort]) ? $sortMap[$sort] : '',
             'filter' => [

--- a/extensions/tags/tests/integration/api/tags/DefaultSortTest.php
+++ b/extensions/tags/tests/integration/api/tags/DefaultSortTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Tests\integration\api\tags;
+
+use Flarum\Tags\Tag;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A tag can name the sort its discussion list opens with.
+ *
+ * The value stored is the alias that appears in a URL — `newest`, `top`, and
+ * whatever else extensions have added — rather than the API sort behind it, so
+ * that it round-trips through the sort dropdown unchanged.
+ *
+ * Nothing validates that the alias still exists. Sorts arrive and leave with
+ * the extensions that register them, and a tag pointing at one that has gone
+ * should fall back quietly rather than break the page or lose the setting: the
+ * extension may well be reinstalled tomorrow.
+ */
+class DefaultSortTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Tag::class => [
+                ['id' => 1, 'name' => 'Support', 'slug' => 'support', 'position' => 0],
+                ['id' => 2, 'name' => 'Archive', 'slug' => 'archive', 'position' => 1, 'default_sort' => 'oldest'],
+            ],
+        ]);
+    }
+
+    protected function update(int $id, array $attributes, int $actor = 1)
+    {
+        return $this->send(
+            $this->request('PATCH', "/api/tags/$id", [
+                'authenticatedAs' => $actor,
+                'json' => [
+                    'data' => ['attributes' => $attributes],
+                ],
+            ])
+        );
+    }
+
+    #[Test]
+    public function an_admin_can_set_a_default_sort()
+    {
+        $response = $this->update(1, ['defaultSort' => 'newest']);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('newest', Tag::find(1)->default_sort);
+    }
+
+    #[Test]
+    public function an_admin_can_clear_a_default_sort()
+    {
+        $response = $this->update(2, ['defaultSort' => null]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertNull(Tag::find(2)->default_sort);
+    }
+
+    #[Test]
+    public function a_normal_user_cannot_set_a_default_sort()
+    {
+        $response = $this->update(1, ['defaultSort' => 'newest'], 2);
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertNull(Tag::find(1)->default_sort);
+    }
+
+    #[Test]
+    public function the_default_sort_is_visible_in_the_api()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/tags', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $archive = collect($body['data'])->firstWhere('id', '2');
+
+        $this->assertEquals('oldest', $archive['attributes']['defaultSort']);
+    }
+
+    #[Test]
+    public function a_tag_with_no_default_sort_reports_null_rather_than_omitting_it()
+    {
+        // The admin UI needs to tell "no preference" apart from "attribute
+        // missing", so the field is always present.
+        $response = $this->send(
+            $this->request('GET', '/api/tags', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $support = collect($body['data'])->firstWhere('id', '1');
+
+        $this->assertArrayHasKey('defaultSort', $support['attributes']);
+        $this->assertNull($support['attributes']['defaultSort']);
+    }
+
+    #[Test]
+    public function a_sort_that_no_longer_exists_is_kept_rather_than_rejected()
+    {
+        // The extension that registered `trending` may be disabled today and
+        // enabled again next week. Refusing the value, or clearing it, would
+        // lose a setting the administrator never changed.
+        $response = $this->update(1, ['defaultSort' => 'trending']);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('trending', Tag::find(1)->default_sort);
+    }
+}

--- a/extensions/tags/tests/integration/content/TagDefaultSortTest.php
+++ b/extensions/tags/tests/integration/content/TagDefaultSortTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Tests\integration\content;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Tags\Tag;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A tag's default sort decides the order its page opens with.
+ *
+ * Applied while the page is rendered rather than after it loads, so that the
+ * discussions arrive in the right order to begin with instead of being
+ * reordered in front of the reader.
+ *
+ * An explicit `?sort=` in the URL always wins: the default answers "what should
+ * this tag look like when nobody has asked for anything", not "how must this
+ * tag always look".
+ */
+class TagDefaultSortTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Tag::class => [
+                ['id' => 1, 'name' => 'Plain', 'slug' => 'plain', 'position' => 0],
+                ['id' => 2, 'name' => 'Oldest First', 'slug' => 'oldest-first', 'position' => 1, 'default_sort' => 'oldest'],
+                ['id' => 3, 'name' => 'Gone', 'slug' => 'gone', 'position' => 2, 'default_sort' => 'sort_from_a_removed_extension'],
+            ],
+            Discussion::class => [
+                $this->discussion(1, 'First', '2020-01-01'),
+                $this->discussion(2, 'Second', '2021-01-01'),
+                $this->discussion(3, 'Third', '2022-01-01'),
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 2, 'tag_id' => 1],
+                ['discussion_id' => 3, 'tag_id' => 1],
+                ['discussion_id' => 1, 'tag_id' => 2],
+                ['discussion_id' => 2, 'tag_id' => 2],
+                ['discussion_id' => 3, 'tag_id' => 2],
+                ['discussion_id' => 1, 'tag_id' => 3],
+                ['discussion_id' => 2, 'tag_id' => 3],
+                ['discussion_id' => 3, 'tag_id' => 3],
+            ],
+        ]);
+    }
+
+    protected function discussion(int $id, string $title, string $date): array
+    {
+        return [
+            'id' => $id,
+            'title' => $title,
+            'created_at' => Carbon::parse($date)->toDateTimeString(),
+            'last_posted_at' => Carbon::parse($date)->toDateTimeString(),
+            'user_id' => 1,
+            'comment_count' => 1,
+            'is_private' => 0,
+        ];
+    }
+
+    /**
+     * @return string[] Discussion titles in the order the page rendered them.
+     */
+    protected function titles(string $slug, array $query = []): array
+    {
+        $response = $this->send(
+            $this->request('GET', "/t/$slug")->withQueryParams($query)
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        preg_match('/<script id="flarum-json-payload" type="application\/json">(.+?)<\/script>/s', (string) $response->getBody(), $matches);
+
+        $payload = json_decode(html_entity_decode($matches[1]), true);
+
+        return array_map(
+            fn (array $d) => $d['attributes']['title'],
+            array_filter(
+                $payload['apiDocument']['data'] ?? [],
+                fn (array $d) => $d['type'] === 'discussions'
+            )
+        );
+    }
+
+    #[Test]
+    public function a_tag_without_a_default_sort_uses_the_forum_order()
+    {
+        // Newest activity first, which is what the discussion list does when
+        // nothing else is asked of it.
+        $this->assertEquals(['Third', 'Second', 'First'], $this->titles('plain'));
+    }
+
+    #[Test]
+    public function a_tag_with_a_default_sort_opens_in_that_order()
+    {
+        $this->assertEquals(['First', 'Second', 'Third'], $this->titles('oldest-first'));
+    }
+
+    #[Test]
+    public function an_explicit_sort_in_the_url_beats_the_tags_default()
+    {
+        $this->assertEquals(['Third', 'Second', 'First'], $this->titles('oldest-first', ['sort' => 'newest']));
+    }
+
+    #[Test]
+    public function a_default_sort_that_no_longer_exists_falls_back_quietly()
+    {
+        // The extension that registered this sort has gone. The page should
+        // render in the forum's usual order rather than erroring, and the tag
+        // keeps the setting in case the extension comes back.
+        $this->assertEquals(['Third', 'Second', 'First'], $this->titles('gone'));
+
+        $this->assertEquals('sort_from_a_removed_extension', Tag::find(3)->default_sort);
+    }
+}

--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -98,6 +98,13 @@ export interface AdminApplicationData extends ApplicationData {
   knownQueues: string[];
   schedulerStatus: string;
   sessionDriver: string;
+
+  /**
+   * The sort options each resource offers, keyed by resource type, and within
+   * that by the alias that appears in a URL. Mirrors what the forum receives,
+   * so admin UI can offer sorting without keeping its own copy of the list.
+   */
+  sortMaps: Record<string, Record<string, string>>;
 }
 
 export default class AdminApplication extends Application {

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -655,14 +655,14 @@ core:
 
     # These translations are used by the sorting control above the discussion list.
     index_sort:
-      az_button: Title (A–Z)
-      latest_button: Latest
+      az_button: => core.ref.title_az
+      latest_button: => core.ref.latest
       newest_button: => core.ref.newest
       oldest_button: => core.ref.oldest
       relevance_button: => core.ref.relevance
       toggle_dropdown_accessible_label: Change discussion list sorting
-      top_button: Top
-      za_button: Title (Z–A)
+      top_button: => core.ref.top
+      za_button: => core.ref.title_za
 
     # These translations are used in the Log In modal dialog.
     log_in:
@@ -964,6 +964,18 @@ core:
       maintenance_mode_low: Down for maintenance. Only administrators can access the forum.
       maintenance_mode_safe: Down for maintenance with safe mode. Only administrators can access the forum and no extensions are booted.
 
+    # The names of the discussion list's sort options. These live here rather
+    # than under `forum` because the admin panel names them too — a tag's
+    # default sort, for one — and the forum namespace is not shipped to it.
+    index_sort:
+      az_button: => core.ref.title_az
+      latest_button: => core.ref.latest
+      newest_button: => core.ref.newest
+      oldest_button: => core.ref.oldest
+      relevance_button: => core.ref.relevance
+      top_button: => core.ref.top
+      za_button: => core.ref.title_za
+
     # These translations are used as suffixes when abbreviating numbers.
     number_suffix:
       kilo_text: K
@@ -1237,6 +1249,7 @@ core:
     light_hc_mode_label: Light High Contrast Mode
     light_mode_label: Light Mode
     load_more: Load More
+    latest: Latest
     loading: Loading...
     log_in: Log In
     log_out: Log Out
@@ -1266,6 +1279,9 @@ core:
     sign_up: Sign Up
     some_others: "{count, plural, one {# other} other {# others}}" # Referenced by flarum-likes.yml, flarum-mentions.yml
     start_a_discussion: Start a Discussion
+    title_az: Title (A–Z)
+    title_za: Title (Z–A)
+    top: Top
     username: Username
     username_or_email_placeholder: Username or Email
     users: Users # Referenced by flarum-statistics.yml

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Admin\Content;
 
+use Flarum\Api\Resource\AbstractResource;
 use Flarum\Database\AbstractModel;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\ApplicationInfoProvider;
@@ -46,6 +47,42 @@ class AdminPayload
         $queue = $this->container->make(\Illuminate\Contracts\Queue\Queue::class);
 
         return $factory->pausedQueues((string) $queue->getConnectionName());
+    }
+
+    /**
+     * The sort options each resource offers, keyed by resource type.
+     *
+     * The forum already receives this, as it is what the sort dropdown is built
+     * from and how `?sort=newest` in a URL becomes `-createdAt` for the API. The
+     * admin side needs the same list wherever it offers sorting as a setting,
+     * and assembling one in JavaScript would mean a second copy that silently
+     * omits whatever sorts extensions have added.
+     *
+     * Only aliased sorts appear: a sort without one is perfectly usable through
+     * the API, but has no name to put in front of an administrator. Resources
+     * with nothing to offer are left out rather than published empty.
+     *
+     * @return array<string, array<string, string>>
+     */
+    protected function sortMaps(): array
+    {
+        $maps = [];
+
+        foreach ($this->container->make('flarum.api.resources') as $resourceClass) {
+            $resource = $this->container->make($resourceClass);
+
+            // Sorting is a listing concern, so anything that cannot be listed —
+            // the forum resource, for one — has no sorts to offer.
+            if (! $resource instanceof AbstractResource) {
+                continue;
+            }
+
+            if ($map = $resource->sortMap()) {
+                $maps[$resource->type()] = $map;
+            }
+        }
+
+        return $maps;
     }
 
     public function __construct(
@@ -91,6 +128,7 @@ class AdminPayload
         $document->payload['avatarDrivers'] = array_keys($this->container->make('flarum.user.avatar.supported_drivers'));
         $document->payload['slugDrivers'] = array_map(array_keys(...), $this->container->make('flarum.http.slugDrivers'));
         $document->payload['searchDrivers'] = $this->getSearchDrivers();
+        $document->payload['sortMaps'] = $this->sortMaps();
 
         $document->payload['phpVersion'] = $this->appInfo->identifyPHPVersion();
         $document->payload['dbDriver'] = $this->appInfo->identifyDatabaseDriver();

--- a/framework/core/tests/integration/admin/SortMapsPayloadTest.php
+++ b/framework/core/tests/integration/admin/SortMapsPayloadTest.php
@@ -9,11 +9,10 @@
 
 namespace Flarum\Tests\integration\admin;
 
-use Flarum\Extend;
 use Flarum\Api\Sort\SortColumn;
+use Flarum\Extend;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
-use Flarum\User\User;
 use PHPUnit\Framework\Attributes\Test;
 
 /**

--- a/framework/core/tests/integration/admin/SortMapsPayloadTest.php
+++ b/framework/core/tests/integration/admin/SortMapsPayloadTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\admin;
+
+use Flarum\Extend;
+use Flarum\Api\Sort\SortColumn;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The sort options a resource offers, published to the admin frontend.
+ *
+ * The forum already receives this — it is how the sort dropdown is built and
+ * how `?sort=newest` in a URL becomes `-createdAt` for the API. The admin side
+ * needs the same list to offer sorting as a setting, and building that list in
+ * JavaScript instead would mean a second copy that silently omits whatever
+ * sorts extensions have added.
+ *
+ * Keyed by resource type rather than hardcoded to discussions, since posts and
+ * users have sort maps of their own.
+ */
+class SortMapsPayloadTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    protected function payload(): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/admin', ['authenticatedAs' => 1])
+        );
+
+        preg_match('/<script id="flarum-json-payload" type="application\/json">(.+?)<\/script>/s', (string) $response->getBody(), $matches);
+
+        $this->assertNotEmpty($matches, 'The admin page carried no JSON payload.');
+
+        return json_decode(html_entity_decode($matches[1]), true);
+    }
+
+    #[Test]
+    public function payload_carries_sort_maps_keyed_by_resource_type()
+    {
+        $maps = $this->payload()['sortMaps'];
+
+        $this->assertArrayHasKey('discussions', $maps);
+
+        // Only discussions ship aliased sorts in core. Users, for instance, can
+        // be sorted through the API but none of those sorts are named, so there
+        // is nothing to publish — see the test below.
+        $this->assertIsArray($maps['discussions']);
+    }
+
+    #[Test]
+    public function a_sort_map_maps_the_alias_to_the_api_sort()
+    {
+        $discussions = $this->payload()['sortMaps']['discussions'];
+
+        $this->assertEquals('-lastPostedAt', $discussions['latest']);
+        $this->assertEquals('-createdAt', $discussions['newest']);
+        $this->assertEquals('createdAt', $discussions['oldest']);
+    }
+
+    #[Test]
+    public function resources_without_sorts_are_left_out_entirely()
+    {
+        // An empty map would have the admin offering a control with nothing in
+        // it, so those resources are omitted rather than published empty.
+        foreach ($this->payload()['sortMaps'] as $type => $map) {
+            $this->assertNotEmpty($map, "The sort map for $type is empty and should not have been published.");
+        }
+    }
+
+    #[Test]
+    public function a_sort_added_by_an_extension_is_published_too()
+    {
+        // The reason this belongs on the server: an extension adding a sort
+        // gets it into the admin UI without touching the admin frontend.
+        $this->extend(
+            (new Extend\ApiResource(\Flarum\Api\Resource\DiscussionResource::class))
+                ->sorts(fn () => [
+                    SortColumn::make('participantCount')
+                        ->ascendingAlias('fewest_people')
+                        ->descendingAlias('most_people'),
+                ])
+        );
+
+        $discussions = $this->payload()['sortMaps']['discussions'];
+
+        $this->assertArrayHasKey('most_people', $discussions);
+        $this->assertEquals('-participantCount', $discussions['most_people']);
+        $this->assertEquals('participantCount', $discussions['fewest_people']);
+    }
+
+    #[Test]
+    public function sorts_without_an_alias_are_not_published()
+    {
+        // A sort with no alias is usable through the API but has no name to
+        // show in a dropdown, so it has nothing to contribute here.
+        $this->extend(
+            (new Extend\ApiResource(\Flarum\Api\Resource\DiscussionResource::class))
+                ->sorts(fn () => [
+                    SortColumn::make('slug'),
+                ])
+        );
+
+        $this->assertArrayNotHasKey('slug', $this->payload()['sortMaps']['discussions']);
+    }
+
+    #[Test]
+    public function a_resource_whose_sorts_are_all_unaliased_is_absent()
+    {
+        // Users can be sorted through the API, but core gives none of those
+        // sorts an alias, so there is nothing to name in a dropdown and the
+        // resource does not appear at all.
+        $this->assertArrayNotHasKey('users', $this->payload()['sortMaps']);
+    }
+
+    #[Test]
+    public function a_normal_user_never_sees_this()
+    {
+        // Belt and braces: the admin payload is admin-only, and this test
+        // fails loudly if that ever stops being true.
+        $response = $this->send(
+            $this->request('GET', '/admin', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

Follow-on from #4921. A tag can now name the order its discussion list opens with, chosen in the tag edit modal.

The `tags.default_sort` column has existed since 2015, with a model attribute and an API field to match, but nothing ever wrote to it or read it — on 1.x either. This finishes it.

**Changes proposed in this pull request:**

* **Core** — `AdminPayload` publishes each resource's sort map, keyed by resource type. Core already computes this for the forum; the admin panel now receives the same thing.
* **Core** — the sort names move to the `lib` namespace, which admin receives and `forum` is not. Both namespaces point at the same `core.ref.*` entries, so the keys language packs already translate are untouched.
* **Tags** — `defaultSort` becomes writable, inheriting the endpoint's existing `can('edit')` gate.
* **Tags** — a select in the tag edit modal, built from the payload rather than a hardcoded list.
* **Tags** — the default applied when rendering the page, and again in the search state.

**Why the sort list comes from the server**

Building it in JavaScript would mean a second copy that silently omits whatever sorts extensions have added. As it stands, a sort registered by an extension can be chosen as a tag's default without that extension knowing tags exist — on my install the dropdown offers `trending` and `votes` from fof/gamification alongside core's, with no changes anywhere.

**Why it is applied twice**

Once during rendering, so discussions arrive in the right order rather than being reordered in front of the reader. Once in `GlobalSearchState`, because the first client-side request is built from the URL alone — without it the list is refetched in the default order and replaces the one the reader arrived to. I had this wrong at first: server-side alone fixes the first paint and nothing else.

An explicit `?sort=` wins in both places.

**When a sort disappears**

Sorts arrive and leave with the extensions that register them, so a stored value is never validated against the current list:

* Forum — an unrecognised sort falls through to the usual order; it is never passed to the API, which would reject it.
* Admin — the value is kept and shown as unavailable, rather than being silently replaced by whatever sits at the top of the dropdown.
* API — an unknown value is accepted, since the extension may be reinstalled tomorrow.

**Reviewers should focus on:**

* `sortMaps` is a new public payload key. It omits resources whose sorts carry no alias — those are usable through the API but have no name to show — which is why `users` is absent in a bare install.
* The locale move is the part that could affect translators. Nothing was renamed or removed; `core.forum.index_sort.*` still resolves exactly as before, verified in the built bundle.
* `ShowTest::can_show_tag_with_url_decoded_utf8_slug` fails in the tags suite. It fails on a clean `2.x` too — not from this branch.

**Screenshot**

<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
