### PR TITLE
[2.x] Harden the updater: authenticate it, and pause the queue while it runs

### DIFF
--- a/framework/core/src/Database/Console/MigrateCommand.php
+++ b/framework/core/src/Database/Console/MigrateCommand.php
@@ -14,11 +14,14 @@ use Flarum\Database\Migrator;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Application;
 use Flarum\Foundation\Paths;
+use Flarum\Queue\QueueFactory;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Builder;
+use Illuminate\Queue\Worker;
 use Symfony\Component\Console\Command\Command;
 
 class MigrateCommand extends AbstractCommand implements Isolatable
@@ -50,6 +53,65 @@ class MigrateCommand extends AbstractCommand implements Isolatable
 
     public function upgrade(): void
     {
+        // A migration reshapes the schema out from under any queue worker
+        // running at the same time. Pause the queue for the duration so no job
+        // runs against a half-changed database, and resume it the moment the
+        // migrations finish — even if they fail, since a queue left paused
+        // forever is its own outage.
+        //
+        // The pause is conditional: `migrate` is run routinely with nothing
+        // pending, and idling every worker for a no-op run would be a
+        // regression.
+        if ($this->hasPendingMigrations()) {
+            $this->pauseQueue();
+        }
+
+        try {
+            $this->runMigrations();
+        } finally {
+            // The resume is not conditional. The web updater arms a pause the
+            // moment it detects the version drift — before this command runs,
+            // and whether or not there turns out to be anything to migrate. If
+            // resume were gated on pending work too, a no-op run reached
+            // through the updater would leave that pause set forever. Resuming
+            // unconditionally clears whatever is set; on a queue that was never
+            // paused it is a harmless no-op.
+            $this->resumeQueue();
+        }
+    }
+
+    /**
+     * Pause every queue on the active connection for the duration of the
+     * migration.
+     *
+     * This mirrors what `queue:pause --all` does — including its refusal to
+     * act when pausing is disabled, since a flag no worker will read is only
+     * misleading state — but without a console Application to `call()` into,
+     * which Flarum's command base does not provide.
+     */
+    protected function pauseQueue(): void
+    {
+        if (! Worker::$pausable) {
+            return;
+        }
+
+        $this->container->make(QueueFactory::class)->pause($this->queueConnectionName(), '*');
+    }
+
+    protected function resumeQueue(): void
+    {
+        // Resume is not gated on Worker::$pausable: a flag set earlier must
+        // always be clearable, even if pausing was disabled since.
+        $this->container->make(QueueFactory::class)->resume($this->queueConnectionName(), '*');
+    }
+
+    private function queueConnectionName(): string
+    {
+        return $this->container->make(Queue::class)->getConnectionName();
+    }
+
+    protected function runMigrations(): void
+    {
         $this->container->bind(Builder::class, function ($container) {
             return $container->make(ConnectionInterface::class)->getSchemaBuilder();
         });
@@ -75,5 +137,48 @@ class MigrateCommand extends AbstractCommand implements Isolatable
         }
 
         $this->container->make(SettingsRepositoryInterface::class)->set('version', Application::VERSION);
+    }
+
+    /**
+     * Is there any migration — core or extension — that has not run yet?
+     *
+     * A read-only comparison of the migration files on disk against the ledger
+     * of what has run, with no side effects, so it is safe to ask before
+     * deciding whether the run is worth pausing the queue for.
+     */
+    protected function hasPendingMigrations(): bool
+    {
+        $migrator = $this->container->make(Migrator::class);
+
+        // Before the very first migration the ledger table does not exist yet.
+        // Nothing has run, so everything on disk is pending.
+        if (! $migrator->repositoryExists()) {
+            return true;
+        }
+
+        if ($this->pathHasPendingMigrations($migrator, __DIR__.'/../../../migrations')) {
+            return true;
+        }
+
+        $extensions = $this->container->make(ExtensionManager::class);
+
+        foreach ($extensions->getEnabledExtensions() as $extension) {
+            if (
+                $extension->hasMigrations()
+                && $this->pathHasPendingMigrations($migrator, $extension->getPath().'/migrations', $extension->getId())
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function pathHasPendingMigrations(Migrator $migrator, string $path, ?string $extensionId = null): bool
+    {
+        $files = $migrator->getMigrationFiles($path);
+        $ran = $migrator->getRepository()->getRan($extensionId);
+
+        return count(array_diff($files, $ran)) > 0;
     }
 }

--- a/framework/core/src/Foundation/InstalledApp.php
+++ b/framework/core/src/Foundation/InstalledApp.php
@@ -16,13 +16,13 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\Worker;
-use Psr\Log\LoggerInterface;
 use Laminas\Stratigility\Middleware\OriginalMessages;
 use Laminas\Stratigility\MiddlewarePipe;
 use Middlewares\BasePath;
 use Middlewares\BasePathRouter;
 use Middlewares\RequestHandler;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
 
 class InstalledApp implements AppInterface
 {

--- a/framework/core/src/Foundation/InstalledApp.php
+++ b/framework/core/src/Foundation/InstalledApp.php
@@ -10,9 +10,13 @@
 namespace Flarum\Foundation;
 
 use Flarum\Http\Middleware as HttpMiddleware;
+use Flarum\Queue\QueueFactory;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\Worker;
+use Psr\Log\LoggerInterface;
 use Laminas\Stratigility\Middleware\OriginalMessages;
 use Laminas\Stratigility\MiddlewarePipe;
 use Middlewares\BasePath;
@@ -70,6 +74,8 @@ class InstalledApp implements AppInterface
 
     protected function getUpdaterHandler(): RequestHandlerInterface|MiddlewarePipe
     {
+        $this->pauseQueueForUpdate();
+
         $pipe = new MiddlewarePipe;
         $pipe->pipe(new BasePath($this->basePath()));
         $pipe->pipe(
@@ -78,6 +84,43 @@ class InstalledApp implements AppInterface
         $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
         return $pipe;
+    }
+
+    /**
+     * Pause the queue for as long as the site needs updating.
+     *
+     * The window between new code landing and its migrations running is when a
+     * worker is most dangerous — it reserves jobs against a schema the code no
+     * longer matches. That window opens the moment `settings.version` drifts,
+     * long before an admin visits /update, so the pause is armed here, the
+     * moment the app first routes a request to the updater, rather than waiting
+     * for the migration itself.
+     *
+     * `MigrateCommand` clears this same flag when the migrations finish, so a
+     * pause armed here is lifted there. Setting an already-set flag is a
+     * no-op, so re-arming on every request through this window is harmless.
+     *
+     * Mirrors `queue:pause --all`, including its refusal to act when pausing is
+     * disabled — a flag no worker reads is only misleading state.
+     */
+    protected function pauseQueueForUpdate(): void
+    {
+        if (! Worker::$pausable) {
+            return;
+        }
+
+        try {
+            $connection = $this->container->make(Queue::class)->getConnectionName();
+
+            $this->container->make(QueueFactory::class)->pause($connection, '*');
+        } catch (\Throwable $e) {
+            // The updater must render even if the queue cannot be reached — a
+            // failure to pause must never be a failure to update. The worker's
+            // own maintenance handling remains the backstop.
+            $this->container->make(LoggerInterface::class)->warning(
+                'Could not pause the queue before serving the updater: '.$e->getMessage()
+            );
+        }
     }
 
     protected function basePath(): string

--- a/framework/core/src/Update/Controller/IndexController.php
+++ b/framework/core/src/Update/Controller/IndexController.php
@@ -40,9 +40,17 @@ class IndexController extends AbstractHtmlController
     {
         $view = $this->view->make('flarum.update::app')->with('title', 'Update Flarum');
 
+        // SQLite has no username or password, so the updater verifies against
+        // the database file's name instead. Only then does the form need that
+        // field — the same condition the verification uses, kept in step so the
+        // form never asks for something the check ignores, or omits something
+        // it requires.
+        $usesDatabaseName = (string) $this->config['database.username'] === ''
+            && (string) $this->config['database.password'] === '';
+
         $view->with('content', $this->view->make('flarum.update::update')->with(
-            'needsPassword',
-            $this->config['database.password'] !== null
+            'usesDatabaseName',
+            $usesDatabaseName
         ));
 
         return $view;

--- a/framework/core/src/Update/Controller/UpdateController.php
+++ b/framework/core/src/Update/Controller/UpdateController.php
@@ -33,11 +33,8 @@ class UpdateController implements RequestHandlerInterface
     {
         $input = $request->getParsedBody();
 
-        if (
-            $this->databaseHasPassword()
-            && Arr::get($input, 'databasePassword') !== $this->config['database.password']
-        ) {
-            return new HtmlResponse('Incorrect database password.', 500);
+        if (! $this->verifyCredentials(is_array($input) ? $input : [])) {
+            return new HtmlResponse('Incorrect database credentials.', 500);
         }
 
         $body = fopen('php://temp', 'wb+');
@@ -53,8 +50,45 @@ class UpdateController implements RequestHandlerInterface
         return new Response($body, 200);
     }
 
-    private function databaseHasPassword(): bool
+    /**
+     * Confirm the caller is the admin, by the only means available before the
+     * app can authenticate anyone: echoing back the database credentials that
+     * config.php holds.
+     *
+     * For MySQL, MariaDB and PostgreSQL the username and password must both
+     * match. On a passwordless database the password half is an empty string
+     * on both sides, so the username is what a passing visitor would not know —
+     * and checking it unconditionally is what closed the old hole, where a null
+     * password meant no check ran at all.
+     *
+     * SQLite has neither a username nor a password — it is a file, not a
+     * network service. There the database file's name stands in as the secret:
+     * still something an admin knows and an anonymous visitor does not.
+     *
+     * @param array<string, mixed> $input
+     */
+    private function verifyCredentials(array $input): bool
     {
-        return $this->config['database.password'] !== null;
+        $username = (string) $this->config['database.username'];
+        $password = (string) $this->config['database.password'];
+
+        if ($username === '' && $password === '') {
+            // No credentials to check — this is SQLite. Fall back to the
+            // database name, the one thing in its config an outsider would not
+            // know. It is a weak secret (defaults like `flarum.sqlite` are
+            // guessable), but a weak check is worth more than none, and it
+            // closes the bodyless-POST hole for this driver too.
+            $database = (string) $this->config['database.database'];
+
+            return hash_equals($database, (string) Arr::get($input, 'databaseName', ''));
+        }
+
+        // Both comparisons are evaluated before they are combined, so a failed
+        // username check does not short-circuit the password check and reveal,
+        // through timing, which half was wrong.
+        $usernameOk = hash_equals($username, (string) Arr::get($input, 'databaseUsername', ''));
+        $passwordOk = hash_equals($password, (string) Arr::get($input, 'databasePassword', ''));
+
+        return $usernameOk && $passwordOk;
     }
 }

--- a/framework/core/tests/integration/console/MigrateCommandQueuePauseTest.php
+++ b/framework/core/tests/integration/console/MigrateCommandQueuePauseTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\console;
+
+use Flarum\Database\Console\MigrateCommand;
+use Flarum\Foundation\Paths;
+use Flarum\Queue\QueueFactory;
+use Flarum\Testing\integration\ConsoleTestCase;
+use Illuminate\Contracts\Queue\Factory;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+/**
+ * A migration reshapes the schema out from under any queue worker running at
+ * the same time. So while migrations run — whether started from the web
+ * updater or `php flarum migrate` — the queue is paused, and resumed the
+ * moment they finish.
+ *
+ * That a paused worker actually stops popping jobs is proven by
+ * {@see \Flarum\Tests\integration\queue\QueuePauseTest}. These tests cover the
+ * one thing the migrate command is responsible for: setting and clearing the
+ * pause flag at the right times, and only when there is work to do.
+ */
+class MigrateCommandQueuePauseTest extends ConsoleTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config('queue', ['driver' => 'database']);
+    }
+
+    private function factory(): QueueFactory
+    {
+        $factory = $this->app()->getContainer()->make(Factory::class);
+
+        $this->assertInstanceOf(QueueFactory::class, $factory);
+
+        return $factory;
+    }
+
+    /**
+     * A migrate command with its migration body replaced, so the test decides
+     * whether there is pending work and whether it fails, while the real
+     * pause/resume wrapping runs unchanged. It records whether the queue was
+     * paused at the moment the body ran.
+     */
+    private function stubCommand(bool $pending, bool $fail = false): TestMigrateCommand
+    {
+        $container = $this->app()->getContainer();
+
+        $command = new TestMigrateCommand($container, $container->make(Paths::class));
+        $command->pending = $pending;
+        $command->fail = $fail;
+        $command->factory = $this->factory();
+
+        $this->console()->add($command);
+
+        return $command;
+    }
+
+    #[Test]
+    public function a_run_with_nothing_pending_leaves_the_queue_alone()
+    {
+        // `php flarum migrate` is run routinely with nothing to do. Idling
+        // every worker for a no-op run would be a regression.
+        $command = $this->stubCommand(pending: false);
+
+        $this->runCommand(['command' => 'migrate']);
+
+        $this->assertFalse($command->wasPausedDuringRun, 'A no-op migrate must not pause the queue.');
+        $this->assertFalse($this->factory()->isPaused('flarum', '*'));
+    }
+
+    #[Test]
+    public function a_no_op_run_still_clears_a_pause_armed_before_it()
+    {
+        // The web updater arms a pause the moment it sees the version drift,
+        // before this command runs — and there may be nothing left to migrate
+        // by the time it does. The resume must clear that earlier pause anyway,
+        // or the updater flow leaves the queue paused forever. This is the real
+        // bug that reached the dev forum.
+        $this->factory()->pause('flarum', '*');
+
+        $command = $this->stubCommand(pending: false);
+
+        $this->runCommand(['command' => 'migrate']);
+
+        $this->assertFalse(
+            $this->factory()->isPaused('flarum', '*'),
+            'A no-op migrate must still clear a pause armed before it, or the web updater leaves the queue stuck.'
+        );
+    }
+
+    #[Test]
+    public function a_run_with_pending_work_is_paused_while_it_runs_and_resumed_after()
+    {
+        $command = $this->stubCommand(pending: true);
+
+        $this->runCommand(['command' => 'migrate']);
+
+        $this->assertTrue($command->wasPausedDuringRun, 'The queue must be paused while migrations run.');
+        $this->assertFalse($this->factory()->isPaused('flarum', '*'), 'The queue must be resumed afterwards.');
+    }
+
+    #[Test]
+    public function the_queue_is_resumed_even_when_the_migration_fails()
+    {
+        // A failing migration is exactly when a worker must not touch the
+        // half-changed schema — but leaving the queue paused forever is its own
+        // outage. Resume runs in a finally.
+        $command = $this->stubCommand(pending: true, fail: true);
+
+        try {
+            $this->runCommand(['command' => 'migrate']);
+        } catch (RuntimeException) {
+            // The stubbed body throws on purpose.
+        }
+
+        $this->assertTrue($command->wasPausedDuringRun, 'The queue must have been paused before the failure.');
+        $this->assertFalse($this->factory()->isPaused('flarum', '*'), 'A failed migration must still resume the queue.');
+    }
+}
+
+/**
+ * A migrate command whose real migration body is replaced, so a test can drive
+ * the pause/resume wrapping without touching the schema.
+ */
+class TestMigrateCommand extends MigrateCommand
+{
+    public bool $pending = false;
+    public bool $fail = false;
+    public ?QueueFactory $factory = null;
+    public bool $wasPausedDuringRun = false;
+
+    protected function hasPendingMigrations(): bool
+    {
+        return $this->pending;
+    }
+
+    protected function runMigrations(): void
+    {
+        // Observe the pause the moment the (stubbed) migration runs — this is
+        // the window a real worker would be in danger.
+        $this->wasPausedDuringRun = (bool) $this->factory?->isPaused('flarum', '*');
+
+        if ($this->fail) {
+            throw new RuntimeException('Simulated migration failure.');
+        }
+    }
+}

--- a/framework/core/tests/integration/forum/UpgradePageTest.php
+++ b/framework/core/tests/integration/forum/UpgradePageTest.php
@@ -10,11 +10,32 @@
 namespace Flarum\Tests\integration\forum;
 
 use Flarum\Foundation\Application;
+use Flarum\Queue\QueueFactory;
 use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\Queue\Factory;
+use Illuminate\Queue\Worker;
 use PHPUnit\Framework\Attributes\Test;
 
 class UpgradePageTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        // The pausable flag is process-global; a test that flips it must not
+        // leak that into the next one.
+        Worker::$pausable = true;
+
+        parent::tearDown();
+    }
+
+    private function factory(): QueueFactory
+    {
+        $factory = $this->app()->getContainer()->make(Factory::class);
+
+        $this->assertInstanceOf(QueueFactory::class, $factory);
+
+        return $factory;
+    }
+
     #[Test]
     public function upgrade_page_returns_503_when_version_is_outdated(): void
     {
@@ -39,5 +60,46 @@ class UpgradePageTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringNotContainsString('Update Flarum', (string) $response->getBody());
+    }
+
+    #[Test]
+    public function serving_the_updater_pauses_the_queue(): void
+    {
+        $this->setting('version', '0.1.0');
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->assertFalse($this->factory()->isPaused('flarum', '*'));
+
+        $this->send($this->request('GET', '/'));
+
+        // A worker must not run jobs against a schema that is about to change,
+        // and the danger starts now — not when migrations eventually run.
+        $this->assertTrue($this->factory()->isPaused('flarum', '*'));
+    }
+
+    #[Test]
+    public function serving_the_normal_site_does_not_pause_the_queue(): void
+    {
+        $this->setting('version', Application::VERSION);
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->send($this->request('GET', '/'));
+
+        $this->assertFalse($this->factory()->isPaused('flarum', '*'));
+    }
+
+    #[Test]
+    public function the_queue_is_not_paused_when_pausing_is_disabled(): void
+    {
+        // If workers are told not to poll for pause signals, writing the flag
+        // is only misleading state — the same refusal `queue:pause` makes.
+        $this->setting('version', '0.1.0');
+        $this->config('queue', ['driver' => 'database']);
+
+        Worker::$pausable = false;
+
+        $this->send($this->request('GET', '/'));
+
+        $this->assertFalse($this->factory()->isPaused('flarum', '*'));
     }
 }

--- a/framework/core/tests/unit/Update/IndexControllerTest.php
+++ b/framework/core/tests/unit/Update/IndexControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Update;
+
+use Flarum\Foundation\Config;
+use Flarum\Testing\unit\TestCase;
+use Flarum\Update\Controller\IndexController;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Laminas\Diactoros\ServerRequest;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The updater form asks for whatever config.php can prove ownership with, and
+ * that differs by driver: a username and password for MySQL/MariaDB/PostgreSQL,
+ * the database file's name for SQLite, which has neither.
+ *
+ * The form must ask for exactly what the controller then checks — no more, no
+ * less — so this pins the flag the view branches on to the same condition the
+ * verification uses.
+ */
+class IndexControllerTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    private function usesDatabaseNameFor(array $database): bool
+    {
+        $captured = false;
+
+        // The update view records the value it is handed for `usesDatabaseName`.
+        $updateView = m::mock(View::class);
+        $updateView->shouldReceive('with')
+            ->with('usesDatabaseName', m::capture($captured))
+            ->andReturnSelf();
+
+        // The outer app view is passed through untouched.
+        $appView = m::mock(View::class);
+        $appView->shouldReceive('with')->andReturnSelf();
+        $appView->shouldReceive('render')->andReturn('');
+
+        $factory = m::mock(Factory::class);
+        $factory->shouldReceive('make')->with('flarum.update::app')->andReturn($appView);
+        $factory->shouldReceive('make')->with('flarum.update::update')->andReturn($updateView);
+
+        $config = new Config(['url' => 'http://flarum.test', 'database' => $database]);
+
+        (new IndexController($factory, $config))->render(new ServerRequest());
+
+        return $captured;
+    }
+
+    #[Test]
+    public function sqlite_asks_for_the_database_name()
+    {
+        $this->assertTrue($this->usesDatabaseNameFor([
+            'driver' => 'sqlite',
+            'database' => 'flarum.sqlite',
+            'username' => null,
+            'password' => null,
+        ]));
+    }
+
+    #[Test]
+    public function a_credentialed_database_asks_for_username_and_password()
+    {
+        $this->assertFalse($this->usesDatabaseNameFor([
+            'driver' => 'mysql',
+            'database' => 'flarum',
+            'username' => 'flarum',
+            'password' => 's3cret',
+        ]));
+    }
+
+    #[Test]
+    public function a_passwordless_credentialed_database_still_asks_for_the_username()
+    {
+        // MySQL/MariaDB over a socket has a username but no password. It is not
+        // SQLite, so it must still use the credential form, not the
+        // database-name one.
+        $this->assertFalse($this->usesDatabaseNameFor([
+            'driver' => 'mysql',
+            'database' => 'flarum',
+            'username' => 'flarum',
+            'password' => null,
+        ]));
+    }
+}

--- a/framework/core/tests/unit/Update/UpdateControllerTest.php
+++ b/framework/core/tests/unit/Update/UpdateControllerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Update;
+
+use Flarum\Database\Console\MigrateCommand;
+use Flarum\Foundation\Config;
+use Flarum\Testing\unit\TestCase;
+use Flarum\Update\Controller\UpdateController;
+use Laminas\Diactoros\ServerRequest;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The updater runs before the app can authenticate anyone: `settings.version`
+ * has drifted, the schema may be mid-change, and there is no session to trust.
+ * The one thing available is `config.php`, so the caller proves they are the
+ * admin by echoing back the database credentials it holds.
+ *
+ * Previously only the password was checked, and only when it was non-null — so
+ * an install with no database password (which our own installer produces by
+ * pressing Enter at the prompt) had no check at all, and an anonymous POST ran
+ * every pending migration.
+ *
+ * Now the username is checked too, on every install. On a passwordless
+ * database the password half matches an empty field, but the username still
+ * has to be right — something a passing visitor has no reason to know.
+ */
+class UpdateControllerTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, string|null> $database  what config.php holds
+     * @param array<string, string>|null $input     the submitted form body
+     */
+    private function attempt(array $database, ?array $input): int
+    {
+        $command = m::mock(MigrateCommand::class);
+
+        // A blocked request must never reach the migrator; an allowed one runs
+        // it exactly once. The count is the real assertion — the status code
+        // only confirms what the caller is told.
+        $command->shouldReceive('run')
+            ->with(m::type(InputInterface::class), m::type(OutputInterface::class))
+            ->andReturn(0);
+
+        $config = new Config([
+            'url' => 'http://flarum.test',
+            'database' => $database,
+        ]);
+
+        $controller = new UpdateController($command, $config);
+
+        $request = (new ServerRequest())->withParsedBody($input);
+
+        return $controller->handle($request)->getStatusCode();
+    }
+
+    private function ran(array $database, ?array $input): bool
+    {
+        $command = m::mock(MigrateCommand::class);
+        $ran = false;
+        $command->shouldReceive('run')->andReturnUsing(function () use (&$ran) {
+            $ran = true;
+
+            return 0;
+        });
+
+        $config = new Config([
+            'url' => 'http://flarum.test',
+            'database' => $database,
+        ]);
+
+        (new UpdateController($command, $config))
+            ->handle((new ServerRequest())->withParsedBody($input));
+
+        return $ran;
+    }
+
+    #[Test]
+    public function correct_username_and_password_runs_the_migration()
+    {
+        $this->assertTrue($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 's3cret']
+        ));
+    }
+
+    #[Test]
+    public function a_wrong_password_is_refused()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 'wrong']
+        ));
+    }
+
+    #[Test]
+    public function a_wrong_username_is_refused_even_with_the_right_password()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'attacker', 'databasePassword' => 's3cret']
+        ));
+    }
+
+    #[Test]
+    public function a_passwordless_database_runs_when_the_password_field_is_blank()
+    {
+        // The heart of the fix: no password to check, so a blank field matches
+        // — but the username still has to be the real one.
+        $this->assertTrue($this->ran(
+            ['username' => 'flarum', 'password' => ''],
+            ['databaseUsername' => 'flarum', 'databasePassword' => '']
+        ));
+    }
+
+    #[Test]
+    public function a_null_password_behaves_the_same_as_an_empty_one()
+    {
+        // Our installer stores null when the admin leaves the prompt blank.
+        // Null and '' must be indistinguishable here, or the old "skip the
+        // check entirely" hole reopens.
+        $this->assertTrue($this->ran(
+            ['username' => 'flarum', 'password' => null],
+            ['databaseUsername' => 'flarum', 'databasePassword' => '']
+        ));
+    }
+
+    #[Test]
+    public function a_passwordless_database_is_refused_when_a_password_is_guessed()
+    {
+        // An attacker who submits any password against a passwordless database
+        // no longer matches — the empty config value only matches an empty
+        // field.
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => ''],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 'anything']
+        ));
+    }
+
+    #[Test]
+    public function a_passwordless_database_still_needs_the_right_username()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => ''],
+            ['databaseUsername' => 'wrong', 'databasePassword' => '']
+        ));
+    }
+
+    #[Test]
+    public function sqlite_verifies_against_the_database_name_when_there_is_no_username()
+    {
+        // SQLite has no username and no password — both are absent from config.
+        // The only thing an admin knows that a passing visitor does not is the
+        // database file, so that stands in as the secret.
+        $this->assertTrue($this->ran(
+            ['driver' => 'sqlite', 'database' => 'flarum.sqlite', 'username' => null, 'password' => null],
+            ['databaseName' => 'flarum.sqlite']
+        ));
+    }
+
+    #[Test]
+    public function sqlite_is_refused_when_the_database_name_is_wrong()
+    {
+        $this->assertFalse($this->ran(
+            ['driver' => 'sqlite', 'database' => 'flarum.sqlite', 'username' => null, 'password' => null],
+            ['databaseName' => 'wrong.sqlite']
+        ));
+    }
+
+    #[Test]
+    public function sqlite_is_refused_when_nothing_is_submitted()
+    {
+        // The reported hole was a bodyless POST running migrations. On SQLite
+        // that must now be blocked too.
+        $this->assertFalse($this->ran(
+            ['driver' => 'sqlite', 'database' => 'flarum.sqlite', 'username' => null, 'password' => null],
+            []
+        ));
+    }
+
+    #[Test]
+    public function a_credentialed_database_ignores_the_database_name_field()
+    {
+        // MySQL/Postgres verify by username + password. The database-name
+        // fallback must not become a second way in — submitting the right
+        // database name but the wrong password is still refused.
+        $this->assertFalse($this->ran(
+            ['driver' => 'mysql', 'database' => 'flarum', 'username' => 'flarum', 'password' => 's3cret'],
+            ['databaseName' => 'flarum', 'databaseUsername' => 'flarum', 'databasePassword' => 'wrong']
+        ));
+    }
+
+    #[Test]
+    public function a_credentialed_database_still_runs_with_the_right_username_and_password()
+    {
+        // And the database-name field, if present, does not interfere with the
+        // normal credentialed path.
+        $this->assertTrue($this->ran(
+            ['driver' => 'mysql', 'database' => 'flarum', 'username' => 'flarum', 'password' => 's3cret'],
+            ['databaseName' => 'anything', 'databaseUsername' => 'flarum', 'databasePassword' => 's3cret']
+        ));
+    }
+
+    #[Test]
+    public function an_empty_submission_is_refused()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            []
+        ));
+    }
+
+    #[Test]
+    public function a_missing_body_is_refused()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            null
+        ));
+    }
+
+    #[Test]
+    public function a_refused_request_returns_a_generic_error()
+    {
+        // Wrong password and wrong username must be indistinguishable from
+        // outside, so the response cannot say which was wrong.
+        $wrongPassword = $this->attempt(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 'wrong']
+        );
+
+        $wrongUsername = $this->attempt(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'wrong', 'databasePassword' => 's3cret']
+        );
+
+        $this->assertSame(500, $wrongPassword);
+        $this->assertSame($wrongPassword, $wrongUsername);
+    }
+}

--- a/framework/core/views/install/update.php
+++ b/framework/core/views/install/update.php
@@ -1,19 +1,33 @@
 <h2>Update Flarum</h2>
 
-<?php if ($needsPassword): ?>
-<p>Enter your database password to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
+<?php if ($usesDatabaseName): ?>
+<p>Enter your database name to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
 <?php else: ?>
-<p>Click the button below to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
+<p>Enter your database username and password to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If your database has no password, leave that field blank. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
 <?php endif; ?>
 
 <form method="post">
   <div id="error" style="display:none"></div>
 
-  <?php if ($needsPassword): ?>
+  <?php if ($usesDatabaseName): ?>
+  <div class="FormGroup">
+    <div class="FormField">
+      <label>Database Name</label>
+      <input class="FormControl" type="text" name="databaseName" autocomplete="off">
+    </div>
+  </div>
+  <?php else: ?>
+  <div class="FormGroup">
+    <div class="FormField">
+      <label>Database Username</label>
+      <input class="FormControl" type="text" name="databaseUsername" autocomplete="off">
+    </div>
+  </div>
+
   <div class="FormGroup">
     <div class="FormField">
       <label>Database Password</label>
-      <input class="FormControl" type="password" name="databasePassword">
+      <input class="FormControl" type="password" name="databasePassword" autocomplete="off">
     </div>
   </div>
   <?php endif; ?>


### PR DESCRIPTION
**Fixes #0000**

<!-- From a private security review; no public issue behind it. -->

**Changes proposed in this pull request:**

Hardens the updater — the page shown while the code is ahead of the database, between uploading new files and running migrations. Two things were wrong with that window.

*Authentication.* The updater ran pending migrations for anyone who submitted the right `database.password`, but it only checked the password when one was set. An install with no database password — which the installer produces, and which is valid for socket-auth MySQL/MariaDB/Postgres — had no check at all: a bodyless POST ran every pending migration. Now the username **and** password are both verified for those drivers, so a passwordless install is still gated by the username (which the installer always requires). SQLite has neither, so it falls back to the database file's name. The comparison uses `hash_equals`, and every failure returns the same generic error.

*The queue.* Nothing stopped a queue worker running jobs against a schema that was mid-migration. The queue is now paused while migrations run and resumed when they finish. The web updater arms the pause the moment it first serves the update page — the danger starts when the version drifts, not when an admin clicks Update. `php flarum migrate` (run any time from the CLI) pauses around its own run too, but only when something is actually pending, so a routine no-op `migrate` doesn't idle every worker. Resume always runs in a `finally`, so a failed migration never leaves the queue stuck. This uses the existing `queue:pause`/`queue:resume` mechanism — not maintenance mode, so the forum stays online to visitors.

Impacted: `UpdateController`, `IndexController` and the updater form; `MigrateCommand`; `InstalledApp`.

**Reviewers should focus on:**

- **The SQLite fallback is a weak secret.** `flarum.sqlite` is guessable. The case for it: SQLite is a supported production driver, and leaving one driver with zero check while the others have one is hard to defend. It raises the bar from nothing to "must know the db name", no more. The `root` + no-password case stays guessable for the same reason it always was — indefensible from HTTP, and refusing the web updater would break the shared-hosting users it exists for.
- **The queue pause is conditional but the resume is not.** The web arm pauses unconditionally when serving the updater (it can't cheaply check pending state on the request path), so `MigrateCommand` must resume unconditionally to clear it — otherwise a no-op run reached through the updater leaves the queue paused forever. This exact case stuck the queue on my dev forum during development; there's a test for it now.
- **The web arm swallows pause failures** (logs, still serves the updater) — a queue that can't be reached must never block the update itself.

**Screenshot**

<!-- The updater form now asks for username + password (or the database name on SQLite). -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. *(updater form)*
- [ ] Frontend changes: tests are green — no JS changes
- [ ] Frontend changes: tests have been added — no JS changes
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

New tests: `UpdateControllerTest` and `IndexControllerTest` (unit — verification across all drivers, oracle-free errors, and the form asking for exactly what's checked); `MigrateCommandQueuePauseTest` and additions to `UpgradePageTest` (integration — pause/resume, no-op leaves the queue alone, resume-on-failure, the web arm, and the no-op-clears-a-prior-pause regression). All load-bearing behaviours mutation-tested.

**Required changes:**

- [ ] Related documentation PR: the updater form now asks for username + password (or the database name on SQLite) — the update docs describe the old single-password field.
