### PR TITLE
[2.x] fix: route notification emails through the queue router regardless of provider boot order

### DIFF
--- a/framework/core/src/Notification/Driver/EmailNotificationDriver.php
+++ b/framework/core/src/Notification/Driver/EmailNotificationDriver.php
@@ -44,6 +44,7 @@ readonly class EmailNotificationDriver implements NotificationDriverInterface
         // (QueueServiceProvider::boot). Capturing the connection in the constructor
         // would grab the unwrapped driver and bypass routing, so mail jobs would
         // fall through to the `default` queue instead of `mail`.
+        /** @var Queue $queue */
         $queue = $this->container->make(Queue::class);
 
         foreach ($recipients as $user) {

--- a/framework/core/src/Notification/Driver/EmailNotificationDriver.php
+++ b/framework/core/src/Notification/Driver/EmailNotificationDriver.php
@@ -13,13 +13,14 @@ use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Job\SendEmailNotificationJob;
 use Flarum\Notification\MailableInterface;
 use Flarum\User\User;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use ReflectionClass;
 
 readonly class EmailNotificationDriver implements NotificationDriverInterface
 {
     public function __construct(
-        private Queue $queue
+        private Container $container
     ) {
     }
 
@@ -37,9 +38,17 @@ readonly class EmailNotificationDriver implements NotificationDriverInterface
      */
     protected function mailNotifications(MailableInterface&BlueprintInterface $blueprint, array $recipients): void
     {
+        // Resolve the queue connection at push time, not construction time. This
+        // driver is built at boot by NotificationServiceProvider; the RoutingQueue
+        // wrapper that places jobs onto their registered queue is applied later
+        // (QueueServiceProvider::boot). Capturing the connection in the constructor
+        // would grab the unwrapped driver and bypass routing, so mail jobs would
+        // fall through to the `default` queue instead of `mail`.
+        $queue = $this->container->make(Queue::class);
+
         foreach ($recipients as $user) {
             if ($user->shouldEmail($blueprint::getType())) {
-                $this->queue->push(new SendEmailNotificationJob($blueprint, $user));
+                $queue->push(new SendEmailNotificationJob($blueprint, $user));
             }
         }
     }

--- a/framework/core/tests/integration/queue/NotificationQueueRoutingTest.php
+++ b/framework/core/tests/integration/queue/NotificationQueueRoutingTest.php
@@ -1,0 +1,271 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\queue;
+
+use Flarum\Extend;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Driver\EmailNotificationDriver;
+use Flarum\Notification\Job\SendEmailNotificationJob;
+use Flarum\Notification\MailableInterface;
+use Flarum\Notification\NotificationSyncer;
+use Flarum\Queue\RoutingQueue;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The email notification driver must push jobs through the routing queue, so a
+ * job routed (e.g. by fof/horizon) onto the `mail` queue actually lands there
+ * instead of falling through to `default`.
+ *
+ * Regression: the driver is constructed at boot by NotificationServiceProvider,
+ * which captured whatever queue was bound at that instant. Because the
+ * RoutingQueue wrapper is applied in QueueServiceProvider::boot() and
+ * NotificationServiceProvider booted first, the long-lived driver held the raw,
+ * unwrapped connection — so every notification email bypassed routing and was
+ * pushed to `default` (tries=1), tombstoning on any worker recycle.
+ */
+class NotificationQueueRoutingTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * End to end: with SendEmailNotificationJob routed onto `mail`, sending a
+     * mailable notification through the registered driver must enqueue the job
+     * on `mail`, not `default`. A recording queue is installed as the underlying
+     * connection so the routed queue name can be asserted without depending on a
+     * physical jobs table.
+     *
+     * This is the core regression guard. With the boot-order bug, the driver
+     * captured the connection at construction — before the RoutingQueue wrapper
+     * was applied — so the route was never consulted and the job was pushed with
+     * no queue (falling through to `default`) instead of `mail`.
+     */
+    #[Test]
+    public function sending_a_mailable_notification_routes_the_job_onto_its_queue(): void
+    {
+        $recorder = new RecordingQueue();
+        RecordingQueueServiceProvider::$recorder = $recorder;
+
+        $this->extend(
+            (new Extend\Queue())->route(SendEmailNotificationJob::class, 'mail'),
+            (new Extend\ServiceProvider())->register(RecordingQueueServiceProvider::class),
+            // Register the mailable blueprint with the email driver enabled by
+            // default, so the recipient's shouldEmail() is true and a job is pushed.
+            (new Extend\Notification())->type(TestMailableBlueprint::class, ['email'])
+        );
+
+        $this->app();
+
+        /** @var EmailNotificationDriver $email */
+        $email = NotificationSyncer::getNotificationDrivers()['email'];
+
+        $email->send(new TestMailableBlueprint(), [User::find(1)]);
+
+        $this->assertCount(1, $recorder->pushed, 'Exactly one notification email job should be pushed.');
+        $this->assertSame(
+            'mail',
+            $recorder->pushed[0]['queue'],
+            'The notification email job must be routed onto the `mail` queue, not fall through to `default`.'
+        );
+    }
+
+    /**
+     * Installs without any queue routing (a plain database or Redis queue with
+     * no Horizon) must be unaffected: with no route registered, the job is pushed
+     * with no explicit queue and falls through to the driver's own default —
+     * exactly as before this fix.
+     */
+    #[Test]
+    public function without_a_route_the_job_uses_the_driver_default_queue(): void
+    {
+        $recorder = new RecordingQueue();
+        RecordingQueueServiceProvider::$recorder = $recorder;
+
+        $this->extend(
+            // No Extend\Queue route registered.
+            (new Extend\ServiceProvider())->register(RecordingQueueServiceProvider::class),
+            (new Extend\Notification())->type(TestMailableBlueprint::class, ['email'])
+        );
+
+        $this->app();
+
+        /** @var EmailNotificationDriver $email */
+        $email = NotificationSyncer::getNotificationDrivers()['email'];
+
+        $email->send(new TestMailableBlueprint(), [User::find(1)]);
+
+        $this->assertCount(1, $recorder->pushed, 'The notification email job should still be pushed.');
+        $this->assertNull(
+            $recorder->pushed[0]['queue'],
+            'With no route, the job must be pushed with no explicit queue so the driver default applies.'
+        );
+    }
+
+    /**
+     * On a sync-queue install there is no separate queue to route onto; the
+     * connection is intentionally left unwrapped (a bare SyncQueue) so jobs run
+     * inline on push and `instanceof SyncQueue` detection keeps working. The
+     * driver resolves this same connection, so nothing about routing interferes
+     * with sync installs. (Inline execution itself is covered by the existing
+     * notification integration tests.)
+     */
+    #[Test]
+    public function sync_queue_connection_stays_unwrapped_for_the_driver(): void
+    {
+        // No queue config → the default sync driver.
+        $this->app();
+
+        $queue = $this->app()->getContainer()->make(\Illuminate\Contracts\Queue\Queue::class);
+
+        $this->assertInstanceOf(
+            \Illuminate\Queue\SyncQueue::class,
+            $queue,
+            'The sync connection must stay unwrapped so inline execution and SyncQueue detection keep working; '.
+            'the driver resolves this same connection at push time.'
+        );
+        $this->assertNotInstanceOf(RoutingQueue::class, $queue);
+    }
+}
+
+/**
+ * A minimal async-style queue that records what it was asked to push, so the
+ * routed queue name can be asserted. It is not a SyncQueue, so the
+ * QueueServiceProvider wraps it in a RoutingQueue exactly as a real driver.
+ */
+class RecordingQueue extends \Illuminate\Queue\Queue implements \Illuminate\Contracts\Queue\Queue
+{
+    /** @var array<int, array{job: mixed, queue: ?string}> */
+    public array $pushed = [];
+
+    public function push($job, $data = '', $queue = null)
+    {
+        $this->pushed[] = ['job' => $job, 'queue' => $queue];
+
+        return null;
+    }
+
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        return null;
+    }
+
+    public function later($delay, $job, $data = '', $queue = null)
+    {
+        $this->pushed[] = ['job' => $job, 'queue' => $queue];
+
+        return null;
+    }
+
+    public function pop($queue = null)
+    {
+        return null;
+    }
+
+    public function size($queue = null)
+    {
+        return 0;
+    }
+
+    public function pendingSize($queue = null)
+    {
+        return 0;
+    }
+
+    public function delayedSize($queue = null)
+    {
+        return 0;
+    }
+
+    public function reservedSize($queue = null)
+    {
+        return 0;
+    }
+
+    public function creationTimeOfOldestPendingJob($queue = null)
+    {
+        return null;
+    }
+
+    public function getConnectionName()
+    {
+        return 'recording';
+    }
+
+    public function setConnectionName($name)
+    {
+        return $this;
+    }
+}
+
+class RecordingQueueServiceProvider extends \Flarum\Foundation\AbstractServiceProvider
+{
+    public static ?RecordingQueue $recorder = null;
+
+    public function register(): void
+    {
+        $this->container->extend('flarum.queue.connection', function ($queue, $container) {
+            $recorder = static::$recorder;
+            $recorder->setContainer($container);
+
+            return $recorder;
+        });
+    }
+}
+
+class TestMailableBlueprint implements BlueprintInterface, MailableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?\Flarum\Database\AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): mixed
+    {
+        return null;
+    }
+
+    public static function getType(): string
+    {
+        return 'testMailable';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return User::class;
+    }
+
+    public function getEmailViews(): array
+    {
+        return ['text' => 'flarum.forum::default', 'html' => 'flarum.forum::default'];
+    }
+
+    public function getEmailSubject(\Flarum\Locale\TranslatorInterface $translator): string
+    {
+        return 'Test';
+    }
+}

--- a/framework/core/tests/integration/queue/NotificationQueueRoutingTest.php
+++ b/framework/core/tests/integration/queue/NotificationQueueRoutingTest.php
@@ -15,7 +15,6 @@ use Flarum\Notification\Driver\EmailNotificationDriver;
 use Flarum\Notification\Job\SendEmailNotificationJob;
 use Flarum\Notification\MailableInterface;
 use Flarum\Notification\NotificationSyncer;
-use Flarum\Queue\RoutingQueue;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -137,13 +136,14 @@ class NotificationQueueRoutingTest extends TestCase
 
         $queue = $this->app()->getContainer()->make(\Illuminate\Contracts\Queue\Queue::class);
 
+        // A bare SyncQueue (not a RoutingQueue) confirms the connection is left
+        // unwrapped, so inline execution and SyncQueue detection keep working.
         $this->assertInstanceOf(
             \Illuminate\Queue\SyncQueue::class,
             $queue,
             'The sync connection must stay unwrapped so inline execution and SyncQueue detection keep working; '.
             'the driver resolves this same connection at push time.'
         );
-        $this->assertNotInstanceOf(RoutingQueue::class, $queue);
     }
 }
 

--- a/framework/core/tests/integration/queue/NotificationQueueRoutingTest.php
+++ b/framework/core/tests/integration/queue/NotificationQueueRoutingTest.php
@@ -127,7 +127,7 @@ class NotificationQueueRoutingTest extends TestCase
      * inline on push and `instanceof SyncQueue` detection keeps working. The
      * driver resolves this same connection, so nothing about routing interferes
      * with sync installs. (Inline execution itself is covered by the existing
-     * notification integration tests.)
+     * notification integration tests.).
      */
     #[Test]
     public function sync_queue_connection_stays_unwrapped_for_the_driver(): void


### PR DESCRIPTION
**Changes proposed in this pull request:**

Notification emails were being pushed onto the **`default`** queue instead of whatever queue they are routed to (e.g. `mail`), so on installs with queue routing they missed their dedicated worker profile and were served with the wrong retry/timeout settings. On a live install this surfaced as recurring `MaxAttemptsExceededException` for `SendEmailNotificationJob`: the `default` profile runs `tries=1`, so any worker recycle or slow SMTP send tombstoned the job on its next pickup, with no retry.

Cause: a provider boot-order race. `EmailNotificationDriver` is constructed at boot by `NotificationServiceProvider::boot()`, which injected the queue connection **at that instant**. The `RoutingQueue` wrapper — the piece that applies the job→queue route map to low-level `push()` calls — is applied later, in `QueueServiceProvider::boot()`. Because `NotificationServiceProvider` boots first, the long-lived driver captured the raw, **unwrapped** connection, so every notification email bypassed routing and fell through to the driver default queue. (Confirmed on a live install: the driver instance registered with the syncer held the unwrapped connection, while a freshly-resolved one held the `RoutingQueue`.)

The fix makes `EmailNotificationDriver` resolve the queue connection **at push time** rather than capturing it in the constructor. By then boot is complete and the wrapper is in place, so the routed connection is always used. The change is a constructor swap (`Queue` → `Container`) plus a single `make(Queue::class)` at the point of push.

This is deliberately conservative and driver-agnostic — it changes *when* the connection is resolved, never *which* driver or *how* routing behaves:

- **Sync queue** (no worker): the connection is intentionally left unwrapped; the driver resolves the bare `SyncQueue` and runs inline as before. No change.
- **Database / plain Redis queue, no routing**: with no route registered, the job is pushed with no explicit queue and falls through to the driver default — identical to before.
- **Horizon (or any `Extend\Queue()->route(...)`)**: the registered route is now honoured, so the job lands on its intended queue (`mail`).

Impacted: `core/src/Notification/Driver/EmailNotificationDriver.php`.

**Reviewers should focus on:**

- **The constructor signature change** (`Illuminate\Contracts\Queue\Queue` → `Illuminate\Contracts\Container\Container`). The driver is only ever built via `$container->make(EmailNotificationDriver::class)` in `NotificationServiceProvider`, so autowiring supplies the container; there are no direct `new EmailNotificationDriver(...)` callers in core or in the bundled/vendor extensions.
- **That resolving at push time is the right fix** vs. moving the `RoutingQueue` wrapping earlier. The wrapping is applied in `boot()` on purpose — it must run *after* FoF Redis/Horizon replace the connection, so decorating it earlier would be fragile. Deferring the *consumer's* resolution is the localised, order-independent fix.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — deferring resolution in the consumer, vs. wrapping the connection earlier; the latter is fragile because the boot-time wrapping ordering relative to FoF Redis/Horizon is load-bearing.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the affected driver and the routing wrapper both live in core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no frontend changes.
- [ ] Frontend changes: tests are green — no frontend changes.
- [ ] Frontend changes: tests have been added — no frontend changes.
- [x] Backend changes: tests are green (`composer test:integration`, queue + notification suites).
- [x] Backend changes: tests have been added — `NotificationQueueRoutingTest` covers the routed case (the regression, fails without the fix), plus the no-route and sync-queue cases which must stay unchanged (green both before and after).
- [x] Where applicable, changes are suitable for all supported database drivers — the change is queue-layer only and driver-agnostic; the added tests explicitly cover sync, unrouted (db/redis-style), and routed (horizon-style) queues.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
