### PR TITLE
[2.x] fix: keep old-line-only news out of the announcements feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - (tags) resolve differently-cased tag slugs in `Utf8SlugDriver::fromSlugs()` by @imorland [#4940]
 - (core) route notification emails through the queue router regardless of provider boot order by @imorland [#4941]
 - (core) make the LESS compiler cache resilient to concurrent writes by @imorland [#4942]
+- (core) keep old-line-only news out of the announcements feed by @imorland [#4945]
 
 ### Security
 

--- a/framework/core/src/Announcements/AnnouncementsFetcher.php
+++ b/framework/core/src/Announcements/AnnouncementsFetcher.php
@@ -27,6 +27,30 @@ class AnnouncementsFetcher
     }
     protected const API_BASE_URL = 'https://discuss.flarum.org/api/discussions';
     protected const TAG = 'blog';
+
+    /**
+     * Version tags whose news is only relevant to older lines. A discussion is
+     * dropped from the feed when it carries one of these AND none of the tags in
+     * {@see KEEP_VERSION_TAGS} — so a 1.x-only patch note is hidden, but a post
+     * tagged for both 1.x and 2.x still comes through. Version-neutral posts
+     * (Community Updates, announcements) carry neither and are always kept.
+     *
+     * This has to be applied in PHP: the discussions API's negated tag filter
+     * excludes on the mere presence of a tag, so it can't express "1.x but not
+     * also 2.x" and would drop the dual-tagged posts we want to keep.
+     *
+     * @var string[]
+     */
+    protected const EXCLUDE_VERSION_TAGS = ['version-1x'];
+
+    /**
+     * Version tags that rescue a discussion from exclusion — the current line's
+     * news. A post tagged for both an excluded line and this one is kept.
+     *
+     * @var string[]
+     */
+    protected const KEEP_VERSION_TAGS = ['version-2x'];
+
     protected const LIMIT = 8;
     protected const FETCH_LIMIT = 20;
     protected const EXCERPT_LENGTH = 200;
@@ -37,7 +61,7 @@ class AnnouncementsFetcher
             'filter' => ['tag' => self::TAG],
             'sort' => '-createdAt',
             'page' => ['limit' => self::FETCH_LIMIT],
-            'include' => 'firstPost,user',
+            'include' => 'firstPost,user,tags',
         ]);
 
         try {
@@ -61,11 +85,14 @@ class AnnouncementsFetcher
 
         $posts = [];
         $users = [];
+        $tagSlugs = [];
         foreach ($body['included'] ?? [] as $resource) {
             if (Arr::get($resource, 'type') === 'posts') {
                 $posts[$resource['id']] = $resource;
             } elseif (Arr::get($resource, 'type') === 'users') {
                 $users[$resource['id']] = $resource;
+            } elseif (Arr::get($resource, 'type') === 'tags') {
+                $tagSlugs[$resource['id']] = Arr::get($resource, 'attributes.slug');
             }
         }
 
@@ -78,6 +105,12 @@ class AnnouncementsFetcher
 
             // Skip any discussion missing the fields we require to render a card.
             if (! $id || ! $title || ! $slug || ! $createdAt) {
+                continue;
+            }
+
+            // Filter out news for older lines, keeping posts that also target the
+            // current line (dual-tagged) and version-neutral posts.
+            if ($this->isExcludedByVersion($discussion, $tagSlugs)) {
                 continue;
             }
 
@@ -111,6 +144,31 @@ class AnnouncementsFetcher
         usort($items, fn (array $a, array $b) => $b['isSticky'] <=> $a['isSticky']);
 
         return array_slice($items, 0, self::LIMIT);
+    }
+
+    /**
+     * A discussion is excluded when it carries a tag for an older line and none
+     * for the current one — 1.x-only news on a 2.x forum. Dual-tagged and
+     * version-neutral posts are kept.
+     *
+     * @param array<string, mixed> $discussion
+     * @param array<string, string|null> $tagSlugs  tag id => slug, from `included`
+     */
+    private function isExcludedByVersion(array $discussion, array $tagSlugs): bool
+    {
+        $slugs = [];
+        foreach (Arr::get($discussion, 'relationships.tags.data', []) as $tag) {
+            $slug = $tagSlugs[Arr::get($tag, 'id')] ?? null;
+
+            if ($slug !== null) {
+                $slugs[] = $slug;
+            }
+        }
+
+        $hasExcluded = array_intersect($slugs, self::EXCLUDE_VERSION_TAGS) !== [];
+        $hasKept = array_intersect($slugs, self::KEEP_VERSION_TAGS) !== [];
+
+        return $hasExcluded && ! $hasKept;
     }
 
     private function makeExcerpt(string $html): string

--- a/framework/core/tests/unit/Announcements/AnnouncementsFetcherTest.php
+++ b/framework/core/tests/unit/Announcements/AnnouncementsFetcherTest.php
@@ -78,6 +78,71 @@ class AnnouncementsFetcherTest extends TestCase
         ];
     }
 
+    /**
+     * Build the `tags` relationship + matching `included` resources for a set of
+     * tag slugs, so a discussion can be tagged in a test.
+     *
+     * @param string[] $slugs
+     * @return array{0: array<string, mixed>, 1: array<int, array<string, mixed>>}
+     */
+    private function tags(array $slugs): array
+    {
+        $relationship = ['tags' => ['data' => []]];
+        $included = [];
+
+        foreach ($slugs as $slug) {
+            $relationship['tags']['data'][] = ['type' => 'tags', 'id' => $slug];
+            $included[] = ['type' => 'tags', 'id' => $slug, 'attributes' => ['slug' => $slug]];
+        }
+
+        return [$relationship, $included];
+    }
+
+    public function test_excludes_old_line_only_news(): void
+    {
+        [$rel, $included] = $this->tags(['blog', 'version-1x']);
+
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse(
+                [$this->makeDiscussion(['id' => '1', 'title' => '1.x patch', 'slug' => 'onex'], $rel)],
+                $included
+            ),
+        ]);
+
+        $this->assertCount(0, $fetcher->fetch(), 'A 1.x-only post must be dropped from a 2.x forum feed.');
+    }
+
+    public function test_keeps_dual_tagged_news(): void
+    {
+        [$rel, $included] = $this->tags(['blog', 'version-1x', 'version-2x']);
+
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse(
+                [$this->makeDiscussion(['id' => '1', 'title' => 'Applies to both', 'slug' => 'both'], $rel)],
+                $included
+            ),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertCount(1, $result, 'A post tagged for both lines must survive the exclusion.');
+        $this->assertEquals('Applies to both', $result[0]['title']);
+    }
+
+    public function test_keeps_version_neutral_news(): void
+    {
+        [$rel, $included] = $this->tags(['blog', 'meta']);
+
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse(
+                [$this->makeDiscussion(['id' => '1', 'title' => 'Community update', 'slug' => 'cu'], $rel)],
+                $included
+            ),
+        ]);
+
+        $this->assertCount(1, $fetcher->fetch(), 'A post with no version tag must always be kept.');
+    }
+
     public function test_transforms_discussion_to_expected_shape(): void
     {
         $fetcher = $this->makeFetcher([
@@ -220,6 +285,7 @@ class AnnouncementsFetcherTest extends TestCase
 
         $this->assertContains('firstPost', $includes, 'Without firstPost there is no content to excerpt.');
         $this->assertContains('user', $includes, 'Without user there is no author name or avatar.');
+        $this->assertContains('tags', $includes, 'Without tags the version-exclusion filter has nothing to read.');
     }
 
     /**


### PR DESCRIPTION
**Changes proposed in this pull request:**

The admin Announcements widget pulls the `blog` tag from discuss.flarum.org, which mixes 1.x and 2.x release news into a single feed — so a 2.x forum's admin panel shows 1.x patch and security notes it can't act on.

This filters the feed down to what's relevant: pull everything under `blog`, then drop only the posts that are **1.x-only**. A post is kept if it also carries the current line's tag (`version-2x`), if it has no version tag at all (Community Updates, general announcements), or if it carries any other tag. The single carve-out is "tagged for an older line and nothing newer".

The filtering is done in PHP, not via the API's negated tag filter, on purpose:

- The discussions API's `filter[-tag]` excludes on the *presence* of a tag, so `filter[-tag]=version-1x` would also drop posts tagged for **both** 1.x and 2.x — which we want to keep.
- A comma list in that filter (`filter[-tag]=a,b`) is silently ignored and excludes nothing, so it can't be widened there either.

So the fetch now includes the `tags` relationship and applies the rule over the returned discussions: drop when an excluded version tag is present **and** no kept version tag is. The exclude/keep sets are small constant arrays (`EXCLUDE_VERSION_TAGS` / `KEEP_VERSION_TAGS`), so a future line is a one-line change.

Impacted: `core/src/Announcements/AnnouncementsFetcher.php`.

**Reviewers should focus on:**

- **The keep-if-dual-tagged behaviour.** The rule is deliberately "keep everything on `blog`, minus 1.x-only" — not "keep only 2.x + neutral". A `blog` post with a future/unrelated tag and no version tag still shows, because nothing about it is on the exclude list.
- **The `include=tags` cost.** Verified against the live endpoint: +~4 KB on a ~369 KB payload (≈1.1%), no extra request, tags deduplicated in `included`. The fetch runs on a cached weekly schedule (`RefreshAnnouncementsCommand` / `WeeklySchedule`), so this is once per refresh, not per admin pageview.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — the API-side negated filter was tried against the live endpoint and rejected: it can't express "1.x but not also 2.x", and its comma-list form silently excludes nothing.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the announcements fetcher is core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no frontend changes.
- [ ] Frontend changes: tests are green — no frontend changes.
- [ ] Frontend changes: tests have been added — no frontend changes.
- [x] Backend changes: tests are green (`composer test:unit`).
- [x] Backend changes: tests have been added — `AnnouncementsFetcherTest` gains cases for 1.x-only dropped, dual-tagged kept, and version-neutral kept (the exclusion and the `tags` include both fail without the change), and validated against live discuss data.
- [x] Where applicable, changes are suitable for all supported database drivers — no database involvement; this is an HTTP fetch + in-PHP filtering.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
