### PR TITLE
[2.x] fix: resolve differently-cased tag slugs in Utf8SlugDriver::fromSlugs()

### DIFF
--- a/extensions/tags/src/Utf8SlugDriver.php
+++ b/extensions/tags/src/Utf8SlugDriver.php
@@ -54,9 +54,18 @@ class Utf8SlugDriver implements SlugDriverInterface, BatchSlugDriverInterface
         // Map decoded slug (the stored column value) back to the caller's input
         // slug, so the returned collection is keyed exactly as it was queried —
         // matching fromSlug()'s urldecode() while staying transparent to callers.
-        $decodedToInput = [];
+        //
+        // The lookup is keyed case-insensitively: Flarum's default collation
+        // (utf8mb4_unicode_ci) makes the WHERE IN match differently-cased slugs,
+        // so a query for "Extensions" can return the stored "extensions" row.
+        // Keying on the raw stored slug would then miss the input entry and
+        // raise "Undefined array key". Fold both sides to compare like-for-like.
+        $foldedToInput = [];
+        $decodedSlugs = [];
         foreach ($slugs as $slug) {
-            $decodedToInput[urldecode($slug)] = $slug;
+            $decoded = urldecode($slug);
+            $decodedSlugs[] = $decoded;
+            $foldedToInput[mb_strtolower($decoded)] = $slug;
         }
 
         /** @var Collection<string, Tag> $map */
@@ -64,13 +73,16 @@ class Utf8SlugDriver implements SlugDriverInterface, BatchSlugDriverInterface
 
         $tags = $this->repository
             ->query()
-            ->whereIn('slug', array_keys($decodedToInput))
+            ->whereIn('slug', $decodedSlugs)
             ->whereVisibleTo($actor)
             ->get();
 
         /** @var Tag $tag */
         foreach ($tags as $tag) {
-            $map[$decodedToInput[$tag->slug]] = $tag;
+            // Fall back to the tag's own slug if the folded input is somehow
+            // absent, so a returned row is never dropped and never warns.
+            $input = $foldedToInput[mb_strtolower($tag->slug)] ?? $tag->slug;
+            $map[$input] = $tag;
         }
 
         return $map;

--- a/extensions/tags/tests/integration/Utf8SlugDriverTest.php
+++ b/extensions/tags/tests/integration/Utf8SlugDriverTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Tests\integration;
+
+use Flarum\Tags\Tag;
+use Flarum\Tags\TagRepository;
+use Flarum\Tags\Utf8SlugDriver;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use PHPUnit\Framework\Attributes\Test;
+
+class Utf8SlugDriverTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use RetrievesRepresentativeTags;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            Tag::class => $this->tags(),
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * The reverse map in fromSlugs() keys on the *input* slug string, but the
+     * loop keys on the *stored* slug returned by the query. Under a
+     * case/accent-insensitive collation (Flarum's default utf8mb4_unicode_ci)
+     * the stored slug can differ from the queried input — e.g. searching
+     * "Extensions" matches the stored "extensions" row. When it does, the
+     * original code hit `$decodedToInput[$tag->slug]` with a key that was never
+     * inserted, raising "Undefined array key" (the discuss production error at
+     * Utf8SlugDriver.php:73).
+     *
+     * This drives the driver directly with a repository whose query returns a
+     * tag whose slug differs from the input, so the assertion holds on every
+     * database driver (SQLite included) regardless of its collation.
+     */
+    #[Test]
+    public function from_slugs_maps_a_differently_cased_stored_slug_without_warning(): void
+    {
+        $this->app();
+
+        // A real tag whose stored slug is lower-case.
+        $stored = Tag::query()->where('slug', 'primary-1')->firstOrFail();
+
+        // The query matched it via a differently-cased input ("Primary-1"),
+        // as a case-insensitive collation would. The returned row still carries
+        // the stored slug, not the input.
+        $repository = new class($stored) extends TagRepository {
+            public function __construct(private Tag $stored)
+            {
+            }
+
+            public function query(): Builder
+            {
+                $builder = Tag::query();
+
+                // Wrap the builder so get() yields our stored tag regardless of
+                // the (case-sensitive, on SQLite) WHERE IN that would otherwise
+                // miss the differently-cased input.
+                return new class($builder->getQuery(), $this->stored) extends Builder {
+                    public function __construct($query, private Tag $stored)
+                    {
+                        parent::__construct($query);
+                        $this->setModel(new Tag());
+                    }
+
+                    public function get($columns = ['*']): EloquentCollection
+                    {
+                        return new EloquentCollection([$this->stored]);
+                    }
+                };
+            }
+        };
+
+        $driver = new Utf8SlugDriver($repository);
+
+        $actor = User::find(1);
+
+        // Input slug differs in case from the stored "primary-1".
+        $map = $driver->fromSlugs(['Primary-1'], $actor);
+
+        // The collection is keyed by the caller's input slug, and resolves to
+        // the stored tag — no "Undefined array key" warning (PHPUnit turns
+        // warnings into failures).
+        $this->assertTrue($map->has('Primary-1'));
+        $this->assertSame($stored->id, $map->get('Primary-1')->id);
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**

`Utf8SlugDriver::fromSlugs()` (the batch slug driver behind the "Default" tag slug driver) raised `Undefined array key` and dropped the matched tag whenever a tag was searched by a differently-cased or accented form of its slug — e.g. `filter[tag]=Extensions` matching the stored `extensions` tag.

Cause: `fromSlugs()` built a reverse map keyed on the caller's **input** slug, then in the result loop looked that map up by the **stored** `$tag->slug`. Under Flarum's default collation (`utf8mb4_unicode_ci`, case- and accent-insensitive), the `WHERE IN` matches rows whose stored slug differs from the input, so `$decodedToInput[$tag->slug]` was keyed with a string that was never inserted. That both raised a PHP warning and, because the resulting key was `null`/undefined, failed to key the tag into the returned collection.

`fromSlug()` (the single-slug path) is unaffected — it returns the row directly and never does the reverse-map lookup.

The fix folds both the input-map keys and the returned `$tag->slug` with `mb_strtolower` before matching, so the lookup succeeds regardless of the case/accent difference the collation introduced, and falls back to the tag's own slug if an entry is somehow absent so a returned row is never dropped.

This was found in production logs on a live install (the driver in use there is "Default" = `Utf8SlugDriver`); the error fired repeatedly, most plausibly from crawlers or copy-pasted mixed-case tag URLs.

Impacted: `extensions/tags/src/Utf8SlugDriver.php`.

**Reviewers should focus on:**

- **The folding choice.** `mb_strtolower` matches the case-insensitivity of the default collation. Installs on a case-*sensitive* collation never hit the mismatch in the first place, and folding is harmless there because the stored and input slugs are already byte-identical.
- **The fallback (`?? $tag->slug`).** It guarantees a returned tag is always keyed into the map even if an input entry can't be matched, so this method can no longer silently drop a resolved tag.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — folding both sides is the minimal change that matches the collation's own semantics; canonicalising slugs at write time or forcing a binary `WHERE IN` would be far larger and change matching behaviour.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — this is in the `flarum/tags` extension, where the driver lives.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no frontend changes.
- [ ] Frontend changes: tests are green — no frontend changes.
- [ ] Frontend changes: tests have been added — no frontend changes.
- [x] Backend changes: tests are green (`composer test:integration` in `extensions/tags`).
- [x] Backend changes: tests have been added — `Utf8SlugDriverTest` reproduces the exact `Undefined array key` failure first, then passes with the fix; driver-agnostic so it reproduces on SQLite as well as the CI case-insensitive drivers.
- [x] Where applicable, changes are suitable for all supported database drivers — the fix is pure PHP string folding, no DB behaviour change; verified against the SQLite runner and reasoned through the MySQL/MariaDB/PostgreSQL collations that surface the bug.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
