### PR TITLE
[2.x] fix: Declare token models' keys as strings (harden GHSA-55f2-h36g-96c3)

### DIFF
--- a/framework/core/src/User/EmailToken.php
+++ b/framework/core/src/User/EmailToken.php
@@ -38,6 +38,13 @@ class EmailToken extends AbstractModel
 
     protected $primaryKey = 'token';
 
+    /**
+     * The token is a random string, not a number. Without this Eloquent binds
+     * a lookup as an integer, and on MySQL/MariaDB a lookup for `0` matches any
+     * token beginning with a letter (GHSA-55f2-h36g-96c3).
+     */
+    protected $keyType = 'string';
+
     public static function generate(string $email, int $userId): static
     {
         $token = new static;

--- a/framework/core/src/User/PasswordToken.php
+++ b/framework/core/src/User/PasswordToken.php
@@ -32,6 +32,15 @@ class PasswordToken extends AbstractModel
     protected $primaryKey = 'token';
 
     /**
+     * The token is a 40-character random string, not a number. Without this,
+     * Eloquent defaults the key type to `int` and binds a lookup as an integer;
+     * on MySQL/MariaDB a lookup for `0` then matches any token beginning with a
+     * letter — about 84% of them — which was an unauthenticated account
+     * takeover (GHSA-55f2-h36g-96c3).
+     */
+    protected $keyType = 'string';
+
+    /**
      * Generate a password token for the specified user.
      */
     public static function generate(int $userId): static

--- a/framework/core/src/User/RegistrationToken.php
+++ b/framework/core/src/User/RegistrationToken.php
@@ -43,6 +43,13 @@ class RegistrationToken extends AbstractModel
     protected $primaryKey = 'token';
 
     /**
+     * The token is a random string, not a number. Without this Eloquent binds
+     * a lookup as an integer, and on MySQL/MariaDB a lookup for `0` matches any
+     * token beginning with a letter (GHSA-55f2-h36g-96c3).
+     */
+    protected $keyType = 'string';
+
+    /**
      * Generate an auth token for the specified user.
      */
     public static function generate(string $provider, string $identifier, array $attributes, array $payload): static

--- a/framework/core/tests/integration/api/users/PasswordTokenTypeJugglingTest.php
+++ b/framework/core/tests/integration/api/users/PasswordTokenTypeJugglingTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\PasswordToken;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression guard for GHSA-55f2-h36g-96c3.
+ *
+ * The password-reset token is a random 40-character string used as the primary
+ * key of PasswordToken. If the model does not declare its key as a string,
+ * Eloquent treats the key as an integer, and on MySQL/MariaDB a lookup for the
+ * integer 0 coerces every token whose value begins with a letter — about 84% of
+ * them — to 0. An unauthenticated request sending `passwordToken: 0` (a bare
+ * JSON integer, not a quoted string) then matches a real, unseen token and
+ * takes the account over.
+ *
+ * 2.x avoids this, and these tests pin *why* so a refactor cannot quietly bring
+ * it back.
+ */
+class PasswordTokenTypeJugglingTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            'password_tokens' => [
+                // A token that begins with a letter, as ~84% of generated ones
+                // do. This is the value the integer 0 must not be allowed to
+                // match.
+                ['token' => 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2', 'user_id' => 2, 'created_at' => Carbon::now()],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function all_token_models_declare_a_string_key()
+    {
+        // The structural guarantee, for every token looked up by its string
+        // value. Without this, Eloquent binds the lookup as an integer and the
+        // attack becomes possible again — so all three the advisory names are
+        // pinned, not just the password one it was reported against.
+        $this->app();
+
+        $this->assertSame('string', (new PasswordToken)->getKeyType());
+        $this->assertSame('string', (new \Flarum\User\EmailToken)->getKeyType());
+        $this->assertSame('string', (new \Flarum\User\RegistrationToken)->getKeyType());
+    }
+
+    #[Test]
+    public function a_bare_integer_token_does_not_match_a_letter_leading_token()
+    {
+        // The attack itself, end to end: reset the victim's password with a
+        // bare integer token and confirm it is refused.
+        $this->app();
+
+        $original = User::find(2)->password;
+
+        $response = $this->send(
+            $this->request('POST', '/reset', [
+                'json' => [
+                    'passwordToken' => 0,
+                    'password' => 'attacker-chosen-password',
+                    'password_confirmation' => 'attacker-chosen-password',
+                ],
+            ])
+        );
+
+        // The reset must not have succeeded.
+        $this->assertNotEquals(200, $response->getStatusCode(), 'A bare integer token was accepted.');
+
+        // And the victim's password must be untouched.
+        $this->assertSame($original, User::find(2)->refresh()->password, 'The victim password was changed.');
+    }
+
+    #[Test]
+    public function the_lookup_binds_the_token_as_a_string_not_an_integer()
+    {
+        // The mechanism, checked at the query layer so it holds on every
+        // database driver, not only the ones where the coercion happens to be
+        // visible. A string key type makes Eloquent bind `0` as `'0'`, which
+        // cannot equal a letter-leading token.
+        $this->app();
+
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        PasswordToken::find(0);
+
+        $log = $db->getQueryLog();
+        $db->disableQueryLog();
+
+        $last = end($log);
+        $binding = $last['bindings'][0] ?? null;
+
+        $this->assertSame('0', $binding, 'The token lookup bound an integer, not a string.');
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

<!-- Hardening follow-up to GHSA-55f2-h36g-96c3. 2.x is not vulnerable, but the protection is accidental — this makes it structural. -->

**Changes proposed in this pull request:**

`PasswordToken`, `EmailToken` and `RegistrationToken` use a random 40-character string as their primary key (`$primaryKey = 'token'`, `$incrementing = false`) but never declare `$keyType`. Eloquent defaults it to `int`, so a lookup binds the value as an integer. On MySQL/MariaDB a lookup for `0` then coerces every token whose value begins with a letter — about 84% of generated ones — to `0`. That was the unauthenticated account takeover in GHSA-55f2-h36g-96c3.

2.x is **not currently vulnerable**, but only by accident. The reset and confirmation controllers happen to type-hint the token as `string` (`validOrFail(string $id)`), which coerces a bare integer `0` to `"0"` before the query runs — so the query binds a string and matches nothing. That protection is a single type-hint per caller. Any new code path calling `Token::find()` with raw request input, or a refactor dropping the hint, reintroduces the flaw.

Declaring `protected $keyType = 'string'` on all three models fixes it at the model layer, so the lookup binds a string regardless of the caller. This is the same fix shipped for 1.x in `1.8.19`, and it turns the accidental, per-caller protection into a structural one.

Impacted: `PasswordToken`, `EmailToken`, `RegistrationToken`.

**Reviewers should focus on:**

- **This is defence-in-depth, not a live-vuln fix** — 2.x already refuses the attack via the controllers' string hint. The value here is removing the reliance on that accident. I confirmed both facts on MySQL: with `$keyType` removed the model binds integer `0`, yet the end-to-end attack still fails (the hint saves it); with the model fix, the binding is a string regardless.
- **No behaviour change for the non-vulnerable drivers.** SQLite and PostgreSQL compare raw bytes and never coerced; tokens are strings either way. The change only affects how MySQL/MariaDB binds the lookup.
- **`$keyType = 'string'` on a random-string PK is standard Eloquent** and shouldn't affect generation (`Str::random(40)`), deletion, or relationship loading — the test suite exercises those.

**Screenshot**

No UI change.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — the alternative (rely on the controller hint) is what we're moving away from.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — core security models.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: n/a
- [ ] Frontend changes: tests are green — no JS changes
- [ ] Frontend changes: tests have been added — no JS changes
- [x] Backend changes: tests are green (run `composer test`). — verified on SQLite and MySQL locally
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — ran the new test on MySQL specifically, since SQLite alone would not exercise the coercion.
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

New `PasswordTokenTypeJugglingTest`: reproduces the attack with `passwordToken: 0`, asserts all three models declare a string key, and pins that the lookup binds `'0'`. Mutation-tested — removing `$keyType` fails the model and binding assertions. The two pre-existing `PasswordEmailTokensTest` failures on MySQL (a mime-detection memory issue) are unrelated and fail identically without this change.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
