### PR TITLE
[2.x] fix(extension manager): label the icon-only extension card buttons for screen readers

### DIFF
--- a/extensions/package-manager/js/src/admin/components/ExtensionCard.tsx
+++ b/extensions/package-manager/js/src/admin/components/ExtensionCard.tsx
@@ -196,13 +196,22 @@ export default class ExtensionCard<CustomAttrs extends IExtensionAttrs = IExtens
           <Button
             className="Button Button--icon Button--flat"
             icon="fas fa-cloud-arrow-down"
+            aria-label={app.translator.trans('flarum-extension-manager.admin.extensions.install')}
             onclick={() => {
               app.extensionManager.control.requirePackage({ package: extension.name() });
             }}
           />
         );
       } else {
-        items.add('installed', <Button className="Button Button--icon Button--flat Button--success" icon="fas fa-check-circle" disabled={true} />);
+        items.add(
+          'installed',
+          <Button
+            className="Button Button--icon Button--flat Button--success"
+            icon="fas fa-check-circle"
+            aria-label={app.translator.trans('flarum-extension-manager.admin.extensions.already_installed')}
+            disabled={true}
+          />
+        );
       }
     } else {
       if (onClickUpdate && typeof onClickUpdate === 'function') {

--- a/extensions/package-manager/locale/en.yml
+++ b/extensions/package-manager/locale/en.yml
@@ -66,6 +66,7 @@ flarum-extension-manager:
           Please wait until the extensions are updated to be compatible by the authors, or remove them before proceeding.
 
     extensions:
+      already_installed: This extension is already installed
       check_why_it_failed_updating: Show why it did not update to the latest.
       install: Install a new extension
       install_help: >


### PR DESCRIPTION
**Fixes #0000**

<!-- Found via the admin console's own [Flarum Accessibility Warning] output while using extension-manager. -->

**Changes proposed in this pull request:**

The extension manager's admin panel logs, once per installed extension:

```
[Flarum Accessibility Warning] Button has no content and no accessible label.
```

Two icon-only buttons on the extension card (`ExtensionCard.tsx`) have an icon but no text and no `aria-label`, so a screen reader announces them as just "Button":

- the **install** button (cloud-download icon) in the discover list, and
- the **already-installed** indicator (the disabled green check) — which renders once per installed extension, hence the repeated warning.

Both now carry an `aria-label`, exactly the way the card's *other* icon buttons (update, why-not, delete) already do — so this brings the two stragglers in line with the pattern the file already established. The install button reuses the existing `extensions.install` string; the already-installed indicator gets a new `extensions.already_installed` locale key.

Impacted: `js/src/admin/components/ExtensionCard.tsx`, `locale/en.yml`.

**Reviewers should focus on:**

- **These were the only two offenders.** I swept the whole `js/src/admin` tree (self-closing and open-form `<Button>`) for icon buttons with no children and no `aria-label`; nothing else came up. So this is complete, not a first pass.
- **The `already_installed` wording** — "This extension is already installed". Open to a better phrasing if you have one.

**Screenshot**

No visual change — the buttons look identical. The difference is what a screen reader announces and the console warning going away.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension? — extension change (bundled)
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — built + published to a dev install, label confirmed in the served bundle
- [ ] Frontend changes: tests are green — package-manager has no JS test suite
- [ ] Frontend changes: tests have been added, or are not appropriate here. — not appropriate (an aria-label on two buttons)
- [ ] Backend changes: tests are green — no backend changes
- [ ] Backend changes: tests have been added — no backend changes
- [ ] Where applicable, changes are suitable for all supported database drivers — no DB changes
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)

