### PR TITLE
[2.x] fix: statistics date range dropdown clipped by the entity columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@
 - (core) route notification emails through the queue router regardless of provider boot order by @imorland [#4941]
 - (core) make the LESS compiler cache resilient to concurrent writes by @imorland [#4942]
 - (core) keep old-line-only news out of the announcements feed by @imorland [#4945]
+- (statistics) stop the date range dropdown being clipped by the entity columns by @imorland [#4950]
+- (core) don't underline `Button--text` dropdown toggles on hover by @imorland [#4950]
 
 ### Security
 

--- a/extensions/statistics/js/src/admin/components/MiniStatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/MiniStatisticsWidget.tsx
@@ -57,18 +57,22 @@ export default class MiniStatisticsWidget extends DashboardWidget {
             <div className="StatisticsWidget-label">{app.translator.trans('flarum-statistics.admin.statistics.total_label')}</div>
           </div>
 
-          {this.entities.map((entity) => {
-            const totalCount = this.loadingLifetime ? app.translator.trans('flarum-statistics.admin.statistics.loading') : this.getTotalCount(entity);
+          <div className="StatisticsWidget-entityList">
+            {this.entities.map((entity) => {
+              const totalCount = this.loadingLifetime
+                ? app.translator.trans('flarum-statistics.admin.statistics.loading')
+                : this.getTotalCount(entity);
 
-            return (
-              <div className="StatisticsWidget-entity">
-                <h3 className="StatisticsWidget-heading">{app.translator.trans('flarum-statistics.admin.statistics.' + entity + '_heading')}</h3>
-                <div className="StatisticsWidget-total" title={totalCount}>
-                  {this.loadingLifetime ? <LoadingIndicator display="inline" /> : abbreviateNumber(totalCount as number)}
+              return (
+                <div className="StatisticsWidget-entity">
+                  <h3 className="StatisticsWidget-heading">{app.translator.trans('flarum-statistics.admin.statistics.' + entity + '_heading')}</h3>
+                  <div className="StatisticsWidget-total" title={totalCount}>
+                    {this.loadingLifetime ? <LoadingIndicator display="inline" /> : abbreviateNumber(totalCount as number)}
+                  </div>
                 </div>
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
         </div>
 
         <div className="StatisticsWidget-viewFull">

--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -260,47 +260,51 @@ export default class StatisticsWidget extends DashboardWidget {
             </div>
           </div>
 
-          {this.entities.map((entity) => {
-            const totalCount = this.loadingLifetime ? app.translator.trans('flarum-statistics.admin.statistics.loading') : this.getTotalCount(entity);
-            const thisPeriodCount = loadingSelectedEntity
-              ? app.translator.trans('flarum-statistics.admin.statistics.loading')
-              : this.getPeriodCount(entity, thisPeriod!);
-            const lastPeriodCount =
-              this.selectedPeriod === 'custom'
-                ? null
-                : loadingSelectedEntity
+          <div className="StatisticsWidget-entityList">
+            {this.entities.map((entity) => {
+              const totalCount = this.loadingLifetime
                 ? app.translator.trans('flarum-statistics.admin.statistics.loading')
-                : this.getPeriodCount(entity, this.getLastPeriod(thisPeriod!));
-            const periodChange =
-              loadingSelectedEntity || lastPeriodCount === 0 || lastPeriodCount === null
-                ? 0
-                : (((thisPeriodCount as number) - (lastPeriodCount as number)) / (lastPeriodCount as number)) * 100;
+                : this.getTotalCount(entity);
+              const thisPeriodCount = loadingSelectedEntity
+                ? app.translator.trans('flarum-statistics.admin.statistics.loading')
+                : this.getPeriodCount(entity, thisPeriod!);
+              const lastPeriodCount =
+                this.selectedPeriod === 'custom'
+                  ? null
+                  : loadingSelectedEntity
+                  ? app.translator.trans('flarum-statistics.admin.statistics.loading')
+                  : this.getPeriodCount(entity, this.getLastPeriod(thisPeriod!));
+              const periodChange =
+                loadingSelectedEntity || lastPeriodCount === 0 || lastPeriodCount === null
+                  ? 0
+                  : (((thisPeriodCount as number) - (lastPeriodCount as number)) / (lastPeriodCount as number)) * 100;
 
-            return (
-              <button
-                className={classList('Button--ua-reset StatisticsWidget-entity', { active: this.selectedEntity === entity })}
-                type="button"
-                onclick={this.changeEntity.bind(this, entity)}
-              >
-                <h3 className="StatisticsWidget-heading">{app.translator.trans('flarum-statistics.admin.statistics.' + entity + '_heading')}</h3>
-                <div className="StatisticsWidget-total" title={totalCount}>
-                  {this.loadingLifetime ? <LoadingIndicator display="inline" /> : abbreviateNumber(totalCount as number)}
-                </div>
-                <div className="StatisticsWidget-period" title={thisPeriodCount}>
-                  {loadingSelectedEntity ? <LoadingIndicator display="inline" /> : abbreviateNumber(thisPeriodCount as number)}
-                  {periodChange !== 0 && (
-                    <>
-                      {' '}
-                      <span className={'StatisticsWidget-change StatisticsWidget-change--' + (periodChange > 0 ? 'up' : 'down')}>
-                        <Icon name={'fas fa-arrow-' + (periodChange > 0 ? 'up' : 'down')} />
-                        {Math.abs(periodChange).toFixed(1)}%
-                      </span>
-                    </>
-                  )}
-                </div>
-              </button>
-            );
-          })}
+              return (
+                <button
+                  className={classList('Button--ua-reset StatisticsWidget-entity', { active: this.selectedEntity === entity })}
+                  type="button"
+                  onclick={this.changeEntity.bind(this, entity)}
+                >
+                  <h3 className="StatisticsWidget-heading">{app.translator.trans('flarum-statistics.admin.statistics.' + entity + '_heading')}</h3>
+                  <div className="StatisticsWidget-total" title={totalCount}>
+                    {this.loadingLifetime ? <LoadingIndicator display="inline" /> : abbreviateNumber(totalCount as number)}
+                  </div>
+                  <div className="StatisticsWidget-period" title={thisPeriodCount}>
+                    {loadingSelectedEntity ? <LoadingIndicator display="inline" /> : abbreviateNumber(thisPeriodCount as number)}
+                    {periodChange !== 0 && (
+                      <>
+                        {' '}
+                        <span className={'StatisticsWidget-change StatisticsWidget-change--' + (periodChange > 0 ? 'up' : 'down')}>
+                          <Icon name={'fas fa-arrow-' + (periodChange > 0 ? 'up' : 'down')} />
+                          {Math.abs(periodChange).toFixed(1)}%
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         <>

--- a/extensions/statistics/less/admin.less
+++ b/extensions/statistics/less/admin.less
@@ -29,6 +29,17 @@
     display: flex;
     align-items: flex-end;
     margin: 0 20px;
+
+    & > :not(:last-child) {
+      margin-right: 10px;
+    }
+  }
+
+  &-entityList {
+    display: flex;
+    align-items: flex-end;
+    flex: 1;
+    min-width: 0;
     overflow: auto;
 
     & > :not(:last-child) {

--- a/framework/core/less/common/Button.less
+++ b/framework/core/less/common/Button.less
@@ -177,6 +177,9 @@
   &:hover {
     text-decoration: underline;
   }
+  &.Dropdown-toggle:hover {
+    text-decoration: none;
+  }
   &:active,
   &.active,
   .open > &.Dropdown-toggle {


### PR DESCRIPTION
**Fixes #4949**

**Changes proposed in this pull request:**

The Statistics period dropdown opens into a clipped box, so the menu is invisible behind the graph.

It isn't a z-index problem. `.Dropdown-menu` already has `z-index: var(--zindex-dropdown)` (1030), well above anything the chart sets — the menu is being *clipped*, not painted under. The clipper is `overflow: auto` on `.StatisticsWidget-entities`, added in #3940 to let the entity columns scroll horizontally on narrow screens. The period dropdown lives in the labels column *inside* that same container, and `align-items: flex-end` puts the labels flush with the container's bottom edge, so the menu's `top: 100%` lands entirely outside the clip box. No z-index value can escape that, which is why the reporter found changing it had no effect. `overflow-x: auto; overflow-y: visible` isn't an out either — per spec, if one axis is not `visible`, the other computes to `auto`.

The scroll was only ever meant for the entity columns, so this moves it there: the columns get a `.StatisticsWidget-entityList` wrapper that owns `overflow: auto` (plus `flex: 1; min-width: 0` so it still shrinks and scrolls), leaving the labels column and its dropdown outside any clipping context. `.StatisticsWidget-entities` keeps its flex row and the 10px gap before the first column. Applied to both `StatisticsWidget` and `MiniStatisticsWidget`, which share the class names.

Second, unrelated to the clipping but visible on the same control: `.Button--text` sets `text-decoration: underline` on hover, which makes a dropdown toggle read as a link. That variant exists for link-like buttons (the login/signup modal actions), but it's also what core's own admin dropdowns use — `SettingDropdown` and `PermissionDropdown` both hardcode `buttonClassName = 'Button Button--text'`, so all three underline. Suppressed for `.Dropdown-toggle` only; the link-like uses keep their underline.

Impacted: `extensions/statistics/less/admin.less`, `extensions/statistics/js/src/admin/components/{StatisticsWidget,MiniStatisticsWidget}.tsx`, `framework/core/less/common/Button.less`.

**Reviewers should focus on:**

- **`min-width: 0` on the wrapper.** Without it the flex item won't shrink below its content width and the scroll never engages — that's the line carrying #3940, and it's the thing to check on a narrow viewport.
- **The `Button.less` change reaches beyond statistics.** It also affects `SettingDropdown` and `PermissionDropdown` in core admin.

**Screenshot**

<!-- before/after of the open dropdown -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — dropping `overflow: auto` outright reverts #3940; `Dropdown-menu--top` only moves the clipping to the top edge.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the `Button--text` rule is core's and affects two core dropdowns besides this one.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green — n/a, LESS and markup only.
- [ ] Frontend changes: tests have been added — n/a, LESS and markup only.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added — no backend changes.
- [ ] Where applicable, changes are suitable for all supported database drivers — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.
