### PR TITLE
[2.x] fix: only show the button focus background for keyboard focus

### DIFF
--- a/framework/core/less/common/Button.less
+++ b/framework/core/less/common/Button.less
@@ -118,7 +118,7 @@
   }
 
   &:hover,
-  &:focus,
+  &:focus-visible,
   &.focus {
     background-color: var(--button-bg-hover);
   }
@@ -156,7 +156,7 @@
   }
   &:active,
   &.active,
-  &:focus,
+  &:focus-visible,
   &.focus,
   .open > &.Dropdown-toggle {
     background: transparent !important;


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

A flat button kept its hover background after a modal opened from it closed. Steps: click a button that opens a modal (the search control is the clearest case), then dismiss the modal — the button is left showing the hover background, with no focus ring to explain it.

Cause: the modal's focus trap returns focus to the button it was opened from when it closes. That is correct for keyboard users, but the button's background is applied on `:focus`, which fires for **mouse and programmatic focus too** — while the keyboard focus *ring* already uses `:focus-visible`. So on a mouse-driven open/close the background turned on but the ring did not, leaving the stuck highlight.

This makes the two agree: the background, like the ring, now uses `:focus-visible`, so returning focus after a click leaves no highlight. `.Button--flat` / base `.Button` background and `.Button--link`'s focus colour change are both moved. The `:focus` z-index bump on a grouped button stays as-is — it is stacking, not a visible highlight, and should apply however focus arrived.

Impacted: `less/common/Button.less` (two selectors).

**Reviewers should focus on:**

- **That `&.focus` (the explicit class) is kept** alongside, so anything that programmatically wants the highlight still gets it — only the automatic `:focus` is narrowed to `:focus-visible`.
- **Whether both migrated sites are the right ones.** I moved the base-button background and `Button--link`'s colour change (both are visible states that would stick); I deliberately left the ButtonGroup `:focus { z-index }` alone.

**Screenshot**

No layout change. The difference is that a button clicked with a mouse no longer keeps a highlight after focus returns to it (e.g. after closing the search modal). Keyboard focus is unchanged — it still shows the background and the focus ring.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — `:focus-visible` matches the existing keyboard-focus-ring approach.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — core button styles.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [ ] Frontend changes: tests have been added, or are not appropriate here. — CSS-only; `:focus-visible` is a browser heuristic jsdom does not evaluate, so there is nothing meaningful to assert in a unit test.
- [ ] Backend changes: tests are green — no backend changes
- [ ] Backend changes: tests have been added — no backend changes
- [ ] Where applicable, changes are suitable for all supported database drivers — no DB changes
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
