### PR TITLE
[2.x] fix: make the LESS compiler cache resilient to concurrent writes

### DIFF
--- a/framework/core/src/Frontend/Compiler/LessCompiler.php
+++ b/framework/core/src/Frontend/Compiler/LessCompiler.php
@@ -11,6 +11,7 @@ namespace Flarum\Frontend\Compiler;
 
 use Flarum\Frontend\Compiler\Source\FileSource;
 use Illuminate\Support\Collection;
+use Less_Cache;
 use Less_Exception_Compiler;
 use Less_Parser;
 
@@ -93,6 +94,15 @@ class LessCompiler extends RevisionCompiler
                 'strictMath' => false,
                 'cache_dir' => $this->cacheDir,
                 'import_dirs' => $this->importDirs,
+                // less.php's built-in `serialize` cache writes each per-import
+                // cache file non-atomically and reads it back with an unguarded
+                // unserialize(). Concurrent compiles racing on the same file
+                // leave trailing bytes, and the next reader then fatals on
+                // "unserialize(): Extra data". Take over both sides of the cache
+                // so reads treat corruption as a miss and writes are atomic.
+                'cache_method' => 'callback',
+                'cache_callback_get' => $this->readCache(...),
+                'cache_callback_set' => $this->writeCache(...),
             ]);
 
             if ($this->fileSourceOverrides) {
@@ -143,6 +153,119 @@ class LessCompiler extends RevisionCompiler
         } finally {
             if ($maxNestingLevel !== false) {
                 ini_set('xdebug.max_nesting_level', $maxNestingLevel);
+            }
+        }
+    }
+
+    /**
+     * Read a cached parse result for less.php. Returns the cached rules, or
+     * null to signal a miss so less.php reparses the file.
+     *
+     * A corrupt or unreadable cache file (e.g. a partial write from a raced
+     * compile) is treated as a miss rather than allowed to fatal on
+     * unserialize()'s "Extra data" warning, which Flarum's error handler would
+     * otherwise escalate to an uncaught exception.
+     */
+    protected function readCache(Less_Parser $parser, string $filePath, string $cacheFile): mixed
+    {
+        if (! is_file($cacheFile)) {
+            return null;
+        }
+
+        $contents = @file_get_contents($cacheFile);
+
+        if ($contents === false || $contents === '') {
+            return null;
+        }
+
+        // A partial write leaves trailing bytes, so unserialize() emits an
+        // "Extra data" warning. `@` alone is not enough: a custom error handler
+        // (Sentry's, in production) runs regardless of suppression and would
+        // escalate it to an uncaught exception — the very failure being fixed.
+        // Swallow warnings for just this call so a corrupt file is a clean miss.
+        set_error_handler(fn () => true);
+
+        try {
+            $cache = unserialize($contents);
+        } catch (\Throwable) {
+            $cache = false;
+        } finally {
+            restore_error_handler();
+        }
+
+        // A genuine `false` payload never occurs (rules are always an array),
+        // so treat any falsy/failed result as a corrupt-or-empty miss.
+        return $cache ?: null;
+    }
+
+    /**
+     * Persist a parse result for less.php, writing atomically so a concurrent
+     * reader never observes a half-written cache file: serialize to a temporary
+     * file in the same directory, then rename() it into place (atomic on the
+     * same filesystem).
+     */
+    protected function writeCache(Less_Parser $parser, string $filePath, string $cacheFile, mixed $rules): void
+    {
+        $dir = dirname($cacheFile);
+        $tmp = @tempnam($dir, 'lesscache_');
+
+        if ($tmp === false) {
+            // Couldn't create a temp file (e.g. unwritable dir); skip caching
+            // rather than risk a partial write. The next compile reparses.
+            return;
+        }
+
+        if (@file_put_contents($tmp, serialize($rules)) === false) {
+            @unlink($tmp);
+
+            return;
+        }
+
+        if (! @rename($tmp, $cacheFile)) {
+            @unlink($tmp);
+        }
+
+        $this->pruneCacheOnce();
+    }
+
+    /**
+     * Prune expired cache files at most once per request. less.php's own GC
+     * (Less_Cache::CleanCache) only runs from its high-level Less_Cache::Get()
+     * API, which Flarum doesn't use — the direct Less_Parser path GC'd inline on
+     * every serialize write instead. In callback mode neither fires, so without
+     * this the directory would grow unbounded.
+     *
+     * We prune here rather than call CleanCache() because that method is
+     * deprecated-internal, and hand-rolling the sweep lets us tolerate the
+     * scandir/unlink race (a concurrent sweep removing the same aged file) by
+     * simply suppressing the "No such file" and moving on. Files are removed by
+     * mtime, matching less.php's own policy; a cache hit re-reads and is not
+     * touched, so anything past the lifetime is genuinely stale.
+     */
+    protected function pruneCacheOnce(): void
+    {
+        static $pruned = [];
+
+        if (isset($pruned[$this->cacheDir])) {
+            return;
+        }
+
+        $pruned[$this->cacheDir] = true;
+
+        $files = @glob($this->cacheDir.'/'.Less_Cache::$prefix.'*.lesscache');
+
+        if (! $files) {
+            return;
+        }
+
+        $cutoff = time() - Less_Cache::$gc_lifetime;
+
+        foreach ($files as $file) {
+            $mtime = @filemtime($file);
+
+            if ($mtime !== false && $mtime < $cutoff) {
+                // Tolerate a concurrent sweep having already removed it.
+                @unlink($file);
             }
         }
     }

--- a/framework/core/tests/unit/Frontend/Compiler/LessCacheIntegrityTest.php
+++ b/framework/core/tests/unit/Frontend/Compiler/LessCacheIntegrityTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend\Compiler;
+
+use Flarum\Frontend\Compiler\FileVersioner;
+use Flarum\Frontend\Compiler\LessCompiler;
+use Flarum\Frontend\Compiler\Source\SourceCollector;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * less.php caches each parsed @import to a `*.lesscache` file in the cache dir.
+ * Its built-in `serialize` cache writes the file non-atomically
+ * (`file_put_contents(serialize(...))`) and reads it back with an unguarded
+ * `unserialize()`. Under concurrent compiles two processes writing the same
+ * cache file interleave, leaving a few trailing bytes past the serialized
+ * payload; the next reader's `unserialize()` then emits a warning
+ * ("Extra data at offset N of N+k") which Flarum's error handler escalates to
+ * an uncaught exception — the recurring production failure at
+ * `Less/Parser.php:654`, which also killed the `drafts:publish` scheduled run
+ * with exit code 255.
+ *
+ * The compiler must be resilient to a corrupt cache file: read it defensively
+ * (treat corruption as a miss and reparse) and write it atomically (so a
+ * concurrent reader never sees a half-written file).
+ */
+class LessCacheIntegrityTest extends TestCase
+{
+    private string $tmpDir;
+    private string $cacheDir;
+
+    /** @var array<string, string> */
+    private array $written = [];
+
+    /** @var array<string, string|null> */
+    private array $manifest = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tmpDir = sys_get_temp_dir().'/flarum-lesscache-'.uniqid();
+        $this->cacheDir = $this->tmpDir.'/cache';
+
+        @mkdir($this->cacheDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->tmpDir);
+
+        parent::tearDown();
+    }
+
+    private function removeTree(string $dir): void
+    {
+        foreach (glob($dir.'/*') ?: [] as $path) {
+            is_dir($path) ? $this->removeTree($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+
+    /**
+     * Compile a small stylesheet that imports another file, so less.php writes
+     * per-import cache files, and return the compiled CSS.
+     */
+    private function compile(): string
+    {
+        // A file that @imports another triggers the cached parseFile() path.
+        $imported = $this->tmpDir.'/Imported.less';
+        file_put_contents($imported, '.imported { color: red; }');
+
+        $source = $this->tmpDir.'/forum.less';
+        file_put_contents($source, "@import 'Imported';\n.dummy { color: yellow; }");
+
+        $compiler = new LessCompiler(
+            $this->assetsDir(),
+            'forum.css',
+            $this->settings(),
+            $this->versioner()
+        );
+
+        $compiler->setCacheDir($this->cacheDir);
+        $compiler->setImportDirs([$this->tmpDir => '']);
+        $compiler->addSources(function (SourceCollector $sources) use ($source) {
+            $sources->addFile($source);
+        });
+        $compiler->commit(true);
+
+        return $this->written['forum.css'] ?? '';
+    }
+
+    /** @return string[] paths of the `*.lesscache` files in the cache dir */
+    private function cacheFiles(): array
+    {
+        return glob($this->cacheDir.'/*.lesscache') ?: [];
+    }
+
+    #[Test]
+    public function a_corrupt_cache_file_is_treated_as_a_miss_not_a_fatal(): void
+    {
+        // Prime the cache.
+        $first = $this->compile();
+        $this->assertStringContainsString('.imported', $first);
+
+        $files = $this->cacheFiles();
+        $this->assertNotEmpty($files, 'The compile should have written per-import cache files.');
+
+        // Corrupt every cache file exactly the way a raced, non-atomic write
+        // does: valid serialized data followed by a few trailing bytes.
+        foreach ($files as $file) {
+            file_put_contents($file, file_get_contents($file).'XX');
+        }
+
+        // Escalate any warning to an exception, mirroring production where
+        // Flarum's error handler turns the unserialize() warning into an
+        // uncaught ErrorException. A resilient read must not warn at all.
+        set_error_handler(function (int $severity, string $message): bool {
+            throw new \ErrorException($message, 0, $severity);
+        });
+
+        try {
+            // Must not throw (previously: unserialize() "Extra data") and must
+            // still produce the CSS by treating the corrupt cache as a miss.
+            $second = $this->compile();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertStringContainsString('.imported', $second);
+        $this->assertStringContainsString('.dummy', $second);
+    }
+
+    #[Test]
+    public function cache_files_are_written_atomically_and_leave_no_temporary_files(): void
+    {
+        $this->compile();
+
+        // Every cache file must be complete and valid — no partial writes.
+        foreach ($this->cacheFiles() as $file) {
+            $this->assertNotFalse(
+                @unserialize(file_get_contents($file)),
+                "Cache file $file should contain a complete, valid serialized payload."
+            );
+        }
+
+        // No stray temporary files left behind by the atomic write.
+        $all = glob($this->cacheDir.'/*') ?: [];
+        $strays = array_filter($all, fn ($f) => ! str_ends_with($f, '.lesscache'));
+
+        $this->assertSame(
+            [],
+            array_values($strays),
+            'Atomic writes must not leave temporary files behind: '.implode(', ', $strays)
+        );
+    }
+
+    #[Test]
+    public function a_valid_cache_is_used_on_the_next_compile(): void
+    {
+        // Prime the cache for the imported file.
+        $this->assertStringContainsString('.imported', $this->compile());
+
+        $files = $this->cacheFiles();
+        $this->assertNotEmpty($files);
+
+        // Round-trip check: the write callback must produce a payload the read
+        // callback accepts as a hit (not silently always-miss). Every primed
+        // file must therefore read back as a non-null, valid parse result.
+        $compiler = new LessCompiler($this->assetsDir(), 'forum.css', $this->settings(), $this->versioner());
+        $compiler->setCacheDir($this->cacheDir);
+
+        $read = (new \ReflectionMethod($compiler, 'readCache'))->getClosure($compiler);
+
+        foreach ($files as $file) {
+            $this->assertNotNull(
+                $read(new \Less_Parser(), '', $file),
+                "A freshly written cache file ($file) must read back as a hit."
+            );
+        }
+    }
+
+    #[Test]
+    public function expired_cache_files_are_pruned_but_fresh_ones_are_kept(): void
+    {
+        // A unique cache dir keeps the once-per-request prune guard from having
+        // already fired for this path in the test process.
+        $dir = $this->tmpDir.'/gc-'.uniqid();
+        @mkdir($dir, 0777, true);
+
+        $prefix = \Less_Cache::$prefix;
+        $lifetime = \Less_Cache::$gc_lifetime;
+
+        $stale = $dir.'/'.$prefix.'stale.lesscache';
+        $fresh = $dir.'/'.$prefix.'fresh.lesscache';
+        $foreign = $dir.'/keep-me.txt';
+
+        file_put_contents($stale, serialize(['x']));
+        file_put_contents($fresh, serialize(['y']));
+        file_put_contents($foreign, 'not ours');
+
+        // Age the stale file well past the lifetime.
+        touch($stale, time() - $lifetime - 3600);
+
+        $compiler = new LessCompiler($this->assetsDir(), 'forum.css', $this->settings(), $this->versioner());
+        $compiler->setCacheDir($dir);
+
+        (new \ReflectionMethod($compiler, 'pruneCacheOnce'))->invoke($compiler);
+
+        $this->assertFileDoesNotExist($stale, 'A cache file past its lifetime must be pruned.');
+        $this->assertFileExists($fresh, 'A recent cache file must be kept.');
+        $this->assertFileExists($foreign, 'Files not created by less.php must never be touched.');
+    }
+
+    private function settings(): SettingsRepositoryInterface
+    {
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->andReturn(null);
+        $settings->shouldReceive('delete')->andReturnNull();
+
+        return $settings;
+    }
+
+    private function assetsDir(): Cloud
+    {
+        $assetsDir = m::mock(Cloud::class);
+        $assetsDir->shouldReceive('put')->andReturnUsing(function ($file, $content) {
+            $this->written[$file] = $content;
+
+            return true;
+        });
+        $assetsDir->shouldReceive('exists')->andReturnUsing(fn ($file) => isset($this->written[$file]));
+        $assetsDir->shouldReceive('url')->andReturnUsing(fn ($file) => '/assets/'.$file);
+
+        return $assetsDir;
+    }
+
+    private function versioner(): FileVersioner
+    {
+        $manifestFs = m::mock(Filesystem::class);
+        $manifestFs->shouldReceive('exists')->with(FileVersioner::REV_MANIFEST)->andReturnUsing(fn () => $this->manifest !== []);
+        $manifestFs->shouldReceive('get')->with(FileVersioner::REV_MANIFEST)->andReturnUsing(fn () => json_encode($this->manifest));
+        $manifestFs->shouldReceive('put')->with(FileVersioner::REV_MANIFEST, m::type('string'))
+            ->andReturnUsing(function ($_, $json) {
+                $this->manifest = json_decode($json, true);
+
+                return true;
+            });
+
+        return new FileVersioner($manifestFs);
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**

The LESS compiler was producing recurring fatal errors on busy installs:

```
ErrorException: unserialize(): Extra data starting at offset N of N+k bytes
  in vendor/wikimedia/less.php/lib/Less/Parser.php:654
```

Cause: `wikimedia/less.php`'s default `serialize` cache method writes each per-`@import` `*.lesscache` file non-atomically (`file_put_contents($file, serialize($rules))`) and reads it back with an unguarded `unserialize()`. When two compiles run concurrently — multiple PHP-FPM workers, or several app containers sharing a cache directory — they race on the same cache file, and one write lands on top of another mid-flight, leaving a few trailing bytes past the serialized payload. The next reader's `unserialize()` then emits an "Extra data" warning, which Flarum's error handler escalates to an uncaught exception. On one production install this fired dozens of times a day, and also took down a scheduled console command (`drafts:publish` exited 255) whose boot happened to hit a corrupt file.

This makes the compiler take over both sides of the cache via less.php's supported `callback` cache method, so the fix lives entirely at Flarum's integration boundary — `wikimedia/less.php` is not patched:

- **Atomic writes.** Serialize to a temp file created in the cache directory itself (so it always shares a filesystem with the final file), then `rename()` it into place. On the same filesystem `rename()` is a single atomic operation, so a concurrent reader never observes a half-written file. Two writers each use their own unique temp file and produce byte-identical content, so whichever `rename()` wins is correct.
- **Defensive reads.** A corrupt or unreadable cache file is treated as a miss (reparse) instead of being allowed to fatal. This closes the failure mode on every filesystem — even one where `rename()` isn't perfectly atomic, a torn write can only ever cause a harmless reparse.
- **Preserved GC.** less.php only auto-prunes via its high-level `Less_Cache::Get()` API, which Flarum doesn't use — the direct `Less_Parser` path GC'd inline on every serialize write. In callback mode neither fires, so the compiler prunes expired cache files itself (once per request, by mtime, using less.php's own prefix and lifetime), tolerating the concurrent-unlink race. Without this the directory would grow unbounded.

Impacted: `core/src/Frontend/Compiler/LessCompiler.php`.

**Reviewers should focus on:**

- **The read guard uses a scoped `set_error_handler`, not `@`.** A custom error handler (e.g. Sentry's, in production) runs regardless of `@` suppression and would still escalate the `unserialize()` warning — which is the exact failure being fixed — so the warning must be swallowed for the duration of the call.
- **The temp file is created in the cache dir** (`tempnam(dirname($cacheFile), …)`), never the system temp dir, so temp and target always share a filesystem and `rename()` stays atomic. On an exotic backend where `rename()` is emulated non-atomically, this is still no worse than the previous non-atomic write, and the read guard keeps it non-fatal.
- **GC is hand-rolled rather than calling `Less_Cache::CleanCache()`**, which is marked deprecated-internal in current less.php; the local sweep matches its policy (prefix + `gc_lifetime`, mtime-based) and tolerates a concurrent sweep having already removed a file.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — the alternative (wrapping/patching less.php, or moving GC earlier) is fragile; the `callback` cache method is a supported hook that keeps the fix in Flarum.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — `LessCompiler` is core, and is marked `@internal`; there are no third-party consumers of it.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no JS/frontend changes.
- [ ] Frontend changes: tests are green — no JS/frontend changes.
- [ ] Frontend changes: tests have been added — no JS/frontend changes.
- [x] Backend changes: tests are green (`composer test:unit` + asset/frontend integration suites).
- [x] Backend changes: tests have been added — `LessCacheIntegrityTest`: a corrupt cache file is a miss not a fatal (fails without the fix with the exact production `ErrorException`), writes are atomic and leave no temp files, a valid cache round-trips as a hit, and expired files are pruned while fresh ones are kept.
- [x] Where applicable, changes are suitable for all supported database drivers — no database involvement; the change is filesystem-only.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
