### PR TITLE
[2.x] perf: update Babel browserslist targets to reduce bundle size

### DIFF
--- a/js-packages/webpack-config/babel.config.cjs
+++ b/js-packages/webpack-config/babel.config.cjs
@@ -16,8 +16,7 @@ module.exports = {
     privateFieldsAsProperties: true,
   },
   targets: {
-    // `not android > 0` means the build-in Android browser used up to Android 4.4 KitKat.
-    browsers: '>0.2%, not dead, not android > 0, not operamini all',
+    browsers: '>0.5%, last 2 versions, not dead, not operamini all',
   },
   presets: [
     require.resolve('@babel/preset-react'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,9 +2219,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001759:
-  version "1.0.30001769"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz#1ad91594fad7dc233777c2781879ab5409f7d9c2"
-  integrity sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==
+  version "1.0.30001809"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz"
+  integrity sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
This PR updates the browser targets in `babel.config.cjs`:
```js
'>0.2%, not dead, not android > 0, not operamini all'
```
to:
```js
'>0.5%, last 2 versions, not dead, not operamini all'
```

The new query raises the global usage threshold while explicitly retaining the latest two versions of each browser. This drops support for low-usage legacy browser versions and reduces unnecessary Babel transforms, while keeping broad compatibility with current browsers.

The explicit Android exclusion is also no longer necessary, since unsupported legacy versions are excluded by the remaining criteria.

## Bundle size impact

Rebuilding `flarum/core` produced the following results:

| Asset | Before | After | Saving |
| --- | ---: | ---: | ---: |
| `dist/forum.js` | 476 KB | 440 KB | 36 KB |
| `dist/admin.js` | 464 KB | 428 KB | 36 KB  |

Because `flarum-webpack-config` is shared across the ecosystem, extensions using this configuration can benefit from the updated targets when rebuilt.

---

Ref: https://discuss.flarum.org/d/39653-are-we-supporting-too-old-browser