### PR TITLE
[2.x] fix: don't fatal the admin payload on a non-core sort type

### DIFF
--- a/framework/core/src/Api/Resource/Concerns/HasSortMap.php
+++ b/framework/core/src/Api/Resource/Concerns/HasSortMap.php
@@ -15,13 +15,20 @@ trait HasSortMap
 {
     public function sortMap(): array
     {
-        /** @var SortColumn[] $sorts */
         $sorts = $this->resolveSorts();
 
         $map = [];
 
         foreach ($sorts as $sort) {
-            $map = array_merge($map, $sort->sortMap());
+            // A resource's sorts are not necessarily core's SortColumn — an
+            // extension may register its own Sort subclass (extension-manager
+            // does, to proxy a sort to an external registry). Only core's
+            // SortColumn carries the alias-to-API-sort map; anything else has
+            // no map to contribute and is skipped rather than fatalling the
+            // whole admin payload.
+            if ($sort instanceof SortColumn) {
+                $map = array_merge($map, $sort->sortMap());
+            }
         }
 
         return $map;

--- a/framework/core/tests/integration/admin/SortMapsPayloadTest.php
+++ b/framework/core/tests/integration/admin/SortMapsPayloadTest.php
@@ -134,6 +134,39 @@ class SortMapsPayloadTest extends TestCase
     }
 
     #[Test]
+    public function a_resource_using_a_non_core_sort_type_does_not_break_the_payload()
+    {
+        // A sort does not have to be core's SortColumn — an extension may
+        // register its own Sort subclass (extension-manager does, to proxy a
+        // sort to an external registry). Such a sort has no sortMap(), so
+        // building the admin payload must skip it rather than fatal on the
+        // whole page. Before this was guarded, enabling extension-manager threw
+        // "Call to undefined method ...SortColumn::sortMap()".
+        $this->extend(
+            (new Extend\ApiResource(\Flarum\Api\Resource\DiscussionResource::class))
+                ->sorts(fn () => [
+                    new CustomSort('downloads'),
+                ])
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/admin', ['authenticatedAs' => 1])
+        );
+
+        // The page renders at all — the non-core sort is quietly ignored rather
+        // than bringing the admin panel down.
+        $this->assertEquals(200, $response->getStatusCode());
+
+        preg_match('/<script id="flarum-json-payload" type="application\/json">(.+?)<\/script>/s', (string) $response->getBody(), $matches);
+        $payload = json_decode(html_entity_decode($matches[1]), true);
+
+        // Whatever named sorts the resource has are still published; the
+        // unmappable one just contributes nothing.
+        $this->assertArrayNotHasKey('downloads', $payload['sortMaps']['discussions'] ?? []);
+        $this->assertEquals('-lastPostedAt', $payload['sortMaps']['discussions']['latest']);
+    }
+
+    #[Test]
     public function a_normal_user_never_sees_this()
     {
         // Belt and braces: the admin payload is admin-only, and this test
@@ -143,5 +176,17 @@ class SortMapsPayloadTest extends TestCase
         );
 
         $this->assertEquals(403, $response->getStatusCode());
+    }
+}
+
+/**
+ * A sort that is not core's SortColumn — it extends the base Sort directly and
+ * has no sortMap(), the way extension-manager's own SortColumn does.
+ */
+class CustomSort extends \Tobyz\JsonApiServer\Schema\Sort
+{
+    public function apply(object $query, string $direction, \Tobyz\JsonApiServer\Context $context): void
+    {
+        // Never applied in this test; the base class just requires it to exist.
     }
 }


### PR DESCRIPTION
**Fixes #0000**

<!-- Surfaced by enabling flarum-extension-manager on a dev install; no separate issue filed. -->

**Changes proposed in this pull request:**

Enabling flarum-extension-manager took the whole admin panel down with:

```
Call to undefined method Flarum\ExtensionManager\Api\Schema\SortColumn::sortMap()
```

`HasSortMap::sortMap()` iterates a resource's sorts and calls `sortMap()` on each, trusting the `@var SortColumn[]` annotation. That only holds for resources using core's own `Flarum\Api\Sort\SortColumn`. A resource can register a **different** `Sort` subclass — extension-manager's `ExternalExtensionResource` does, using its own `SortColumn` that proxies the sort to the external package registry and has no `sortMap()`. Building the admin `sortMaps` payload then called `sortMap()` on that class and fatalled the entire page.

Guarded with an `instanceof SortColumn`: only core's `SortColumn` carries the alias-to-API-sort map, so anything else has nothing to contribute and is skipped rather than crashing the payload. This protects every extension with a custom sort type, not just the one that surfaced it.

Impacted: `Flarum\Api\Resource\Concerns\HasSortMap` (and therefore the admin page payload for any resource with a non-core sort).

**Reviewers should focus on:**

- **The annotation was the bug.** `@var SortColumn[]` was a promise the code couldn't keep once an extension supplied its own sort type. I removed it and replaced the trust with a runtime `instanceof`. Worth confirming that's the right seam rather than, say, giving the base `Sort` a `sortMap()` returning `[]` — I chose the core guard because it fixes the assumption at its source, not one symptom.
- **Silent skip vs. surfacing.** A non-core sort is quietly omitted from the sort map. That's correct here (it has no alias to publish), but flagging it in case you'd want a louder signal for a sort that *should* have been mappable.

**Screenshot**

No UI change — this is a crash fix. The admin page renders instead of 500ing.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension? — core: the unsafe assumption is core's, and the fix protects all extensions.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — reproduced on dev (500 → 403 auth, no longer fatal)
- [ ] Frontend changes: tests are green — no JS changes
- [ ] Frontend changes: tests have been added — no JS changes
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

Added `a_resource_using_a_non_core_sort_type_does_not_break_the_payload` to `SortMapsPayloadTest` — it reproduces the 500 and confirms the unmappable sort is skipped while the resource's real sorts still publish. Full `SortMapsPayloadTest` (8) and the admin suite green; PHPStan clean.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
