### PR TITLE
[2.x] fix: register Input in the common export manifest

### DIFF
--- a/framework/core/js/src/common/common.ts
+++ b/framework/core/js/src/common/common.ts
@@ -69,6 +69,7 @@ import './components/LabelValue';
 import './components/Link';
 import './components/LinkButton';
 import './components/Checkbox';
+import './components/Input';
 import './components/ColorPreviewInput';
 import './components/SelectDropdown';
 import './components/ModalManager';


### PR DESCRIPTION
**Changes proposed in this pull request:**

`Input` is public extension API — documented attrs, shipped typings — but it was never listed in `common.ts`, the manifest that eagerly registers components with the export registry. It only reached the forum bundle incidentally, because `AbstractGlobalSearch` imported it statically.

#4909 replaced that `<Input>` with a plain button and dropped the import. That leaves the lazily-loaded `SearchModal` as the only forum-side importer, so webpack moved `Input` into the `SearchModal` chunk — in the built `forum.js` it now appears only as `addChunkModule`, never `reg.add`.

Extensions resolve core components synchronously via `reg.get()`, which returns `undefined` for a chunk-only module. So any extension rendering `flarum/common/components/Input` throws *"The selector must be either a string or a component"* on first render — `fof/ui-kit`'s `DiscussionSearch` is one, which breaks `fof/move-posts`. It recovers only once something else loads the search modal chunk.

Adding `Input` to `common.ts` restores the eager registration.

**Reviewers should focus on:**

Whether other public components are in the same position. Bundle membership is an emergent property of which modules core happens to import statically, so any refactor that removes core's last eager import silently demotes a public component to chunk-only — no build error, no type error, just `undefined` at runtime in downstream extensions. A test asserting the documented public surface is `reg.add`'d in the built bundles would catch the next one; happy to follow up with that separately if wanted.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [ ] Frontend changes: tests have been added, or are not appropriate here.
- [x] The description above is written by me and describes what this pull request actually does.
