### PR TITLE
[2.x] fix: populate statistics previous period

### DIFF
--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -379,7 +379,7 @@ export default class StatisticsWidget extends DashboardWidget {
       labels.push(label);
 
       thisPeriod.push(this.getPeriodCount(this.selectedEntity, { start: i, end: i + period.step }));
-      lastPeriod.push(this.getPeriodCount(this.selectedEntity, { start: i - periodLength, end: i - periodLength }));
+      lastPeriod.push(this.getPeriodCount(this.selectedEntity, { start: i - periodLength, end: i - periodLength + period.step }));
     }
 
     if (thisPeriod.length === 0) {


### PR DESCRIPTION
## What changed

The previous-period chart points were querying zero-length ranges because each end timestamp matched its start timestamp. This includes the selected period step in the end timestamp so every point covers the corresponding interval from the preceding period.

## Why

The Statistics chart displayed zero for the entire previous-period series even when the API response contained matching data.

Fixes #4951.

## Validation

- Statistics frontend formatting check
- TypeScript check
- Statistics production Webpack build
- Focused range regression check for the previous-period interval
