### PR TITLE
[2.x] fix: treat relative links as the forum's own

### DIFF
--- a/framework/core/js/tests/unit/forum/utils/labelDiscussionLinks.test.ts
+++ b/framework/core/js/tests/unit/forum/utils/labelDiscussionLinks.test.ts
@@ -138,6 +138,38 @@ describe('labelDiscussionLinks', () => {
     expect(preview(`${ORIGIN}/forums/d/123`).querySelector('.UrlLink-discussion')).toBeNull();
   });
 
+  it('labels a relative discussion link', () => {
+    // `[text](/d/123)` is how people link within a forum most of the time, and
+    // the browser resolves it against the page it is read on — which is this
+    // forum.
+    const el = document.createElement('div');
+    el.innerHTML = '<p><a href="/d/123-the-slug">/d/123-the-slug</a></p>';
+
+    labelDiscussionLinks(el);
+
+    expect(el.querySelector('.UrlLink-discussion')?.textContent).toBe('#123');
+  });
+
+  it('labels a relative link to a post', () => {
+    const el = document.createElement('div');
+    el.innerHTML = '<p><a href="/d/123-the-slug/4">/d/123-the-slug/4</a></p>';
+
+    labelDiscussionLinks(el);
+
+    expect(el.querySelector('.UrlLink-post')?.textContent).toBe('4');
+  });
+
+  it('does not treat a protocol-relative link as ours', () => {
+    // `//evil.com/d/1` has no scheme but is absolute, and must not be read as
+    // a path on this forum.
+    const el = document.createElement('div');
+    el.innerHTML = '<p><a href="//evil.com/d/1">//evil.com/d/1</a></p>';
+
+    labelDiscussionLinks(el);
+
+    expect(el.querySelector('.UrlLink-discussion')).toBeNull();
+  });
+
   it('can be run twice without doubling the label', () => {
     // The preview re-renders as the writer types, so this must not compound
     // its own output.

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -368,9 +368,9 @@ class Formatter
             return null;
         }
 
-        // `/d/1/near-something` and other non-numeric fragments are positions
-        // this cannot label, so the link keeps its address rather than
-        // claiming a post number it did not find.
+        // `/d/1/near-something` and other non-numeric positions cannot be
+        // labelled, so the link keeps its address rather than claiming a post
+        // number it did not find.
         $near = ($matches[2] ?? '') !== '' ? $matches[2] : null;
 
         if ($near !== null && ! ctype_digit($near)) {
@@ -442,22 +442,33 @@ class Formatter
      */
     protected function isInternalUrl(string $url): bool
     {
+        // A scheme with no host — `mailto:`, `tel:`, `data:` — does not address
+        // a place on this or any other site.
+        if (preg_match('~^[a-z][a-z0-9+.-]*:~i', $url) && ! preg_match('~^https?://~i', $url)) {
+            return false;
+        }
+
+        // `//evil.com/x` has no scheme but is absolute, and would otherwise be
+        // read as the path `//evil.com/x` on this forum.
+        if (str_starts_with($url, '//')) {
+            return false;
+        }
+
         $host = parse_url($url, PHP_URL_HOST);
 
-        // Anything without a host is a relative link, a mailto:, or malformed.
-        // A relative link already stays on the forum without any help from us,
-        // and the rest are not ours to claim.
-        if (! is_string($host) || $host === '') {
+        if (is_string($host) && $host !== '') {
+            if (strcasecmp($host, $this->getForumOrigin()['host']) !== 0) {
+                return false;
+            }
+        } elseif (! str_starts_with($url, '/')) {
+            // A path-relative link like `d/1` resolves against whatever page it
+            // happens to be read on, which is not knowable while rendering.
             return false;
         }
 
-        $forum = $this->getForumOrigin();
-
-        if (strcasecmp($host, $forum['host']) !== 0) {
-            return false;
-        }
-
-        $base = $forum['path'];
+        // Either it named this forum's host, or it is a root-relative path on
+        // whatever host the reader is using — which is this forum.
+        $base = $this->getForumOrigin()['path'];
 
         if ($base === '') {
             return true;

--- a/framework/core/tests/integration/formatter/InternalLinksTest.php
+++ b/framework/core/tests/integration/formatter/InternalLinksTest.php
@@ -126,6 +126,63 @@ class InternalLinksTest extends TestCase
     }
 
     #[Test]
+    public function a_relative_link_is_ours()
+    {
+        // `[text](/d/123)` is how people link within a forum most of the time.
+        // Treating it as external told search engines not to follow a forum's
+        // own links — the very thing this is meant to stop.
+        $this->extension('flarum-markdown');
+
+        $html = $this->render('[FriendsOfFlarum OAuth](/d/25182)');
+
+        $this->assertStringNotContainsString('nofollow', $html);
+        $this->assertStringContainsString('UrlLink--internal', $html);
+    }
+
+    #[Test]
+    public function a_relative_link_outside_the_discussion_routes_is_still_ours()
+    {
+        $this->extension('flarum-markdown');
+
+        $this->assertStringNotContainsString('nofollow', $this->render('[settings](/settings)'));
+    }
+
+    #[Test]
+    public function a_protocol_relative_link_is_not_ours()
+    {
+        // `//evil.com/d/1` has no scheme but is absolute. Read as a path it
+        // would look like this forum's own, which is how you would smuggle a
+        // followed link past this.
+        $this->extension('flarum-markdown');
+
+        $html = $this->render('[evil](//evil.com/d/1)');
+
+        $this->assertStringContainsString('nofollow', $html);
+        $this->assertStringNotContainsString('UrlLink--internal', $html);
+    }
+
+    #[Test]
+    public function a_path_relative_link_is_left_alone()
+    {
+        // `d/1` resolves against whichever page it is read on, and a post can
+        // be read from more than one place, so where it leads is not knowable
+        // while rendering.
+        $this->extension('flarum-markdown');
+
+        $this->assertStringContainsString('nofollow', $this->render('[rel](d/1)'));
+    }
+
+    #[Test]
+    public function a_mailto_link_is_not_claimed_as_ours()
+    {
+        $this->extension('flarum-markdown');
+
+        $html = $this->render('[mail](mailto:someone@example.com)');
+
+        $this->assertStringNotContainsString('UrlLink--internal', $html);
+    }
+
+    #[Test]
     public function a_discussion_link_is_shown_as_the_discussion_it_points_at()
     {
         // A pasted address is unreadable in a sentence. What the reader cares


### PR DESCRIPTION
**Follow-up to #4924**

**Changes proposed in this pull request:**

#4924 only recognised links that spelled out the forum's host. But `[FriendsOfFlarum OAuth](/d/25182)` is how people link within a forum most of the time, and it was still getting `rel="ugc nofollow"` — the forum telling search engines not to follow links to its own discussions, which is exactly what #4924 set out to stop.

A link with no host isn't a link somewhere else. Root-relative paths are now measured against the forum's base path like any other, so they're followed and open in the same tab.

Two neighbouring cases needed pinning down at the same time:

- `//evil.com/d/1` has no scheme but is absolute. Read as a path it would have looked like one of the forum's own, so it needed an explicit check — it stays external.
- `d/1` resolves against whichever page it's read on, and a post can be read from more than one place, so where it leads isn't knowable at render time. Left alone.

`mailto:`, `tel:` and other schemes without a host are excluded explicitly rather than falling out of the host check by accident.

The JS half (composer preview) already handled relative links correctly, because it reads `link.href`, which the browser resolves for it. Added tests to pin that down rather than leave it to luck.

| Link | Before | After |
| --- | --- | --- |
| `/d/25182` | `ugc nofollow` | internal, followed |
| `/d/39189/4` | `ugc nofollow` | internal, followed |
| `/settings` | `ugc nofollow` | internal, followed |
| `//evil.com/d/1` | `ugc nofollow` | `ugc nofollow` |
| `d/1` | `ugc nofollow` | `ugc nofollow` |
| `mailto:a@b.com` | untouched | untouched |

Relative links keep the writer's own text — the `#123` label still only ever replaces a bare pasted address.

**Reviewers should focus on:**

- **The protocol-relative check.** `str_starts_with($url, '//')` is what stops `//evil.com/d/1` being read as a local path. Worth confirming that's the right guard and there isn't another absolute form that slips through.
- **Whether path-relative (`d/1`) should really be excluded.** I left it external because it can't be resolved at render time, but it does mean a genuinely internal link written that way keeps `nofollow`. I think correctness beats coverage here, but it's a judgement call.
- **The scheme regex** `~^[a-z][a-z0-9+.-]*:~i` — matches RFC 3986 scheme syntax, then re-admits `http`/`https`. Consider whether anything odd gets caught.

**Screenshot**

No visual change — this affects `rel`/`target` on links that already rendered normally.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

24 backend integration tests (`InternalLinksTest`, 6 new) and 18 frontend unit tests (`labelDiscussionLinks.test.ts`, 3 new). PHPStan clean.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
