### PR TITLE
[2.x] feat: surface search in the fixed mobile navigation

### DIFF
--- a/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
+++ b/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
@@ -8,10 +8,14 @@ import Icon from './Icon';
 import type Mithril from 'mithril';
 
 export interface SearchAttrs extends ComponentAttrs {
-  /** The type of alert this is. Will be used to give the alert a class name of `Alert--{type}`. */
   state: SearchState;
   label: string;
   a11yRoleLabel: string;
+  /**
+   * Render as a compact control for the fixed mobile navigation strip: an icon
+   * button rather than the full-width prompt, with no drawer to close first.
+   */
+  navigation?: boolean;
 }
 
 /**
@@ -102,14 +106,20 @@ export default abstract class AbstractGlobalSearch<T extends SearchAttrs = Searc
       app.modal.show(() => import('../../common/components/SearchModal'), { searchState: this.searchState, sources: this.sourceItems().toArray() });
     };
 
+    const navigation = !!this.attrs.navigation;
+
     return (
-      <div role="search" className={classList('Search', { 'Search--active': !!value })} aria-label={this.attrs.a11yRoleLabel}>
+      <div
+        role="search"
+        className={classList('Search', { 'Search--active': !!value, 'Search--navigation': navigation })}
+        aria-label={this.attrs.a11yRoleLabel}
+      >
         <button
           type="button"
           // `Button--flat` rather than `Button--link`: this sits among the
           // notification and message controls, which are flat buttons, and
           // should pick up the same hover and focus treatment as them.
-          className="Search-input Button Button--flat"
+          className={classList('Search-input Button Button--flat', { 'Button--icon': navigation })}
           aria-label={
             value
               ? extractText(app.translator.trans('core.lib.search.search_active_button_accessible_label', { query: value }))
@@ -117,6 +127,13 @@ export default abstract class AbstractGlobalSearch<T extends SearchAttrs = Searc
           }
           title={value || extractText(this.attrs.label)}
           onclick={() => {
+            if (navigation) {
+              // This control sits in the fixed mobile strip, not the drawer, so
+              // there is nothing to close first.
+              openSearchModal();
+              return;
+            }
+
             // On phones the search button lives inside the slide-out drawer. Close the drawer as soon as
             // search is activated, before the modal is shown, so it isn't left open behind (and overlapping)
             // the full-screen search modal as it animates in. Hiding it here rather than in `openSearchModal`

--- a/framework/core/js/src/common/components/Navigation.tsx
+++ b/framework/core/js/src/common/components/Navigation.tsx
@@ -4,12 +4,14 @@ import Button from './Button';
 import LinkButton from './LinkButton';
 import type Mithril from 'mithril';
 import classList from '../utils/classList';
+import ItemList from '../utils/ItemList';
 
 /**
- * The `Navigation` component displays a set of navigation buttons. Typically
- * this is just a back button which pops the app's History. If the user is on
- * the root page and there is no history to pop, then in some instances it may
- * show a button that toggles the app's drawer.
+ * The `Navigation` component displays a set of navigation buttons. In `drawer`
+ * mode — the fixed control strip at the top of the mobile layout — the drawer
+ * toggle is always present, so the menu and the notification badge it carries
+ * stay reachable on every page; the back button joins it only when there is
+ * history to pop. Elsewhere (the desktop header) it is the back button alone.
  *
  * If the app has a pane, it will also include a 'pin' button which toggles the
  * pinned state of the pane.
@@ -17,12 +19,13 @@ import classList from '../utils/classList';
  * Accepts the following attrs:
  *
  * - `className` The name of a class to set on the root element.
- * - `drawer` Whether or not to show a button to toggle the app's drawer if
- *   there is no more history to pop.
+ * - `drawer` Whether or not to show a button to toggle the app's drawer.
+ * - `search` A rendered search control to include in `drawer` mode, so search
+ *   is reachable from the fixed mobile strip on every page.
  */
 export default class Navigation extends Component {
   view() {
-    const { history, pane } = app;
+    const { pane } = app;
 
     return (
       <div
@@ -30,9 +33,43 @@ export default class Navigation extends Component {
         onmouseenter={pane && pane.show.bind(pane)}
         onmouseleave={pane && pane.onmouseleave.bind(pane)}
       >
-        {history?.canGoBack() ? [this.getBackButton(), this.getPaneButton()] : this.getDrawerButton()}
+        {this.items().toArray()}
       </div>
     );
+  }
+
+  /**
+   * The controls shown in the navigation, as an ItemList so that other parts of
+   * the app — and extensions — can contribute their own. The forum app adds a
+   * search control here in `drawer` mode.
+   */
+  items(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    if (this.attrs.drawer) {
+      items.add('drawer', this.getDrawerButton(), 100);
+
+      // A search control supplied by the frontend — the forum passes one, so
+      // search is reachable on every page from the fixed mobile strip rather
+      // than only from inside the drawer. Kept generic (a rendered child, not a
+      // component reference) so this common component stays free of any
+      // forum-only import.
+      if (this.attrs.search) {
+        items.add('search', this.attrs.search, 95);
+      }
+    }
+
+    if (app.history?.canGoBack()) {
+      items.add('back', this.getBackButton(), 90);
+
+      const paneButton = this.getPaneButton();
+
+      if (paneButton) {
+        items.add('pane', paneButton, 80);
+      }
+    }
+
+    return items;
   }
 
   /**

--- a/framework/core/js/src/forum/ForumApplication.tsx
+++ b/framework/core/js/src/forum/ForumApplication.tsx
@@ -5,6 +5,7 @@ import Pane from './utils/Pane';
 import DiscussionPage from './components/DiscussionPage';
 import HeaderPrimary from './components/HeaderPrimary';
 import HeaderSecondary from './components/HeaderSecondary';
+import GlobalSearch from './components/GlobalSearch';
 import DiscussionRenamedNotification from './components/DiscussionRenamedNotification';
 import CommentPost from './components/CommentPost';
 import DiscussionRenamedPost from './components/DiscussionRenamedPost';
@@ -117,7 +118,9 @@ export default class ForumApplication extends Application {
 
     // We mount navigation and header components after the page, so components
     // like the back button can access the updated state when rendering.
-    m.mount(document.getElementById('app-navigation')!, { view: () => <Navigation className="App-backControl" drawer /> });
+    m.mount(document.getElementById('app-navigation')!, {
+      view: () => <Navigation className="App-backControl" drawer search={<GlobalSearch state={this.search.state} navigation />} />,
+    });
     m.mount(document.getElementById('header-navigation')!, Navigation);
     m.mount(document.getElementById('header-primary')!, HeaderPrimary);
     m.mount(document.getElementById('header-secondary')!, HeaderSecondary);

--- a/framework/core/js/tests/integration/common/components/Navigation.test.ts
+++ b/framework/core/js/tests/integration/common/components/Navigation.test.ts
@@ -1,12 +1,30 @@
 import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import { jest } from '@jest/globals';
 import Navigation from '../../../../src/common/components/Navigation';
+import type ItemList from '../../../../src/common/utils/ItemList';
+import { extend } from '../../../../src/common/extend';
 import { app } from '../../../../src/forum';
+import m from 'mithril';
+import type Mithril from 'mithril';
 import mq from 'mithril-query';
 
 beforeAll(() => bootstrapForum());
 
 describe('Navigation', () => {
   beforeAll(() => app.boot());
+
+  const originalItems = Navigation.prototype.items;
+
+  const setCanGoBack = (value: boolean) => {
+    jest.spyOn(app.history, 'canGoBack').mockReturnValue(value);
+    jest.spyOn(app.history, 'backUrl').mockReturnValue('/');
+    jest.spyOn(app.history, 'getPrevious').mockReturnValue({ name: 'x', title: 'Previous', url: '/' } as any);
+  };
+
+  afterEach(() => {
+    Navigation.prototype.items = originalItems;
+    jest.restoreAllMocks();
+  });
 
   test('renders as normal nav', () => {
     const nav = mq(Navigation);
@@ -18,5 +36,60 @@ describe('Navigation', () => {
     const nav = mq(Navigation, { drawer: true });
 
     expect(nav).toBeTruthy();
+  });
+
+  test('the drawer toggle stays available even when there is history to go back to', () => {
+    // The flaw this fixes: the drawer toggle used to be replaced by the back
+    // button off the home page, so the menu — and the notification badge it
+    // carries — became unreachable until the reader navigated home.
+    setCanGoBack(true);
+
+    const nav = mq(Navigation, { drawer: true });
+
+    expect(nav).toHaveElement('.Navigation-drawer');
+  });
+
+  test('the back button appears only when there is history to go back to', () => {
+    setCanGoBack(true);
+    expect(mq(Navigation, { drawer: true })).toHaveElement('.Navigation-back');
+
+    jest.restoreAllMocks();
+    setCanGoBack(false);
+    expect(mq(Navigation, { drawer: true })).not.toHaveElement('.Navigation-back');
+  });
+
+  test('without drawer mode there is no drawer toggle', () => {
+    // The desktop header uses Navigation without `drawer`, and must keep its
+    // back-only behaviour.
+    setCanGoBack(true);
+
+    const nav = mq(Navigation, {});
+
+    expect(nav).not.toHaveElement('.Navigation-drawer');
+    expect(nav).toHaveElement('.Navigation-back');
+  });
+
+  test('a supplied search control is shown in drawer mode', () => {
+    const nav = mq(Navigation, { drawer: true, search: m('button', { className: 'my-search' }) });
+
+    expect(nav).toHaveElement('.my-search');
+  });
+
+  test('a supplied search control is ignored outside drawer mode', () => {
+    // The desktop header carries its own search; the strip control is a
+    // mobile-only affordance.
+    const nav = mq(Navigation, { search: m('button', { className: 'my-search' }) });
+
+    expect(nav).not.toHaveElement('.my-search');
+  });
+
+  test('an extension can add its own control to the group', () => {
+    extend(Navigation.prototype, 'items', (items: ItemList<Mithril.Children>) => {
+      items.add('custom', m('button', { className: 'my-nav-control' }), 5);
+    });
+
+    const nav = mq(Navigation, { drawer: true });
+
+    expect(nav).toHaveElement('.my-nav-control');
   });
 });

--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -191,3 +191,39 @@
   color: transparent;
 }
 
+
+// The mobile navigation strip carries its own search control, so the copy that
+// lives in the drawer (part of the secondary header) is redundant there and is
+// hidden on phones. It remains on wider screens, where the secondary header is
+// the top bar rather than the drawer.
+@media @phone {
+  .Header-secondary .Search {
+    display: none;
+  }
+}
+
+// The search control in the fixed mobile navigation strip: an icon button
+// sitting alongside the drawer toggle and back button, matching their size and
+// flat treatment rather than the full-width prompt shown elsewhere. When a
+// search is active the clear button sits beside it, so the query can be cleared
+// in one tap rather than by reopening the modal.
+.Search--navigation {
+  .Search-input {
+    .Button--icon();
+  }
+
+  // The clear button reads as part of the search control, not a separate one,
+  // so it tucks against the magnifier rather than sitting a full icon-width
+  // away. It is also a touch smaller — it is a secondary affordance next to the
+  // control it belongs to.
+  .Search-clear {
+    .Button--icon();
+    width: auto;
+    margin-left: -8px;
+    padding: 8px 4px;
+
+    .Button-icon {
+      font-size: 13px;
+    }
+  }
+}


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

On phones the header — search, notifications, and the rest of the secondary controls — *is* the slide-out drawer. So search was reachable only after opening the menu, and, worse, the drawer toggle was **replaced** by the back button off the home page: the menu, and the notification badge it carries, became unreachable until the reader navigated home.

This reworks the fixed mobile control strip so it:

- keeps the **drawer toggle present on every page** (fixing the unreachable-menu / vanishing-notification-badge flaw),
- adds a **search control** beside it — a compact icon that opens the existing search modal, with a clear button appearing next to it when a search is active (one-tap clear, no reopening the modal),
- shows the **back button only when there is history** to go back to (an optional slot, not an either/or with the menu).

`Navigation`'s contents are now an `ItemList`, so the strip is extensible like the app's other control rows. The search control is passed in as a **rendered child** rather than imported, keeping this common component free of any forum-only dependency: the forum supplies search, the admin app doesn't. The desktop header (which uses `Navigation` without `drawer` mode) is unchanged and keeps its own search in the secondary header; the drawer copy is hidden on phones so search isn't duplicated.

The admin app gains the same always-present drawer toggle, since it shared the flaw.

Impacted: `Navigation`, `AbstractGlobalSearch` (a `navigation` compact mode), `ForumApplication` (mounts the strip's search), `Search.less`.

**Reviewers should focus on:**

- **The either/or → ItemList change in `Navigation`.** Previously `canGoBack() ? [back, pane] : [drawer]`. Now, in `drawer` mode, the drawer toggle is always present and back joins it conditionally. Non-drawer usage (the desktop header) is unchanged — worth confirming that split reads cleanly.
- **Keeping `Navigation` free of a forum import.** Search is passed as a `search` attr (a rendered child), not by importing the forum's `GlobalSearch` into this common component. That's what lets admin reuse `Navigation` without pulling in forum search. Open to a different seam if you'd prefer one.
- **No `<li>` wrapping.** The items render via `toArray()` directly, not `listItems()` — the strip is a button group, and wrapping each control in an `<li>` broke the fixed-control CSS (`.App-backControl > .Button`). Flagging since it differs from how menu ItemLists render.
- **The drawer search is hidden on phones via CSS**, not removed — desktop still needs it in the secondary header.

**Screenshot**

Phone, discussion page: hamburger (with notification dot) + search + back, all in the left group — previously the hamburger would have been replaced by back. Search opens the full-screen modal; an active search shows a clear ✕ beside the magnifier.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension? — it reworks core's own mobile navigation and fixes a menu-reachability flaw.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — validated across phone/tablet/desktop viewports on a dev forum.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [ ] Backend changes: tests are green — no backend changes
- [ ] Backend changes: tests have been added — no backend changes
- [ ] Where applicable, changes are suitable for all supported database drivers — no DB changes
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

`Navigation` tests cover: drawer toggle always present in drawer mode; back only when `canGoBack()`; a supplied search control shown in drawer mode and ignored elsewhere; the ItemList is extensible. Full frontend suite green (427).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
