### PR TITLE
[2.x] fix: count the whole custom range in the statistics period totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@
 - (core) keep old-line-only news out of the announcements feed by @imorland [#4945]
 - (statistics) stop the date range dropdown being clipped by the entity columns by @imorland [#4950]
 - (core) don't underline `Button--text` dropdown toggles on hover by @imorland [#4950]
+- (statistics) populate the previous period series on the chart by @drewmt [#4952]
+- (statistics) count the whole custom range in the per-entity period totals by @imorland [#4956]
 
 ### Security
 

--- a/extensions/statistics/js/jest.config.cjs
+++ b/extensions/statistics/js/jest.config.cjs
@@ -1,0 +1,8 @@
+module.exports = require('@flarum/jest-config')({
+  moduleNameMapper: {
+    '^flarum/(.*)$': '<rootDir>/../../../framework/core/js/src/$1',
+    // frappe-charts renders into a real SVG and measures it; jsdom has no
+    // layout. The stub records what the widget asked it to draw.
+    '^frappe-charts$': '<rootDir>/tests/stubs/frappe-charts.ts',
+  },
+});

--- a/extensions/statistics/js/package.json
+++ b/extensions/statistics/js/package.json
@@ -7,6 +7,7 @@
         "frappe-charts": "^1.6.2"
     },
     "devDependencies": {
+        "@flarum/jest-config": "^2.0.0",
         "@flarum/prettier-config": "^1.0.0",
         "@types/mithril": "^2.0.11",
         "flarum-tsconfig": "^2.0.0",
@@ -27,6 +28,7 @@
         "build-typings": "yarn run clean-typings && ([ -e src/@types ] && cp -r src/@types dist-typings/@types || true) && tsc && yarn run post-build-typings",
         "post-build-typings": "find dist-typings -type f -name '*.d.ts' -print0 | xargs -0 sed -i 's,../src/@types,@types,g'",
         "check-typings": "tsc --noEmit --emitDeclarationOnly false",
-        "check-typings-coverage": "typescript-coverage-report"
+        "check-typings-coverage": "typescript-coverage-report",
+        "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
     }
 }

--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -179,7 +179,7 @@ export default class StatisticsWidget extends DashboardWidget {
       ? null
       : this.selectedPeriod === 'custom'
       ? {
-          start: this.customPeriod?.end!,
+          start: this.customPeriod?.start!,
           end: this.customPeriod?.end!,
           step: 86400,
         }

--- a/extensions/statistics/js/tests/stubs/frappe-charts.ts
+++ b/extensions/statistics/js/tests/stubs/frappe-charts.ts
@@ -1,0 +1,35 @@
+export interface ChartDataset {
+  name: string;
+  values: number[];
+}
+
+export interface ChartData {
+  labels: string[];
+  datasets: ChartDataset[];
+}
+
+/**
+ * Stands in for frappe-charts, capturing the data the widget hands it so tests
+ * can assert on what would have been plotted.
+ */
+export class Chart {
+  static lastData: ChartData | null = null;
+
+  parent: HTMLElement;
+  data: ChartData;
+
+  constructor(parent: HTMLElement, options: { data: ChartData }) {
+    this.parent = parent;
+    this.data = options.data;
+
+    Chart.lastData = options.data;
+  }
+
+  update(data: ChartData) {
+    this.data = data;
+
+    Chart.lastData = data;
+  }
+
+  export() {}
+}

--- a/extensions/statistics/js/tests/unit/admin/StatisticsWidget.test.ts
+++ b/extensions/statistics/js/tests/unit/admin/StatisticsWidget.test.ts
@@ -1,0 +1,133 @@
+import bootstrapAdmin from '@flarum/jest-config/src/bootstrap/admin';
+import app from 'flarum/admin/app';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import jsYaml from 'js-yaml';
+import flatten from 'flat';
+
+import StatisticsWidget from '../../../src/admin/components/StatisticsWidget';
+import { Chart } from '../../stubs/frappe-charts';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const coreJsDir = resolve(testDir, '../../../../../../framework/core/js');
+const localeFile = resolve(testDir, '../../../../locale/en.yml');
+
+const DAY = 86400;
+
+/** Midnight UTC today, the epoch the widget builds its periods around. */
+const today = (() => {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  return date.getTime() / 1000;
+})();
+
+/**
+ * Counts keyed by day, as the API returns them. Each day carries a distinct
+ * value so an assertion pins down *which* window was read, and in what order —
+ * not merely that something non-zero came back.
+ *
+ * Days 1-7 ago (the "last 7 days" period) hold the day's own offset; days 8-14
+ * ago (the period before it) hold ten times theirs.
+ */
+const counts: Record<number, number> = {};
+for (let daysAgo = 1; daysAgo <= 7; daysAgo++) counts[today - daysAgo * DAY] = daysAgo;
+for (let daysAgo = 8; daysAgo <= 14; daysAgo++) counts[today - daysAgo * DAY] = daysAgo * 10;
+
+beforeAll(() => {
+  const cwd = process.cwd();
+
+  try {
+    process.chdir(coreJsDir);
+    bootstrapAdmin();
+  } finally {
+    process.chdir(cwd);
+  }
+
+  app.boot();
+
+  app.translator.addTranslations(flatten(jsYaml.load(fs.readFileSync(localeFile, 'utf8')) as object));
+});
+
+/**
+ * A widget already holding loaded data, bypassing the XHRs that normally
+ * populate it.
+ */
+function makeWidget(selectedPeriod: string): StatisticsWidget {
+  const widget = new StatisticsWidget();
+
+  widget.periods = {
+    today: { start: today, end: today + DAY, step: 3600 },
+    last_7_days: { start: today - DAY * 7, end: today, step: DAY },
+    previous_7_days: { start: today - DAY * 14, end: today - DAY * 7, step: DAY },
+    last_28_days: { start: today - DAY * 28, end: today, step: DAY },
+    previous_28_days: { start: today - DAY * 28 * 2, end: today - DAY * 28, step: DAY },
+    last_12_months: { start: today - DAY * 364, end: today, step: DAY * 7 },
+  };
+
+  widget.selectedEntity = 'users';
+  widget.selectedPeriod = selectedPeriod;
+  widget.loadingLifetime = false;
+  widget.lifetimeData = { users: 100, discussions: 50, posts: 200 };
+
+  for (const entity of widget.entities) {
+    widget.timedData[entity] = { ...counts };
+    widget.customPeriodData[entity] = { ...counts };
+    widget.loadingTimed[entity] = 'loaded';
+    widget.loadingCustom[entity] = 'loaded';
+  }
+
+  return widget;
+}
+
+/** The datasets the widget would have plotted, keyed by their translated name. */
+function draw(widget: StatisticsWidget): Record<string, number[]> {
+  Chart.lastData = null;
+
+  widget.drawChart({ dom: document.createElement('div') } as any);
+
+  expect(Chart.lastData).not.toBeNull();
+
+  return Object.fromEntries(Chart.lastData!.datasets.map((dataset) => [dataset.name, dataset.values]));
+}
+
+describe('the chart the statistics widget plots', () => {
+  it('plots the selected period, oldest bucket first', () => {
+    const datasets = draw(makeWidget('last_7_days'));
+
+    // Buckets run from 7 days ago up to yesterday; today itself is excluded,
+    // since the period ends at midnight this morning.
+    expect(datasets['Current period']).toEqual([7, 6, 5, 4, 3, 2, 1]);
+  });
+
+  it('plots the period before it alongside, bucket for bucket', () => {
+    const datasets = draw(makeWidget('last_7_days'));
+
+    // The same seven buckets shifted back by the period's own length, so
+    // 14 days ago through 8 days ago — the x10 values.
+    expect(datasets['Previous period']).toEqual([140, 130, 120, 110, 100, 90, 80]);
+  });
+
+  it('gives the previous period a bucket for every bucket of the current one', () => {
+    const datasets = draw(makeWidget('last_7_days'));
+
+    expect(datasets['Previous period']).toHaveLength(datasets['Current period'].length);
+  });
+});
+
+describe('the per-entity count for a custom date range', () => {
+  it('counts the whole selected range', () => {
+    const widget = makeWidget('custom');
+
+    // 14 days ago through 8 days ago — the same window as "previous 7 days".
+    widget.customPeriod = { start: today - DAY * 14, end: today - DAY * 7 };
+
+    const container = document.createElement('div');
+    m.render(container, widget.content());
+
+    // The element carries the unabbreviated count in its title attribute.
+    const period = container.querySelector('.StatisticsWidget-period');
+
+    expect(period?.getAttribute('title')).toBe(String(140 + 130 + 120 + 110 + 100 + 90 + 80));
+  });
+});


### PR DESCRIPTION
Follow-up to #4952, which fixed the previous-period series on the chart.

**Changes proposed in this pull request:**

#4952 fixed one instance of a zero-width date range. There is a second one, on the same component, that it doesn't reach — `content()` builds the custom period as:

```js
start: this.customPeriod?.end!,
end: this.customPeriod?.end!,
```

`start` reads `.end`. `getPeriodCount` filters on `time >= period.start && time < period.end`, so the range matches nothing and the per-entity "period" figure in the columns reads 0 whenever a custom date range is selected. `drawChart` builds the same object correctly with `start: this.customPeriod?.start!`, so the two disagree about what the selected period is. This has been there since custom ranges were added in #3622, on both 1.x and 2.x.

This also adds a frontend test harness to the extension, following the `tags` and `embed` pattern — `@flarum/jest-config`, a `test` script, and `jest.config.cjs`. Two things beyond the standard setup:

- A stub for `frappe-charts` (`tests/stubs/frappe-charts.ts`) that records the data handed to `new Chart(...)`. jsdom has no layout so the real library can't run, but what the widget asked to plot is what matters here.
- `bootstrapAdmin()` plus the extension's own `locale/en.yml`, so the chart's datasets can be asserted by their translated names rather than by index.

No CI change is needed — `flarum/action-build` iterates the workspaces and runs each one's `test` script, so this is picked up automatically.

The tests give each day in the fixture a distinct value (days 1-7 ago hold their own offset, days 8-14 ago hold ten times theirs), so an assertion pins down which window was read and in what order, rather than merely that something non-zero came back. Four tests: three over the chart's datasets, one over the custom-range column total.

Impacted: `extensions/statistics/js/src/admin/components/StatisticsWidget.tsx`, `extensions/statistics/js/package.json`, plus the new `jest.config.cjs` and `tests/`.

**Reviewers should focus on:**

- **Whether the column figure should count the whole custom range**, which is what this assumes, matching `drawChart`. The alternative reading — that it was meant to be the range's final day — would make the number disagree with the chart drawn directly below it.
- **The `frappe-charts` stub.** It asserts on the data passed to the constructor, not on anything rendered, so it proves what the widget computed rather than what a chart would look like.

**Screenshot**

<!-- custom range selected, showing a populated column total -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension? — bundled extension only.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (`yarn test` in `extensions/statistics/js`).
- [x] Frontend changes: tests have been added — the custom-range test fails on current `2.x` and passes with the fix; reverting the fix on its own fails that test and no other.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added — no backend changes.
- [ ] Where applicable, changes are suitable for all supported database drivers — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.
