### PR TITLE
[2.x] feat: optional theme switcher in the header

### DIFF
--- a/framework/core/js/src/admin/components/AppearancePage.tsx
+++ b/framework/core/js/src/admin/components/AppearancePage.tsx
@@ -174,6 +174,19 @@ export default class AppearancePage extends AdminPage {
       60
     );
 
+    if (this.setting('color_scheme')() === 'auto') {
+      items.add(
+        'show-theme-selector',
+        this.buildSettingComponent({
+          type: 'switch',
+          setting: 'show_theme_selector',
+          label: app.translator.trans('core.admin.appearance.show_theme_selector_label'),
+          help: app.translator.trans('core.admin.appearance.show_theme_selector_help'),
+        }),
+        55
+      );
+    }
+
     items.add(
       'colored-header',
       this.buildSettingComponent({

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -275,6 +275,8 @@ export default class Application {
 
   allowUserColorScheme!: boolean;
 
+  colorScheme!: ColorScheme | string;
+
   refs: Record<string, string> = {
     fontawesome: 'https://fontawesome.com/icons?o=r&m=free',
   };
@@ -510,7 +512,7 @@ export default class Application {
     let scheme;
 
     if (this.allowUserColorScheme) {
-      scheme = userConfiguredPreference;
+      scheme = userConfiguredPreference ?? (this.session.user ? undefined : sessionStorage.getItem('colorScheme') ?? undefined);
     }
 
     scheme ||= forumDefault;
@@ -541,6 +543,8 @@ export default class Application {
   }
 
   setColorScheme(scheme: ColorScheme | string): void {
+    this.colorScheme = scheme;
+
     if (scheme === ColorScheme.Auto) {
       scheme = this.getSystemColorSchemePreference();
     }

--- a/framework/core/js/src/common/components/Button.tsx
+++ b/framework/core/js/src/common/components/Button.tsx
@@ -16,6 +16,12 @@ export interface IButtonAttrs extends ComponentAttrs {
    */
   icon?: string | boolean | Mithril.Children;
   /**
+   * Keep the icon's declared style even when the forum forces a Font Awesome
+   * style, for an icon whose meaning depends on its style. Forwarded to the
+   * icon this button renders.
+   */
+  noStyleOverride?: boolean;
+  /**
    * Disables button from user input.
    *
    * Default: `false`
@@ -64,7 +70,18 @@ export interface IButtonAttrs extends ComponentAttrs {
  */
 export default class Button<CustomAttrs extends IButtonAttrs = IButtonAttrs> extends Component<CustomAttrs> {
   view(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
-    let { type, 'aria-label': ariaLabel, icon: iconName, disabled, loading, className, class: _class, helperText, ...attrs } = this.attrs;
+    let {
+      type,
+      'aria-label': ariaLabel,
+      icon: iconName,
+      noStyleOverride,
+      disabled,
+      loading,
+      className,
+      class: _class,
+      helperText,
+      ...attrs
+    } = this.attrs;
 
     // If no `type` attr provided, set to "button"
     type ||= 'button';
@@ -116,7 +133,12 @@ export default class Button<CustomAttrs extends IButtonAttrs = IButtonAttrs> ext
     const icon = this.attrs.icon;
 
     return [
-      icon && (typeof icon === 'string' || icon === true ? <Icon name={icon} className="Button-icon" /> : icon),
+      icon &&
+        (typeof icon === 'string' || icon === true ? (
+          <Icon name={icon} noStyleOverride={this.attrs.noStyleOverride} className="Button-icon" />
+        ) : (
+          icon
+        )),
       children && (
         <span className="Button-label">
           <span className="Button-labelText">{children}</span>

--- a/framework/core/js/src/common/components/Dropdown.tsx
+++ b/framework/core/js/src/common/components/Dropdown.tsx
@@ -15,6 +15,11 @@ export interface IDropdownAttrs extends ComponentAttrs {
   menuClassName?: string;
   /** The name of an icon to show in the dropdown toggle button. */
   icon?: string;
+  /**
+   * Keep the toggle icon's declared style even when the forum forces a Font
+   * Awesome style, for an icon whose meaning depends on its style.
+   */
+  noStyleOverride?: boolean;
   /** The name of an icon to show on the right of the button. */
   caretIcon?: string;
   /** The label of the dropdown toggle button. Defaults to 'Controls'. */
@@ -187,7 +192,7 @@ export default class Dropdown<CustomAttrs extends IDropdownAttrs = IDropdownAttr
    */
   getButtonContent(children: Mithril.ChildArray): Mithril.ChildArray {
     return [
-      this.attrs.icon ? <Icon name={this.attrs.icon} className="Button-icon" /> : '',
+      this.attrs.icon ? <Icon name={this.attrs.icon} noStyleOverride={this.attrs.noStyleOverride} className="Button-icon" /> : '',
       <span className="Button-label">
         <span className="Button-labelText">{this.attrs.label}</span>
         {this.getButtonSubContent()}

--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -53,7 +53,7 @@ export default class SelectDropdown<CustomAttrs extends ISelectDropdownAttrs = I
       // An icon is what identifies the control once there is no room for its
       // label — without one, hiding the label leaves a caret floating on its
       // own with nothing to say what it selects.
-      this.attrs.icon ? <Icon name={this.attrs.icon} className="Button-icon" /> : null,
+      this.attrs.icon ? <Icon name={this.attrs.icon} noStyleOverride={this.attrs.noStyleOverride} className="Button-icon" /> : null,
       <span className="Button-label">
         <span className="Button-labelText">{label}</span>
       </span>,

--- a/framework/core/js/src/forum/components/HeaderSecondary.js
+++ b/framework/core/js/src/forum/components/HeaderSecondary.js
@@ -7,6 +7,7 @@ import NotificationsDropdown from './NotificationsDropdown';
 import ItemList from '../../common/utils/ItemList';
 import listItems from '../../common/helpers/listItems';
 import GlobalSearch from './GlobalSearch';
+import ThemeSwitcher from './ThemeSwitcher';
 
 /**
  * The `HeaderSecondary` component displays secondary header controls, such as
@@ -27,6 +28,10 @@ export default class HeaderSecondary extends Component {
     const items = new ItemList();
 
     items.add('search', <GlobalSearch state={app.search.state} />, 30);
+
+    if (app.allowUserColorScheme && app.forum.attribute('showThemeSelector')) {
+      items.add('themeSwitcher', <ThemeSwitcher />, 12);
+    }
 
     if (app.forum.attribute('showLanguageSelector') && Object.keys(app.data.locales).length > 1) {
       const locales = [];

--- a/framework/core/js/src/forum/components/ThemeSwitcher.tsx
+++ b/framework/core/js/src/forum/components/ThemeSwitcher.tsx
@@ -1,0 +1,78 @@
+import app from '../../forum/app';
+import Component, { type ComponentAttrs } from '../../common/Component';
+import type Mithril from 'mithril';
+import SelectDropdown from '../../common/components/SelectDropdown';
+import Button from '../../common/components/Button';
+import ItemList from '../../common/utils/ItemList';
+import ThemeMode, { ColorScheme } from '../../common/components/ThemeMode';
+
+const DEFAULT_ICON = 'fa-solid fa-circle-half-stroke';
+
+export default class ThemeSwitcher<CustomAttrs extends ComponentAttrs = ComponentAttrs> extends Component<CustomAttrs> {
+  iconItems(): ItemList<string> {
+    const items = new ItemList<string>();
+
+    items.add(ColorScheme.Light, 'fa-regular fa-sun');
+    items.add(ColorScheme.LightHighContrast, 'fa-solid fa-sun');
+    items.add(ColorScheme.Dark, 'fa-regular fa-moon');
+    items.add(ColorScheme.DarkHighContrast, 'fa-solid fa-moon');
+
+    return items;
+  }
+
+  icon(scheme: string): string {
+    const items = this.iconItems();
+
+    return items.has(scheme) ? items.get(scheme) : DEFAULT_ICON;
+  }
+
+  active(): string {
+    return app.colorScheme ?? app.session.user?.preferences()?.colorScheme ?? app.forum.attribute<string>('colorScheme') ?? ColorScheme.Auto;
+  }
+
+  label(scheme: string): string {
+    const custom = ThemeMode.colorSchemes.find((s) => s.id === scheme)?.label;
+
+    return custom || app.translator.trans('core.forum.settings.color_schemes.' + scheme.replace('-', '_') + '_mode_label', {}, true);
+  }
+
+  select(scheme: string): void {
+    app.setColorScheme(scheme);
+
+    if (app.session.user) {
+      app.session.user.savePreferences({ colorScheme: scheme });
+    } else {
+      sessionStorage.setItem('colorScheme', scheme);
+    }
+
+    m.redraw();
+  }
+
+  view(): Mithril.Children {
+    const active = this.active();
+    const resolved = active === ColorScheme.Auto ? app.getSystemColorSchemePreference() : active;
+
+    return (
+      <SelectDropdown
+        className="ThemeSwitcher HeaderDropdown"
+        buttonClassName="Button Button--flat"
+        icon={this.icon(resolved)}
+        noStyleOverride
+        defaultLabel={this.label(active)}
+        accessibleToggleLabel={app.translator.trans('core.forum.header.theme_switcher_accessible_label')}
+      >
+        {ThemeMode.colorSchemes.map((scheme) => (
+          <Button
+            className={`ThemeSwitcher-option ThemeSwitcher-option--${scheme.id}`}
+            icon={active === scheme.id ? 'fa-solid fa-check' : this.icon(scheme.id)}
+            noStyleOverride
+            active={active === scheme.id}
+            onclick={() => this.select(scheme.id)}
+          >
+            {this.label(scheme.id)}
+          </Button>
+        ))}
+      </SelectDropdown>
+    );
+  }
+}

--- a/framework/core/js/tests/integration/admin/components/AppearencePage.test.ts
+++ b/framework/core/js/tests/integration/admin/components/AppearencePage.test.ts
@@ -5,6 +5,11 @@ import mq from 'mithril-query';
 
 beforeAll(() => bootstrapAdmin());
 
+const themeSelectorToggle = (page: any): Element | null =>
+  page.rootEl.querySelector('[data-setting="show_theme_selector"], .Form-group input[name="show_theme_selector"]') ??
+  Array.from(page.rootEl.querySelectorAll('.Form-group')).find((g: any) => /Show theme selector/i.test(g.textContent)) ??
+  null;
+
 describe('AppearancePage', () => {
   beforeAll(() => {
     app.boot();
@@ -14,5 +19,22 @@ describe('AppearancePage', () => {
     const page = mq(AppearancePage);
 
     expect(page).toHaveElement('.AppearancePage');
+  });
+
+  test('offers the show-theme-selector toggle when the forum leaves the scheme to the reader', () => {
+    app.data.settings.color_scheme = 'auto';
+
+    expect(themeSelectorToggle(mq(AppearancePage))).toBeTruthy();
+  });
+
+  test('hides the show-theme-selector toggle when the admin has forced a scheme', () => {
+    // There is nothing for a reader to switch, so surfacing the header control
+    // is not an option to offer — the same way the language selector toggle is
+    // absent when there is only one language.
+    app.data.settings.color_scheme = 'dark';
+
+    expect(themeSelectorToggle(mq(AppearancePage))).toBeFalsy();
+
+    app.data.settings.color_scheme = 'auto';
   });
 });

--- a/framework/core/js/tests/integration/common/components/Button.test.ts
+++ b/framework/core/js/tests/integration/common/components/Button.test.ts
@@ -70,3 +70,25 @@ describe('Button displays as expected', () => {
     expect(onclick).not.toHaveBeenCalled();
   });
 });
+
+describe('Button forwards noStyleOverride to its icon', () => {
+  beforeAll(() => app.boot());
+
+  afterEach(() => app.forum.pushAttributes({ fontAwesomeForcedStyle: null }));
+
+  it('rewrites the icon style by default when the forum forces one', () => {
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: 'fa-duotone fa-light' });
+
+    const button = mq(Button, { icon: 'fa-regular fa-sun' }, 'x');
+
+    expect(button.rootEl.querySelector('.Button-icon')?.className).not.toContain('fa-regular');
+  });
+
+  it('keeps the declared icon style when noStyleOverride is set', () => {
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: 'fa-duotone fa-light' });
+
+    const button = mq(Button, { icon: 'fa-regular fa-sun', noStyleOverride: true }, 'x');
+
+    expect(button.rootEl.querySelector('.Button-icon')?.className).toContain('fa-regular');
+  });
+});

--- a/framework/core/js/tests/integration/common/components/SelectDropdown.test.ts
+++ b/framework/core/js/tests/integration/common/components/SelectDropdown.test.ts
@@ -2,6 +2,7 @@ import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
 import SelectDropdown from '../../../../src/common/components/SelectDropdown';
 import mq from 'mithril-query';
 import m from 'mithril';
+import { app } from '../../../../src/forum';
 
 beforeAll(() => bootstrapForum());
 
@@ -156,5 +157,31 @@ describe('SelectDropdown renders an optional icon', () => {
     const select = mq(m(SelectDropdown, { label: 'Select', defaultLabel: 'Select', icon: 'fas fa-globe' }, buttons()));
 
     expect(select).toContainRaw('Option A');
+  });
+});
+
+describe('SelectDropdown forwards noStyleOverride to its toggle icon', () => {
+  beforeAll(() => app.boot());
+
+  afterEach(() => app.forum.pushAttributes({ fontAwesomeForcedStyle: null }));
+
+  it('keeps the declared toggle icon style when noStyleOverride is set', () => {
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: 'fa-duotone fa-light' });
+
+    const select = mq(
+      m(SelectDropdown, { icon: 'fa-regular fa-sun', noStyleOverride: true, defaultLabel: 'x' }, [m('button', { active: true }, 'A')])
+    );
+
+    expect(select.rootEl.querySelector('.Dropdown-toggle .Button-icon')?.className).toContain('fa-regular');
+  });
+
+  it('rewrites the toggle icon style by default when the forum forces one', () => {
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: 'fa-duotone fa-light' });
+
+    const select = mq(
+      m(SelectDropdown, { icon: 'fa-regular fa-sun', defaultLabel: 'x' }, [m('button', { active: true }, 'A')])
+    );
+
+    expect(select.rootEl.querySelector('.Dropdown-toggle .Button-icon')?.className).not.toContain('fa-regular');
   });
 });

--- a/framework/core/js/tests/integration/forum/components/HeaderSecondary.test.ts
+++ b/framework/core/js/tests/integration/forum/components/HeaderSecondary.test.ts
@@ -8,9 +8,55 @@ beforeAll(() => bootstrapForum());
 describe('HeaderSecondary', () => {
   beforeAll(() => app.boot());
 
+  beforeEach(() => {
+    // The forum leaves the choice to the reader, and surfaces the control, by
+    // default.
+    app.allowUserColorScheme = true;
+    app.forum.pushAttributes({ showThemeSelector: true });
+  });
+
   test('renders', () => {
     const header = mq(HeaderSecondary);
 
     expect(header).toBeTruthy();
+  });
+
+  test('includes the theme switcher', () => {
+    const header = mq(HeaderSecondary);
+
+    expect(header).toHaveElement('.ThemeSwitcher');
+  });
+
+  test('places the theme switcher just above the notifications control', () => {
+    // Notifications sit at 10 and only exist for a logged-in user. The switcher
+    // sits at 12 (higher priority renders further from the session controls),
+    // leaving 11 free for an extension that wants to slot between the two.
+    const items = new HeaderSecondary().items();
+
+    expect(items.has('themeSwitcher')).toBe(true);
+    expect(items.getPriority('themeSwitcher')).toBe(12);
+  });
+
+  test('hides the theme switcher when the forum has forced a theme', () => {
+    // When an admin fixes the forum's colour scheme there is nothing for the
+    // reader to choose, so the control does not appear — the same condition the
+    // user settings page uses to hide its theme section.
+    app.allowUserColorScheme = false;
+
+    const items = new HeaderSecondary().items();
+
+    expect(items.has('themeSwitcher')).toBe(false);
+    expect(mq(HeaderSecondary)).not.toHaveElement('.ThemeSwitcher');
+  });
+
+  test('hides the theme switcher when the admin has turned the selector off', () => {
+    // Users may still change theme from their settings; the admin has just
+    // chosen not to surface the header control.
+    app.forum.pushAttributes({ showThemeSelector: false });
+
+    const items = new HeaderSecondary().items();
+
+    expect(items.has('themeSwitcher')).toBe(false);
+    expect(mq(HeaderSecondary)).not.toHaveElement('.ThemeSwitcher');
   });
 });

--- a/framework/core/js/tests/integration/forum/components/ThemeSwitcher.test.ts
+++ b/framework/core/js/tests/integration/forum/components/ThemeSwitcher.test.ts
@@ -1,0 +1,236 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import { jest } from '@jest/globals';
+import ThemeSwitcher from '../../../../src/forum/components/ThemeSwitcher';
+import ThemeMode, { ColorScheme } from '../../../../src/common/components/ThemeMode';
+import { extend } from '../../../../src/common/extend';
+import type ItemList from '../../../../src/common/utils/ItemList';
+import { app } from '../../../../src/forum';
+import mq from 'mithril-query';
+
+beforeAll(() => bootstrapForum());
+
+const options = (rendered: any): Element[] => Array.from(rendered.rootEl.querySelectorAll('.Dropdown-menu button'));
+
+const optionModes = (rendered: any): (string | null)[] =>
+  options(rendered).map((el) => el.className.match(/ThemeSwitcher-option--([\w-]+)/)?.[1] ?? null);
+
+describe('ThemeSwitcher', () => {
+  beforeAll(() => app.boot());
+
+  const originalSchemes = ThemeMode.colorSchemes;
+  const originalIconItems = ThemeSwitcher.prototype.iconItems;
+  let user: any;
+
+  afterEach(() => {
+    // extend() replaces the method with a wrapper; put the original back so a
+    // registration in one test does not leak into the next.
+    ThemeSwitcher.prototype.iconItems = originalIconItems;
+  });
+
+  beforeEach(() => {
+    ThemeMode.colorSchemes = originalSchemes;
+    app.setColorScheme = jest.fn();
+    app.colorScheme = undefined as any;
+    app.session.user = undefined;
+    sessionStorage.clear();
+
+    user = {
+      preferences: jest.fn(() => ({ colorScheme: 'auto' })),
+      savePreferences: jest.fn(() => Promise.resolve()),
+    };
+  });
+
+  test('offers one option per registered colour scheme', () => {
+    const rendered = mq(ThemeSwitcher);
+
+    expect(optionModes(rendered).sort()).toEqual(ThemeMode.colorSchemes.map((s) => s.id).sort());
+  });
+
+  test('marks the active scheme', () => {
+    app.session.user = user;
+    user.preferences = jest.fn(() => ({ colorScheme: ColorScheme.Dark }));
+
+    const rendered = mq(ThemeSwitcher);
+
+    const current = rendered.rootEl.querySelector('.Dropdown-menu [aria-current="true"]');
+
+    expect(current?.querySelector(`.ThemeSwitcher-option--${ColorScheme.Dark}`)).toBeTruthy();
+  });
+
+  test('a guest change applies the scheme and remembers it for the tab session', () => {
+    app.session.user = undefined;
+
+    const rendered = mq(ThemeSwitcher);
+
+    rendered.click(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Dark}`);
+
+    expect(app.setColorScheme).toHaveBeenCalledWith(ColorScheme.Dark);
+    // Survives a reload, forgotten on tab close — sessionStorage is exactly
+    // that lifetime, and it is not sent to the server.
+    expect(sessionStorage.getItem('colorScheme')).toBe(ColorScheme.Dark);
+  });
+
+  test('a guest change is not saved to the server', () => {
+    app.session.user = undefined;
+
+    const rendered = mq(ThemeSwitcher);
+
+    rendered.click(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Dark}`);
+
+    expect(user.savePreferences).not.toHaveBeenCalled();
+  });
+
+  test('a logged-in change saves the preference the same way the settings page does', () => {
+    app.session.user = user;
+
+    const rendered = mq(ThemeSwitcher);
+
+    rendered.click(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Dark}`);
+
+    expect(user.savePreferences).toHaveBeenCalledWith({ colorScheme: ColorScheme.Dark });
+  });
+
+  test('a change is reflected as active immediately, without waiting on a reload', () => {
+    // The bug this guards: a guest change applied the theme but the control
+    // kept showing the old scheme as active, because nothing it read back had
+    // changed. The applied scheme is now the source of truth.
+    app.session.user = undefined;
+    (app.setColorScheme as jest.Mock).mockImplementation((scheme: string) => {
+      app.colorScheme = scheme;
+    });
+
+    const rendered = mq(ThemeSwitcher);
+    rendered.click(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Dark}`);
+    rendered.redraw();
+
+    const current = rendered.rootEl.querySelector('.Dropdown-menu [aria-current="true"]');
+    expect(current?.querySelector(`.ThemeSwitcher-option--${ColorScheme.Dark}`)).toBeTruthy();
+  });
+
+  test('a scheme registered by an extension appears', () => {
+    ThemeMode.colorSchemes = [...originalSchemes, { id: 'sepia', label: 'Sepia' }];
+
+    const rendered = mq(ThemeSwitcher);
+
+    expect(optionModes(rendered)).toContain('sepia');
+  });
+
+  test('a non-active option shows its own scheme icon', () => {
+    app.session.user = user;
+    user.preferences = jest.fn(() => ({ colorScheme: ColorScheme.Dark }));
+
+    const rendered = mq(ThemeSwitcher);
+
+    const light = rendered.rootEl.querySelector(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Light}`);
+
+    expect(light?.querySelector('.fa-sun')).toBeTruthy();
+    expect(light?.querySelector('.fa-check')).toBeFalsy();
+  });
+
+  test('the scheme icons use the current Font Awesome prefix', () => {
+    const rendered = mq(ThemeSwitcher);
+
+    // Normal contrast is the regular style, high contrast the solid one, so the
+    // two are distinguishable at a glance.
+    const dark = rendered.rootEl.querySelector(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Dark} .Button-icon`);
+    const darkHc = rendered.rootEl.querySelector(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.DarkHighContrast} .Button-icon`);
+
+    expect(dark?.className).toContain('fa-regular');
+    expect(darkHc?.className).toContain('fa-solid');
+  });
+
+  test('a forced Font Awesome style does not flatten the scheme icons', () => {
+    // The regular/solid distinction between normal and high contrast is the
+    // point; a forum-wide forced style must not rewrite it away.
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: 'fa-duotone fa-light' });
+
+    const rendered = mq(ThemeSwitcher);
+
+    const dark = rendered.rootEl.querySelector(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Dark} .Button-icon`);
+    const darkHc = rendered.rootEl.querySelector(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.DarkHighContrast} .Button-icon`);
+
+    expect(dark?.className).toContain('fa-regular');
+    expect(darkHc?.className).toContain('fa-solid');
+
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: null });
+  });
+
+  test('the active option is marked with a check', () => {
+    app.session.user = user;
+    user.preferences = jest.fn(() => ({ colorScheme: ColorScheme.Dark }));
+
+    const rendered = mq(ThemeSwitcher);
+
+    const active = rendered.rootEl.querySelector(`.Dropdown-menu button.ThemeSwitcher-option--${ColorScheme.Dark}`);
+
+    expect(active?.querySelector('.fa-check')).toBeTruthy();
+  });
+
+  test('the toggle shows the icon of the active scheme', () => {
+    app.colorScheme = ColorScheme.Dark;
+
+    const rendered = mq(ThemeSwitcher);
+
+    const toggleIcon = rendered.rootEl.querySelector('.Dropdown-toggle .Button-icon');
+
+    expect(toggleIcon?.className).toContain('fa-moon');
+  });
+
+  test('for the system preference, the toggle shows the icon of the resolved theme', () => {
+    // "Auto" has no icon of its own — it shows whatever the OS resolved to, so
+    // the control reflects what the reader is actually seeing.
+    app.colorScheme = ColorScheme.Auto;
+    app.getSystemColorSchemePreference = jest.fn(() => ColorScheme.Dark);
+
+    const rendered = mq(ThemeSwitcher);
+
+    const toggleIcon = rendered.rootEl.querySelector('.Dropdown-toggle .Button-icon');
+
+    expect(toggleIcon?.className).toContain('fa-moon');
+  });
+
+  test('an extension can register an icon for its own scheme', () => {
+    ThemeMode.colorSchemes = [...originalSchemes, { id: 'sepia', label: 'Sepia' }];
+    extend(ThemeSwitcher.prototype, 'iconItems', (items: ItemList<string>) => {
+      items.add('sepia', 'fa-solid fa-mug-hot');
+    });
+
+    const rendered = mq(ThemeSwitcher);
+
+    const sepia = rendered.rootEl.querySelector('.Dropdown-menu button.ThemeSwitcher-option--sepia .Button-icon');
+
+    expect(sepia?.className).toContain('fa-mug-hot');
+  });
+
+  test('a scheme with no registered icon falls back to the default', () => {
+    ThemeMode.colorSchemes = [...originalSchemes, { id: 'plain', label: 'Plain' }];
+
+    const rendered = mq(ThemeSwitcher);
+
+    const plain = rendered.rootEl.querySelector('.Dropdown-menu button.ThemeSwitcher-option--plain .Button-icon');
+
+    expect(plain?.className).toContain('fa-circle-half-stroke');
+  });
+
+  test('an extension can override the icon of a core scheme', () => {
+    app.colorScheme = ColorScheme.Dark;
+    extend(ThemeSwitcher.prototype, 'iconItems', (items: ItemList<string>) => {
+      items.setContent(ColorScheme.Dark, 'fa-solid fa-star');
+    });
+
+    const rendered = mq(ThemeSwitcher);
+
+    expect(rendered.rootEl.querySelector('.Dropdown-toggle .fa-star')).toBeTruthy();
+  });
+
+  test('the toggle carries a text label, so the mobile drawer can show it', () => {
+    app.session.user = user;
+    user.preferences = jest.fn(() => ({ colorScheme: ColorScheme.Dark }));
+
+    const rendered = mq(ThemeSwitcher);
+
+    const label = rendered.rootEl.querySelector('.Dropdown-toggle .Button-labelText');
+
+    expect(label?.textContent?.trim()).toBeTruthy();
+  });
+});

--- a/framework/core/js/tests/unit/common/Application.test.ts
+++ b/framework/core/js/tests/unit/common/Application.test.ts
@@ -342,3 +342,44 @@ describe('Application defers GET requests that fail while offline', () => {
     expect(resolvedB).toHaveBeenCalledWith(responseB);
   });
 });
+
+describe('Application restores a guest colour scheme for the tab session', () => {
+  const setColorScheme = jest.spyOn(app, 'setColorScheme').mockImplementation(() => {});
+
+  beforeEach(() => {
+    setColorScheme.mockClear();
+    sessionStorage.clear();
+    app.session.user = undefined as any;
+    app.forum.pushAttributes({ colorScheme: 'auto' });
+
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })) as any;
+  });
+
+  test('a scheme stored this session is applied on boot', () => {
+    sessionStorage.setItem('colorScheme', 'dark');
+
+    (app as any).initColorScheme();
+
+    expect(setColorScheme).toHaveBeenCalledWith('dark');
+  });
+
+  test('with nothing stored, the forum default applies', () => {
+    (app as any).initColorScheme();
+
+    expect(setColorScheme).toHaveBeenCalledWith('auto');
+  });
+
+  test('a forum-forced scheme ignores any stored guest choice', () => {
+    sessionStorage.setItem('colorScheme', 'dark');
+    app.forum.pushAttributes({ colorScheme: 'light' });
+
+    (app as any).initColorScheme();
+
+    expect(setColorScheme).toHaveBeenCalledWith('light');
+  });
+});

--- a/framework/core/less/forum/HeaderDropdown.less
+++ b/framework/core/less/forum/HeaderDropdown.less
@@ -20,6 +20,12 @@
       .Button--icon();
     }
   }
+
+  // The 425px above sizes the notification and message panels; a menu of short
+  // theme labels should hug its content instead.
+  .ThemeSwitcher .Dropdown-menu {
+    width: auto;
+  }
 }
 
 .HeaderDropdown .Dropdown-toggle.new .Button-icon {

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -127,6 +127,8 @@ core:
       logo_text: Upload an image to be displayed in place of the forum title.
       logo_dark_mode_heading: Dark mode logo
       logo_dark_mode_text: Upload an alternate logo to be displayed when dark mode is enabled.
+      show_theme_selector_help: Let users switch between the available color schemes from a control in the header.
+      show_theme_selector_label: Show theme selector
       title: Appearance
       color_scheme_label: Color Scheme (default)
       color_schemes:
@@ -640,6 +642,7 @@ core:
       session_dropdown_accessible_label: Toggle session options dropdown menu
       settings_button: => core.ref.settings
       sign_up_link: => core.ref.sign_up
+      theme_switcher_accessible_label: Change theme
 
     # These translations are used on the index page, peripheral to the discussion list.
     index:

--- a/framework/core/src/Api/Resource/ForumResource.php
+++ b/framework/core/src/Api/Resource/ForumResource.php
@@ -83,6 +83,8 @@ class ForumResource extends AbstractResource implements Findable
                 ->get(fn () => $this->settings->get('forum_description')),
             Schema\Boolean::make('showLanguageSelector')
                 ->get(fn () => $this->settings->get('show_language_selector', true)),
+            Schema\Boolean::make('showThemeSelector')
+                ->get(fn () => $this->settings->get('show_theme_selector', true)),
             Schema\Str::make('baseUrl')
                 ->get(fn () => $forumUrl),
             Schema\Str::make('basePath')

--- a/framework/core/src/Settings/SettingsServiceProvider.php
+++ b/framework/core/src/Settings/SettingsServiceProvider.php
@@ -24,11 +24,13 @@ class SettingsServiceProvider extends AbstractServiceProvider
             return new Collection([
                 'theme_primary_color' => '#4D698E',
                 'theme_secondary_color' => '#4D698E',
+                'color_scheme' => 'auto',
                 'mail_format' => 'multipart',
                 'fontawesome_source' => 'local',
                 'fontawesome_forced_style' => '',
                 'maintenance_mode' => 'none',
                 'show_language_selector' => true,
+                'show_theme_selector' => true,
                 'slug_driver_Flarum\Discussion\Discussion' => 'default',
                 'slug_driver_Flarum\User\User' => 'default',
                 'search_driver_Flarum\User\User' => 'default',


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

Adds a theme switcher to the header's secondary controls, so a reader can change colour scheme from anywhere without opening their settings. It's icon-only in the header (a labelled row in the mobile drawer), sitting just above the notifications control.

It surfaces the scheme system that already exists — the `ThemeMode` registry, the `colorScheme` user preference, and `Application.setColorScheme` — rather than adding a parallel one:

- A **logged-in** reader's choice is saved as their preference, via the exact same `savePreferences({ colorScheme })` call the settings page uses, so the two surfaces stay in sync.
- A **guest's** choice is kept in `sessionStorage`: it survives a page reload but is forgotten when the tab closes.

The control is hidden when it has nothing to offer:
- when the forum forces a scheme (the same `allowUserColorScheme` condition the settings page uses to hide its theme section), and
- when an admin turns off a new **"Show theme selector"** switch on the appearance page. That switch is itself only shown while the forum leaves the scheme to the reader — mirroring how the language-selector toggle appears only when there's more than one language.

Impacted: new `ForumSecondary` control (`ThemeSwitcher`), `HeaderSecondary`, `AppearancePage`, `Application` (a `colorScheme` field for the current choice), `Button` / `Dropdown` / `SelectDropdown` (see below), `ForumResource` + settings default, `core.yml`.

**Reviewers should focus on:**

- **`noStyleOverride` forwarding in `Button`, `Dropdown`, `SelectDropdown`.** The normal- and high-contrast schemes use the *regular* and *solid* styles of the same glyph to read apart, so a forum-wide forced Font Awesome style must not flatten them. Core already had `Icon`'s `noStyleOverride` for exactly this ("solid vs regular star conveying state"), but the button/dropdown components didn't forward it. I taught them to — a general improvement, not a switcher-only hack, so any style-dependent icon behind a button or dropdown is now protected.
- **Icon extensibility via `ItemList`.** `ThemeSwitcher.iconItems()` returns an `ItemList<string>` an extension can `add` to (icon for its own scheme), `setContent` on (override a core scheme's icon), or leave alone (fallback). Same mechanism as the rest of core's extensible lists.
- **The new `color_scheme` registered default (`'auto'`).** The setting had no registered default, so the admin page read `''` for it and the "show theme selector" toggle would have wrongly hidden on a fresh install. Adding the default fixes it at the source rather than guarding in JS; it flows through `DefaultSettingsRepository::all()` to every consumer.
- **Guest lifetime.** `sessionStorage`, read back only for guests (`initColorScheme` ignores it once a user is logged in) — reload-surviving, tab-close-forgetting, never sent to the server.

**Screenshot**

Header: an icon reflecting the *resolved* active scheme (a sun or moon — "System preference" shows whatever the OS resolved to). The dropdown lists each scheme with its icon; the active one shows a check.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension? — it drives core's own scheme system and adds a general button/dropdown capability; belongs in core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Backend changes: tests have been added, or are not appropriate here. — the backend change is a settings default + a resource attribute, mirroring the untested-in-that-way `show_language_selector`; no new backend test.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

New `ThemeSwitcher` test (17 cases: save/guest/sync behaviour, active marking, resolved-icon toggle, `ItemList` extensibility, FA prefix, forced-style survival), plus forwarding tests on `Button` and `SelectDropdown`, the `HeaderSecondary` gating cases, the `AppearancePage` conditional-toggle cases, and the `Application` guest-restore cases. Full frontend suite green (421), PHPStan clean.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
