### PR TITLE
[2.x] ci(core): pin external actions to immutable commit hashes

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -246,12 +246,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           # Coverage is not collected or uploaded anywhere, and Xdebug slows the
@@ -338,10 +338,10 @@ jobs:
       ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           coverage: none

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.git_actor_token != '' && secrets.git_actor_token || secrets.GITHUB_TOKEN }}
 
@@ -154,7 +154,7 @@ jobs:
           cache-dependency-path: ${{ env.cache_dependency_path }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.5'
           extensions: curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip
@@ -170,7 +170,7 @@ jobs:
         working-directory: ${{ inputs.frontend_directory }}
 
       - name: JS Checks & Production Build
-        uses: flarum/action-build@v5
+        uses: flarum/action-build@4ef2245181c661e2978c9223f65fa865767aacde # v5.0.1
         with:
           build_script: ${{ inputs.build_script }}
           build_typings_script: ${{ inputs.build_typings_script }}

--- a/.github/workflows/build-install-packages.yml
+++ b/.github/workflows/build-install-packages.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger build in flarum/installation-packages
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           workflow: Build Flarum Install Packages
           repo: flarum/installation-packages

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prepare release
         uses: flarum/action-release@master
         with:


### PR DESCRIPTION
_`2.x` equivalent to #4954_

**Fixes #0000**

**Changes proposed in this pull request:**
Pins all remaining actions to immutable commit hashes. This allows calling workflows downstream (i.e. Flarum Extensions) to continue to target `2.x` as the version of the reusable backend workflows here while still increasing protection against upstream supply chain attacks

**Reviewers should focus on:**
Dependabot will create alerts (and if configured to do so also PR's) to bump actions in the framework. See https://github.com/laravel/framework/pull/60900 as an example

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green (run `yarn test` in `js/`).
- [ ] Frontend changes: tests have been added, or are not appropriate here.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Backend changes: tests have been added, or are not appropriate here.
- [ ] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
