### PR TITLE
[2.x] feat: show links back to the forum as the discussion they point at

### DIFF
--- a/framework/core/js/src/forum/ForumApplication.tsx
+++ b/framework/core/js/src/forum/ForumApplication.tsx
@@ -17,6 +17,7 @@ import GlobalSearchState from './states/GlobalSearchState';
 import DiscussionListState from './states/DiscussionListState';
 import ComposerState from './states/ComposerState';
 import isSafariMobile from './utils/isSafariMobile';
+import routeInternalLinks from './utils/routeInternalLinks';
 
 import type Notification from './components/Notification';
 import type Post from './components/Post';
@@ -123,9 +124,13 @@ export default class ForumApplication extends Application {
     m.mount(document.getElementById('notices')!, Notices);
     m.mount(document.getElementById('footer')!, Footer);
 
+    // Registered before the listeners below, which are bound to elements that
+    // are not on every page — so a missing one cannot stop this from running.
+    routeInternalLinks();
+
     // Route the home link back home when clicked. We do not want it to register
     // if the user is opening it in a new tab, however.
-    document.getElementById('home-link')!.addEventListener('click', (e) => {
+    document.getElementById('home-link')?.addEventListener('click', (e) => {
       if (e.ctrlKey || e.metaKey || e.button === 1) return;
       e.preventDefault();
       app.history.home();

--- a/framework/core/js/src/forum/components/ComposerPostPreview.js
+++ b/framework/core/js/src/forum/components/ComposerPostPreview.js
@@ -1,6 +1,7 @@
 /*global s9e*/
 
 import Component from '../../common/Component';
+import labelDiscussionLinks from '../utils/labelDiscussionLinks';
 
 /**
  * The `ComposerPostPreview` component renders Markdown as HTML using the
@@ -41,7 +42,14 @@ export default class ComposerPostPreview extends Component {
 
       preview = content;
 
-      this.attrs.surround(() => s9e.TextFormatter.preview(preview || '', vnode.dom));
+      this.attrs.surround(() => {
+        s9e.TextFormatter.preview(preview || '', vnode.dom);
+
+        // The JS formatter works from the raw text alone, so it cannot know
+        // which links point back at this forum. Applied after it runs, so the
+        // preview matches what the server will render.
+        labelDiscussionLinks(vnode.dom);
+      });
     };
     updatePreview();
 

--- a/framework/core/js/src/forum/utils/labelDiscussionLinks.ts
+++ b/framework/core/js/src/forum/utils/labelDiscussionLinks.ts
@@ -1,0 +1,83 @@
+import app from '../app';
+
+/**
+ * Label links to discussions in the composer preview.
+ *
+ * The server does this while rendering a post, but the preview never reaches
+ * the server: it is produced in the browser by the JavaScript TextFormatter,
+ * working from the raw text alone. Without this, a link the writer has just
+ * pasted looks like a bare address while they are typing and then changes into
+ * a label once the post is saved.
+ *
+ * This mirrors the decision made in `Formatter::configureDefaultsOnLinks()`.
+ * The two have to agree, so that what the writer sees is what they get.
+ */
+export default function labelDiscussionLinks(element: HTMLElement) {
+  const basePath = app.forum.attribute<string>('basePath') || '';
+  const faviconUrl = app.forum.attribute<string | null>('faviconUrl');
+
+  for (const link of Array.from(element.querySelectorAll('a'))) {
+    // The label stands in for the address only when the address is all the
+    // link says. If the writer wrote their own text, that text is theirs.
+    if (link.textContent !== link.getAttribute('href')) continue;
+
+    let url: URL;
+
+    try {
+      url = new URL(link.href, document.baseURI);
+    } catch {
+      continue;
+    }
+
+    if (url.origin !== window.location.origin) continue;
+
+    let path = url.pathname;
+
+    if (basePath) {
+      if (path !== basePath && !path.startsWith(basePath + '/')) continue;
+
+      path = path.slice(basePath.length);
+    }
+
+    const matches = /^\/d\/(\d+)(?:-[^/]*)?(?:\/([^/]*))?\/?$/.exec(path);
+
+    if (!matches) continue;
+
+    const near = matches[2];
+
+    // Positions this cannot label — `near-something`, and anything else that
+    // is not a plain post number — keep the address rather than claiming a
+    // post number that was never found.
+    if (near !== undefined && near !== '' && !/^\d+$/.test(near)) continue;
+
+    link.classList.add('UrlLink', 'UrlLink--internal', 'UrlLink--discussion');
+    link.textContent = '';
+
+    if (faviconUrl) {
+      const favicon = document.createElement('img');
+      favicon.src = faviconUrl;
+      favicon.className = 'UrlLink-favicon';
+      favicon.alt = '';
+      favicon.setAttribute('aria-hidden', 'true');
+      link.appendChild(favicon);
+    }
+
+    const discussion = document.createElement('span');
+    discussion.className = 'UrlLink-discussion';
+    discussion.textContent = '#' + matches[1];
+    link.appendChild(discussion);
+
+    if (near) {
+      const post = document.createElement('span');
+      post.className = 'UrlLink-post';
+
+      const icon = document.createElement('i');
+      icon.className = 'icon fas fa-comment UrlLink-postIcon';
+      icon.setAttribute('aria-hidden', 'true');
+      post.appendChild(icon);
+      post.appendChild(document.createTextNode(near));
+
+      link.appendChild(post);
+    }
+  }
+}

--- a/framework/core/js/src/forum/utils/routeInternalLinks.ts
+++ b/framework/core/js/src/forum/utils/routeInternalLinks.ts
@@ -1,0 +1,67 @@
+import app from '../app';
+
+/**
+ * Follow links that point back at this forum without reloading the page.
+ *
+ * A discussion link copied from the address bar and pasted into a post is an
+ * ordinary `<a href="https://myforum.com/d/1">`. Left alone, clicking it tears
+ * down the whole application and boots it again, which is slow and loses the
+ * reader's place — even though the destination is a route this app already
+ * knows how to render.
+ *
+ * The server marks these links while rendering the post, so this only has to
+ * recognise the marker rather than work out what is internal on the client.
+ *
+ * One listener on the document handles every post on the page, including posts
+ * loaded later and content rendered by extensions, because the check happens
+ * when a click actually arrives rather than when the markup is created.
+ */
+export default function routeInternalLinks() {
+  document.addEventListener('click', (e: MouseEvent) => {
+    // Anything but an unmodified left click means the reader has asked for
+    // something other than "go there now" — a new tab, a download, a menu —
+    // and the browser does all of those better than we would.
+    if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey || e.defaultPrevented) return;
+
+    const link = (e.target as HTMLElement | null)?.closest?.('a.UrlLink--internal') as HTMLAnchorElement | null;
+
+    if (!link) return;
+
+    // `target` may have been changed by an extension after the server set it;
+    // if the link is meant for another tab, let it go there.
+    if (link.target && link.target !== '_self') return;
+
+    const href = link.getAttribute('href');
+
+    if (!href) return;
+
+    let url: URL;
+
+    try {
+      url = new URL(href, document.baseURI);
+    } catch {
+      return;
+    }
+
+    // The marker was written when the post was rendered, which may have been
+    // before the forum moved. Confirm against the address this page is
+    // actually being served from rather than trusting the class alone.
+    if (url.origin !== window.location.origin) return;
+
+    const basePath = app.forum.attribute<string>('basePath') || '';
+    const path = url.pathname;
+
+    if (basePath && !(path === basePath || path.startsWith(basePath + '/'))) return;
+
+    // What Mithril routes on excludes the base path, since that is its prefix.
+    const route = path.slice(basePath.length) + url.search + url.hash;
+
+    // A link to the exact page we are on, anchor and all, has nowhere to go.
+    // Letting the browser handle it keeps same-page anchor jumps working.
+    if (url.href === window.location.href) return;
+
+    e.preventDefault();
+
+    m.route.set(route || '/');
+  });
+}

--- a/framework/core/js/tests/unit/forum/utils/labelDiscussionLinks.test.ts
+++ b/framework/core/js/tests/unit/forum/utils/labelDiscussionLinks.test.ts
@@ -1,0 +1,155 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from '../../../../src/forum/app';
+import labelDiscussionLinks from '../../../../src/forum/utils/labelDiscussionLinks';
+
+/**
+ * The composer preview is rendered in the browser and never reaches the
+ * server, so the rule deciding which links become `#123` labels exists twice:
+ * once in PHP for saved posts, once here for the preview.
+ *
+ * These tests are the guard on the client half. They deliberately mirror
+ * `tests/integration/formatter/InternalLinksTest.php` case for case — if the
+ * two ever disagree, the preview lies about what the writer will get.
+ */
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+});
+
+const ORIGIN = 'http://localhost';
+
+function setForum(attributes: Record<string, unknown>) {
+  for (const [key, value] of Object.entries(attributes)) {
+    app.forum.data.attributes![key] = value as any;
+  }
+}
+
+beforeEach(() => {
+  setForum({ basePath: '', faviconUrl: null });
+});
+
+/**
+ * Render a link the way the JS formatter would — an anchor whose text is the
+ * address, which is what an autolinked bare URL produces.
+ */
+function preview(href: string, text: string = href): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = `<p><a href="${href}">${text}</a></p>`;
+
+  labelDiscussionLinks(el);
+
+  return el;
+}
+
+describe('labelDiscussionLinks', () => {
+  it('shows a discussion link as the discussion it points at', () => {
+    const el = preview(`${ORIGIN}/d/123-the-slug`);
+
+    expect(el.querySelector('.UrlLink-discussion')?.textContent).toBe('#123');
+    expect(el.textContent).not.toContain('the-slug');
+  });
+
+  it('keeps the address in the href so the link still works', () => {
+    const el = preview(`${ORIGIN}/d/123-the-slug`);
+
+    expect(el.querySelector('a')?.getAttribute('href')).toBe(`${ORIGIN}/d/123-the-slug`);
+  });
+
+  it('says which post when the link points at one', () => {
+    const el = preview(`${ORIGIN}/d/123-the-slug/4`);
+
+    expect(el.querySelector('.UrlLink-discussion')?.textContent).toBe('#123');
+    expect(el.querySelector('.UrlLink-post')?.textContent).toBe('4');
+  });
+
+  it('shows no post number for a link to the discussion itself', () => {
+    expect(preview(`${ORIGIN}/d/123-the-slug`).querySelector('.UrlLink-post')).toBeNull();
+  });
+
+  it('works for a discussion with no slug', () => {
+    expect(preview(`${ORIGIN}/d/123`).querySelector('.UrlLink-discussion')?.textContent).toBe('#123');
+  });
+
+  it('carries the favicon when the forum has one', () => {
+    setForum({ faviconUrl: 'http://localhost/assets/favicon-abc.png' });
+
+    const favicon = preview(`${ORIGIN}/d/123`).querySelector('img.UrlLink-favicon');
+
+    expect(favicon?.getAttribute('src')).toBe('http://localhost/assets/favicon-abc.png');
+    // Decorative: the label beside it already says where the link goes.
+    expect(favicon?.getAttribute('alt')).toBe('');
+    expect(favicon?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('leaves no broken image when the forum has no favicon', () => {
+    const el = preview(`${ORIGIN}/d/123`);
+
+    expect(el.querySelector('img')).toBeNull();
+    expect(el.querySelector('.UrlLink-discussion')?.textContent).toBe('#123');
+  });
+
+  it('leaves a link alone when the writer chose their own words', () => {
+    // `[click here](url)` is the writer's text, and replacing it would
+    // overwrite what they wrote.
+    const el = preview(`${ORIGIN}/d/123-the-slug`, 'click here');
+
+    expect(el.textContent).toBe('click here');
+    expect(el.querySelector('.UrlLink-discussion')).toBeNull();
+  });
+
+  it('leaves links to other sites alone', () => {
+    const el = preview('https://example.com/d/123');
+
+    expect(el.querySelector('.UrlLink-discussion')).toBeNull();
+    expect(el.querySelector('a')?.classList.contains('UrlLink--internal')).toBe(false);
+  });
+
+  it('does not treat a host that merely starts the same as ours', () => {
+    // localhost.evil.com is not localhost, and a prefix match would let an
+    // attacker dress their link up as one of the forum's own.
+    expect(preview('http://localhost.evil.com/d/123').querySelector('.UrlLink-discussion')).toBeNull();
+  });
+
+  it('leaves internal links that are not discussions alone', () => {
+    const el = preview(`${ORIGIN}/u/ianm`);
+
+    expect(el.querySelector('.UrlLink-discussion')).toBeNull();
+    expect(el.textContent).toBe(`${ORIGIN}/u/ianm`);
+  });
+
+  it('leaves a position it cannot label as a plain address', () => {
+    // `near-something` is a position, not a post number, and claiming it as
+    // one would show a number that was never there.
+    const el = preview(`${ORIGIN}/d/123-the-slug/near-something`);
+
+    expect(el.querySelector('.UrlLink-discussion')).toBeNull();
+  });
+
+  it('labels discussions when the forum runs under a base path', () => {
+    setForum({ basePath: '/forum' });
+
+    expect(preview(`${ORIGIN}/forum/d/123-the-slug/4`).querySelector('.UrlLink-discussion')?.textContent).toBe('#123');
+  });
+
+  it('does not claim a path that merely starts like the base path', () => {
+    // A forum at /forum does not own /forums.
+    setForum({ basePath: '/forum' });
+
+    expect(preview(`${ORIGIN}/forums/d/123`).querySelector('.UrlLink-discussion')).toBeNull();
+  });
+
+  it('can be run twice without doubling the label', () => {
+    // The preview re-renders as the writer types, so this must not compound
+    // its own output.
+    const el = document.createElement('div');
+    el.innerHTML = `<p><a href="${ORIGIN}/d/123-the-slug/4">${ORIGIN}/d/123-the-slug/4</a></p>`;
+
+    labelDiscussionLinks(el);
+    const once = el.innerHTML;
+
+    labelDiscussionLinks(el);
+
+    expect(el.innerHTML).toBe(once);
+    expect(el.querySelectorAll('.UrlLink-discussion')).toHaveLength(1);
+  });
+});

--- a/framework/core/less/common/UrlLink.less
+++ b/framework/core/less/common/UrlLink.less
@@ -1,0 +1,74 @@
+// A link to a discussion on this forum, shown as the discussion it points at
+// rather than as the address that was pasted.
+//
+// It reads as one object — icon, number, and post number together — so it is
+// laid out as a unit rather than as a run of separate words.
+.UrlLink--discussion {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 0 6px;
+  border-radius: var(--border-radius);
+  background: var(--control-bg);
+  color: var(--control-color);
+  // Keeps the pieces on one line, so a label never wraps with the favicon
+  // stranded at the end of a line.
+  white-space: nowrap;
+
+  // A post body underlines links in running text, and puts that underline on
+  // `.Post-body a` — matched here at equal specificity so the label opts out
+  // without needing `!important`.
+  .Post-body &,
+  .Post-preview & {
+    border-bottom: 0;
+    font-weight: normal;
+  }
+
+  &:hover,
+  &:focus {
+    color: var(--link-color);
+
+    .UrlLink-discussion {
+      text-decoration: underline;
+    }
+  }
+}
+
+.UrlLink-favicon {
+  // Matched to the text beside it rather than the image's own size, which is
+  // whatever was uploaded — often 128px or larger.
+  width: 1em;
+  height: 1em;
+  // The upload may be any aspect ratio; this stops an oblong one stretching.
+  object-fit: contain;
+  border-radius: 2px;
+  flex-shrink: 0;
+  // `align-items: baseline` would sit the image on the text baseline and push
+  // the line taller; nudging it back keeps the label's line-height intact.
+  align-self: center;
+}
+
+.UrlLink-discussion {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+// The reply this link points at, when it names one.
+.UrlLink-post {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--muted-color);
+  font-variant-numeric: tabular-nums;
+  font-size: 90%;
+
+  // Set apart from the discussion number, so `#411` and the reply number do
+  // not read as one long run of digits.
+  padding-left: 5px;
+  border-left: 1px solid var(--control-color);
+}
+
+.UrlLink-postIcon {
+  font-size: 90%;
+  opacity: 0.8;
+}

--- a/framework/core/less/common/common.less
+++ b/framework/core/less/common/common.less
@@ -35,5 +35,6 @@
 @import "TextEditor";
 @import "ThemeMode";
 @import "Tooltip";
+@import "UrlLink";
 @import "UserSelectionModal";
 @import "ValidationError";

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -9,8 +9,12 @@
 
 namespace Flarum\Formatter;
 
+use Flarum\Foundation\Config;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Factory;
 use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Configurator;
 use s9e\TextFormatter\Parser;
@@ -25,9 +29,30 @@ class Formatter
     protected array $unparsingCallbacks = [];
     protected array $renderingCallbacks = [];
 
+    /**
+     * The forum's own host and base path, worked out once per request.
+     *
+     * @var array{host: string, path: string}|null
+     */
+    protected ?array $forumOrigin = null;
+
+    /**
+     * The forum's favicon URL, or null if there isn't one.
+     *
+     * `false` means "not looked up yet", since null is a real answer here.
+     */
+    protected string|false|null $faviconUrl = false;
+
+    /**
+     * `$config` is optional because extensions subclass this and call
+     * `parent::__construct()` with the two arguments that existed before it
+     * was added. When it is absent the forum's address is resolved from the
+     * container instead, so those subclasses keep working untouched.
+     */
     public function __construct(
         protected Repository $cache,
-        protected string $cacheDir
+        protected string $cacheDir,
+        protected ?Config $config = null
     ) {
     }
 
@@ -144,6 +169,15 @@ class Formatter
         return $configurator;
     }
 
+    /**
+     * Let the link template carry attributes decided when a post is rendered.
+     *
+     * Whether a link points back at this forum is not known when the post is
+     * written — the forum may since have moved — so `rel`, `target` and `class`
+     * are worked out at render time and copied through here. A theme that
+     * replaces this template needs to copy them too, or links lose the
+     * treatment.
+     */
     protected function configureExternalLinks(Configurator $configurator): void
     {
         /**
@@ -153,11 +187,75 @@ class Formatter
 
         foreach ($dom->getElementsByTagName('a') as $a) {
             /** @var \s9e\SweetDOM\Element $a */
+            $a->prependXslCopyOf('@class');
             $a->prependXslCopyOf('@target');
             $a->prependXslCopyOf('@rel');
         }
 
         $dom->saveChanges();
+
+        $this->configureDiscussionLinks($configurator);
+    }
+
+    /**
+     * Show a link to a discussion as the discussion it points at.
+     *
+     * A pasted address says nothing useful in the middle of a sentence, so
+     * where the writer pasted one bare — leaving the address as the link's own
+     * text — it is shown as `#123` instead, with the post number alongside it
+     * when the link points at a particular reply.
+     *
+     * When the writer chose their own words for the link, those words are what
+     * appears; the label replaces an address, never a sentence.
+     */
+    protected function configureDiscussionLinks(Configurator $configurator): void
+    {
+        $tag = $configurator->tags['URL'];
+
+        // Only set when the URL turned out to be a discussion on this forum,
+        // which is decided per render rather than when the post was written.
+        $tag->attributes->add('discussionid')->required = false;
+        $tag->attributes->add('postnumber')->required = false;
+        $tag->attributes->add('faviconurl')->required = false;
+
+        $template = (string) $tag->template;
+
+        // The label stands in for the address only when the link's text *is*
+        // the address. `[click here](...)` and `<url>` both leave other text
+        // in place, and that text is the writer's, so it stays.
+        $tag->template =
+            '<xsl:choose>'
+                .'<xsl:when test="@discussionid and string(.) = @url">'
+                .$this->getDiscussionLinkTemplate()
+                .'</xsl:when>'
+                .'<xsl:otherwise>'.$template.'</xsl:otherwise>'
+            .'</xsl:choose>';
+    }
+
+    /**
+     * The markup for a discussion link that is showing its label.
+     */
+    protected function getDiscussionLinkTemplate(): string
+    {
+        return '<a href="{@url}">'
+            .'<xsl:copy-of select="@rel"/><xsl:copy-of select="@target"/>'
+            // The label is a different thing from a bare link, so it says so
+            // rather than inheriting link styling meant for running text.
+            .'<xsl:attribute name="class"><xsl:value-of select="@class"/> UrlLink--discussion</xsl:attribute>'
+            .'<xsl:if test="@faviconurl">'
+                // Decorative: the text beside it already says where the link
+                // goes, so a screen reader announcing the icon as well would
+                // only repeat it.
+                .'<img src="{@faviconurl}" class="UrlLink-favicon" alt="" aria-hidden="true"/>'
+            .'</xsl:if>'
+            .'<span class="UrlLink-discussion">#<xsl:value-of select="@discussionid"/></span>'
+            .'<xsl:if test="@postnumber">'
+                .'<span class="UrlLink-post">'
+                    .'<i class="icon fas fa-comment UrlLink-postIcon" aria-hidden="true"></i>'
+                    .'<xsl:value-of select="@postnumber"/>'
+                .'</span>'
+            .'</xsl:if>'
+            .'</a>';
     }
 
     /**
@@ -200,13 +298,177 @@ class Formatter
         return $this->getComponent('js');
     }
 
+    /**
+     * Decide how each link in a post should be treated, based on where it goes.
+     *
+     * Only fills in what has not already been set, so an extension rendering
+     * callback — which runs before this — keeps the last word on any link.
+     */
     protected function configureDefaultsOnLinks(string $xml): string
     {
         return Utils::replaceAttributes($xml, 'URL', function ($attributes) {
-            $attributes['rel'] ??= 'ugc nofollow';
+            // The stored XML names this `url`; `href` only exists once the
+            // template has rendered, which has not happened yet.
+            if ($this->isInternalUrl($url = ($attributes['url'] ?? ''))) {
+                // Our own content. `noopener` still applies — trusting where a
+                // link goes says nothing about handing over the opener window
+                // — but `nofollow` and `ugc` would tell search engines to
+                // ignore a forum linking to itself.
+                $attributes['rel'] ??= 'noopener';
+                $attributes['target'] ??= '_self';
+                $attributes['class'] = trim(($attributes['class'] ?? '').' UrlLink UrlLink--internal');
+
+                if ($discussion = $this->parseDiscussionUrl($url)) {
+                    // The template shows these instead of the address when they
+                    // are present. Set as attributes rather than by rewriting
+                    // the link's text, so that a theme can lay the pieces out
+                    // however it likes.
+                    $attributes['discussionid'] = $discussion['id'];
+
+                    if ($discussion['near'] !== null) {
+                        $attributes['postnumber'] = $discussion['near'];
+                    }
+
+                    if ($favicon = $this->getFaviconUrl()) {
+                        $attributes['faviconurl'] = $favicon;
+                    }
+                }
+            } else {
+                $attributes['rel'] ??= 'ugc nofollow';
+            }
 
             return $attributes;
         });
+    }
+
+    /**
+     * Pick out the discussion a URL points at, if it points at one.
+     *
+     * Matches the shape the discussion route declares: an id, optionally
+     * followed by a slug that carries no meaning here, and optionally a post
+     * number after it.
+     *
+     * @return array{id: string, near: string|null}|null
+     */
+    protected function parseDiscussionUrl(string $url): ?array
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (! is_string($path)) {
+            return null;
+        }
+
+        $base = $this->getForumOrigin()['path'];
+
+        if ($base !== '') {
+            $path = substr($path, strlen($base));
+        }
+
+        if (! preg_match('~^/d/(\d+)(?:-[^/]*)?(?:/([^/]*))?/?$~', $path, $matches)) {
+            return null;
+        }
+
+        // `/d/1/near-something` and other non-numeric fragments are positions
+        // this cannot label, so the link keeps its address rather than
+        // claiming a post number it did not find.
+        $near = ($matches[2] ?? '') !== '' ? $matches[2] : null;
+
+        if ($near !== null && ! ctype_digit($near)) {
+            return null;
+        }
+
+        return ['id' => $matches[1], 'near' => $near];
+    }
+
+    /**
+     * The forum's favicon, if one has been uploaded.
+     *
+     * Looked up once per request for the same reason as the forum's address:
+     * this is consulted for every discussion link on the page.
+     */
+    protected function getFaviconUrl(): ?string
+    {
+        if ($this->faviconUrl === false) {
+            $path = resolve(SettingsRepositoryInterface::class)->get('favicon_path');
+
+            // Resolved through the assets filesystem rather than assembled by
+            // hand, so a forum serving its uploads from a CDN gets the CDN
+            // address here too.
+            if ($path) {
+                /** @var Cloud $assets */
+                $assets = resolve(Factory::class)->disk('flarum-assets');
+
+                $this->faviconUrl = $assets->url($path);
+            } else {
+                $this->faviconUrl = null;
+            }
+        }
+
+        return $this->faviconUrl;
+    }
+
+    /**
+     * The forum's host and base path.
+     *
+     * `Config::url()` builds a fresh Uri on every call, and this is consulted
+     * once per link in every post on the page, so the answer is kept rather
+     * than rebuilt. It cannot change within a request.
+     *
+     * @return array{host: string, path: string}
+     */
+    protected function getForumOrigin(): array
+    {
+        if ($this->forumOrigin === null) {
+            $config = $this->config ?? resolve(Config::class);
+            $url = $config->url();
+
+            $this->forumOrigin = [
+                'host' => $url->getHost(),
+                'path' => rtrim($url->getPath(), '/'),
+            ];
+        }
+
+        return $this->forumOrigin;
+    }
+
+    /**
+     * Does this URL point back at the forum itself?
+     *
+     * Host and path both have to match: a forum installed at example.com/forum
+     * does not own example.com/shop. The scheme is ignored, since a forum
+     * reachable over both http and https is still one forum, and a link is not
+     * a different destination for having been copied before the certificate
+     * was installed.
+     */
+    protected function isInternalUrl(string $url): bool
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        // Anything without a host is a relative link, a mailto:, or malformed.
+        // A relative link already stays on the forum without any help from us,
+        // and the rest are not ours to claim.
+        if (! is_string($host) || $host === '') {
+            return false;
+        }
+
+        $forum = $this->getForumOrigin();
+
+        if (strcasecmp($host, $forum['host']) !== 0) {
+            return false;
+        }
+
+        $base = $forum['path'];
+
+        if ($base === '') {
+            return true;
+        }
+
+        $path = parse_url($url, PHP_URL_PATH) ?: '/';
+
+        // `/forum` and `/forum/d/1` are inside the install; `/forums` is not,
+        // so the base has to be followed by a boundary rather than just
+        // appearing at the start.
+        return $path === $base || str_starts_with($path, $base.'/');
     }
 
     /**

--- a/framework/core/src/Formatter/FormatterServiceProvider.php
+++ b/framework/core/src/Formatter/FormatterServiceProvider.php
@@ -10,9 +10,9 @@
 namespace Flarum\Formatter;
 
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Config;
 use Flarum\Foundation\Paths;
 use Illuminate\Cache\Repository;
-use Flarum\Foundation\Config;
 use Illuminate\Contracts\Container\Container;
 
 class FormatterServiceProvider extends AbstractServiceProvider

--- a/framework/core/src/Formatter/FormatterServiceProvider.php
+++ b/framework/core/src/Formatter/FormatterServiceProvider.php
@@ -12,6 +12,7 @@ namespace Flarum\Formatter;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Paths;
 use Illuminate\Cache\Repository;
+use Flarum\Foundation\Config;
 use Illuminate\Contracts\Container\Container;
 
 class FormatterServiceProvider extends AbstractServiceProvider
@@ -21,7 +22,8 @@ class FormatterServiceProvider extends AbstractServiceProvider
         $this->container->singleton('flarum.formatter', function (Container $container) {
             return new Formatter(
                 new Repository($container->make('cache.filestore')),
-                $container[Paths::class]->storage.'/formatter'
+                $container[Paths::class]->storage.'/formatter',
+                $container->make(Config::class)
             );
         });
 

--- a/framework/core/tests/integration/formatter/InternalLinksTest.php
+++ b/framework/core/tests/integration/formatter/InternalLinksTest.php
@@ -224,10 +224,7 @@ class InternalLinksTest extends TestCase
         // one of those extensions fatals on construction.
         $container = $this->app()->getContainer();
 
-        $formatter = new class(
-            new \Illuminate\Cache\Repository($container->make('cache.filestore')),
-            $container->make(\Flarum\Foundation\Paths::class)->storage.'/formatter'
-        ) extends Formatter {
+        $formatter = new class(new \Illuminate\Cache\Repository($container->make('cache.filestore')), $container->make(\Flarum\Foundation\Paths::class)->storage.'/formatter') extends Formatter {
         };
 
         $this->assertStringContainsString(

--- a/framework/core/tests/integration/formatter/InternalLinksTest.php
+++ b/framework/core/tests/integration/formatter/InternalLinksTest.php
@@ -1,0 +1,257 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\formatter;
+
+use Flarum\Formatter\Formatter;
+use Flarum\Testing\integration\RefreshesFormatterCache;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Links back to the forum itself are not the same as links off it.
+ *
+ * A link somewhere else is untrusted: it gets `ugc` and `nofollow` so that a
+ * forum cannot be used to pass ranking signals to whatever someone pastes. A
+ * link to another discussion on the same forum is the forum's own content, and
+ * telling search engines to ignore it means a discussion linked from another
+ * discussion counts for nothing.
+ *
+ * The distinction is made when the post is rendered rather than when it is
+ * written, so that posts written before this existed behave the same way, and
+ * so that moving a forum to a new address does not leave its old posts full of
+ * links it no longer recognises as its own.
+ */
+class InternalLinksTest extends TestCase
+{
+    use RefreshesFormatterCache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The address the forum believes it lives at, which is what every link
+        // is measured against.
+        $this->config('url', 'http://flarum.localhost');
+    }
+
+    protected function render(string $text): string
+    {
+        $formatter = $this->app()->getContainer()->make(Formatter::class);
+
+        return $formatter->render($formatter->parse($text));
+    }
+
+    #[Test]
+    public function a_link_to_another_site_is_not_followed()
+    {
+        $html = $this->render('https://example.com/some-page');
+
+        $this->assertStringContainsString('nofollow', $html);
+        $this->assertStringContainsString('ugc', $html);
+    }
+
+    #[Test]
+    public function a_link_back_to_the_forum_is_followed()
+    {
+        $html = $this->render('http://flarum.localhost/d/1-a-discussion');
+
+        $this->assertStringNotContainsString('nofollow', $html);
+        $this->assertStringNotContainsString('ugc', $html);
+    }
+
+    #[Test]
+    public function a_link_back_to_the_forum_still_says_noopener()
+    {
+        // Nothing about trusting our own content makes it safe to hand the
+        // opener window to whatever the link opens.
+        $this->assertStringContainsString('noopener', $this->render('http://flarum.localhost/d/1'));
+    }
+
+    #[Test]
+    public function a_link_back_to_the_forum_opens_in_the_same_tab()
+    {
+        $this->assertStringContainsString('target="_self"', $this->render('http://flarum.localhost/d/1'));
+    }
+
+    #[Test]
+    public function a_link_back_to_the_forum_is_marked_for_the_frontend()
+    {
+        // The marker is what lets the forum route to the link rather than
+        // reloading the whole page to reach its own content.
+        $this->assertStringContainsString('UrlLink--internal', $this->render('http://flarum.localhost/d/1'));
+    }
+
+    #[Test]
+    public function a_link_to_another_site_is_not_marked_as_internal()
+    {
+        $this->assertStringNotContainsString('UrlLink--internal', $this->render('https://example.com'));
+    }
+
+    #[Test]
+    public function a_different_host_that_merely_starts_the_same_is_not_ours()
+    {
+        // flarum.localhost.evil.com is not flarum.localhost, and a prefix match
+        // would hand an attacker a followed link.
+        $html = $this->render('http://flarum.localhost.evil.com/d/1');
+
+        $this->assertStringContainsString('nofollow', $html);
+        $this->assertStringNotContainsString('UrlLink--internal', $html);
+    }
+
+    #[Test]
+    public function a_link_over_a_different_scheme_is_still_ours()
+    {
+        // A forum served over https that someone linked with http is the same
+        // forum; the address bar simply disagrees with the config.
+        $html = $this->render('https://flarum.localhost/d/1');
+
+        $this->assertStringNotContainsString('nofollow', $html);
+        $this->assertStringContainsString('UrlLink--internal', $html);
+    }
+
+    #[Test]
+    public function a_subdomain_is_not_the_forum()
+    {
+        $html = $this->render('http://blog.flarum.localhost/d/1');
+
+        $this->assertStringContainsString('nofollow', $html);
+        $this->assertStringNotContainsString('UrlLink--internal', $html);
+    }
+
+    #[Test]
+    public function a_discussion_link_is_shown_as_the_discussion_it_points_at()
+    {
+        // A pasted address is unreadable in a sentence. What the reader cares
+        // about is which discussion it is, so the link says that instead.
+        $html = $this->render('http://flarum.localhost/d/123-the-slug');
+
+        $this->assertStringContainsString('#123', $html);
+
+        // The slug stays in the address — the link still has to work — but is
+        // no longer part of what the reader sees.
+        $this->assertStringContainsString('href="http://flarum.localhost/d/123-the-slug"', $html);
+        $this->assertStringNotContainsString('>http://flarum.localhost/d/123-the-slug<', $html);
+    }
+
+    #[Test]
+    public function a_link_to_a_post_says_which_post()
+    {
+        $html = $this->render('http://flarum.localhost/d/123-the-slug/4');
+
+        $this->assertStringContainsString('#123', $html);
+        $this->assertStringContainsString('>4<', $html);
+    }
+
+    #[Test]
+    public function a_discussion_link_carries_the_forums_favicon()
+    {
+        $this->setting('favicon_path', 'favicon-abc.png');
+
+        $this->assertStringContainsString('favicon-abc.png', $this->render('http://flarum.localhost/d/123-the-slug'));
+    }
+
+    #[Test]
+    public function a_discussion_link_without_a_favicon_still_reads_properly()
+    {
+        // Most forums never upload one. The label is the point; the icon is
+        // decoration, and its absence must not leave a broken image behind.
+        $html = $this->render('http://flarum.localhost/d/123-the-slug');
+
+        $this->assertStringContainsString('#123', $html);
+        $this->assertStringNotContainsString('<img', $html);
+    }
+
+    #[Test]
+    public function an_internal_link_that_is_not_a_discussion_is_left_as_it_was()
+    {
+        // Only discussion links have a #123 to show. A link to a user page or
+        // the tag index keeps its address as the visible text.
+        $html = $this->render('http://flarum.localhost/u/ianm');
+
+        $this->assertStringContainsString('http://flarum.localhost/u/ianm', $html);
+        $this->assertStringContainsString('UrlLink--internal', $html);
+    }
+
+    #[Test]
+    public function a_discussion_link_the_writer_gave_their_own_words_keeps_them()
+    {
+        // `[click here](url)` is the writer choosing the text. Replacing it
+        // with #123 would overwrite what they wrote.
+        $this->extension('flarum-markdown');
+
+        $html = $this->render('[click here](http://flarum.localhost/d/123-the-slug)');
+
+        $this->assertStringContainsString('click here', $html);
+        $this->assertStringNotContainsString('#123', $html);
+    }
+
+    #[Test]
+    public function a_bare_discussion_link_is_labelled_with_markdown_enabled_too()
+    {
+        // The label comes from the rendered XML rather than from how the link
+        // was written, so enabling Markdown must not change the outcome.
+        $this->extension('flarum-markdown');
+
+        $html = $this->render('http://flarum.localhost/d/123-the-slug/4');
+
+        $this->assertStringContainsString('#123', $html);
+        $this->assertStringContainsString('>4<', $html);
+    }
+
+    #[Test]
+    public function a_markdown_autolink_is_labelled()
+    {
+        // `<url>` is Markdown's own way of writing a bare link — the writer
+        // supplied no text of their own, so the label applies.
+        $this->extension('flarum-markdown');
+
+        $this->assertStringContainsString('#123', $this->render('<http://flarum.localhost/d/123-the-slug>'));
+    }
+
+    #[Test]
+    public function a_subclass_built_the_old_way_still_works()
+    {
+        // Extensions subclass Formatter and call parent::__construct() with the
+        // two arguments it used to take — fof/user-bio does exactly this. The
+        // forum's address has to be reachable without being handed in, or every
+        // one of those extensions fatals on construction.
+        $container = $this->app()->getContainer();
+
+        $formatter = new class(
+            new \Illuminate\Cache\Repository($container->make('cache.filestore')),
+            $container->make(\Flarum\Foundation\Paths::class)->storage.'/formatter'
+        ) extends Formatter {
+        };
+
+        $this->assertStringContainsString(
+            'UrlLink--internal',
+            $formatter->render($formatter->parse('http://flarum.localhost/d/1'))
+        );
+    }
+
+    #[Test]
+    public function a_rel_set_by_an_extension_is_left_alone()
+    {
+        // `configureDefaultsOnLinks` fills in what is missing rather than
+        // overriding, and that has to stay true for internal links too.
+        $this->extend(
+            (new \Flarum\Extend\Formatter())
+                ->render(function ($renderer, $context, string $xml) {
+                    return \s9e\TextFormatter\Utils::replaceAttributes($xml, 'URL', function (array $attributes) {
+                        $attributes['rel'] = 'author';
+
+                        return $attributes;
+                    });
+                })
+        );
+
+        $this->assertStringContainsString('rel="author"', $this->render('http://flarum.localhost/d/1'));
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

<!-- No existing issue; this came out of noticing the behaviour on a live forum. -->

**Changes proposed in this pull request:**

Paste a discussion link from the address bar into a post and Flarum treats it as if it led to some other website. It gets `rel="ugc nofollow"`, so the forum tells search engines to ignore its own internal linking, and clicking it does a full page reload to reach a route the app could already render itself.

This compares each link against the forum's own address while the post is being rendered. Links back to the forum are followed, open in the same tab, and get a class the frontend uses to route to them instead of reloading. External links are unchanged — they keep `ugc nofollow`.

If such a link points at a discussion and the writer just pasted the URL, it renders as the discussion instead of the raw address:

- `https://example.com/d/123-the-slug` → [favicon] **#123**
- `https://example.com/d/123-the-slug/4` → [favicon] **#123** │ 💬 4

The favicon is the forum's own, from `favicon_path`, resolved through the assets filesystem so a CDN-hosted one works. No favicon uploaded means no image, just the label.

This happens at render time rather than parse time, so existing posts pick it up with no reprocessing, and changing the forum's URL re-evaluates every link. If the writer wrote their own link text (`[click here](...)`), that text is kept — the label only ever replaces a bare address.

The composer preview is rendered in the browser by the JS TextFormatter and never hits the server, so `labelDiscussionLinks.ts` applies the same rule to the preview's output. Otherwise the preview shows a bare URL and the saved post shows a label.

Impacted: `Formatter`, the URL tag template, post bodies and the composer preview.

**Reviewers should focus on:**

- **The duplicated rule.** The label logic exists in PHP (saved posts) and TypeScript (composer preview). They have to agree or the preview misleads the writer. I've tested each independently against the same cases but there's no test asserting they match each other.
- **`Formatter::__construct()` gained a third parameter.** It's optional on purpose: extensions subclass `Formatter` and call `parent::__construct()` with the original two args (`fof/user-bio` does), and a required param fataled them. I hit this on a live forum. There's a test that constructs a two-arg subclass to keep it that way.
- **Whether the trigger condition is right.** The label applies when the link's text *is* its href. With Markdown off, `[click here](url)` autolinks only the URL part, so it labels — I think that's correct since the bracketed text isn't link text there, but worth a second opinion.
- **`configureExternalLinks()` now also copies `@class`** through the URL template alongside `@target`/`@rel`. A theme replacing that template needs all three.
- **Performance**, since `render()` runs for every post on every page. Measured over 20 posts / 80 links, new vs. old: 0.728ms vs 0.661ms (~67µs/page). `Config::url()` builds a fresh `Uri` per call, so host/path and the favicon are resolved once per request.

**Screenshot**

<img width="912" alt="Discussion links rendered as #411 with favicon, and #411 with post number 15" src="https://github.com/user-attachments/assets/PLACEHOLDER" />

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

19 backend integration tests (`InternalLinksTest`) and 15 frontend unit tests (`labelDiscussionLinks.test.ts`), covering both URL formats, favicon present/absent, prefix-spoofing (`flarum.localhost.evil.com`), base paths, and with/without `flarum/markdown`.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
