### PR TITLE
[2.x] fix: scope haptic feedback to browsers with the Vibration API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - (core) don't underline `Button--text` dropdown toggles on hover by @imorland [#4950]
 - (statistics) populate the previous period series on the chart by @drewmt [#4952]
 - (statistics) count the whole custom range in the per-entity period totals by @imorland [#4956]
+- (core) scope haptic feedback to browsers with the Vibration API, and hide its setting elsewhere by @imorland [#4957]
 
 ### Security
 

--- a/framework/core/js/src/common/utils/haptic.ts
+++ b/framework/core/js/src/common/utils/haptic.ts
@@ -1,18 +1,21 @@
 /**
  * Haptic feedback utility.
  *
- * Uses the `web-haptics` package which supports:
- * - Android: via the Web Vibration API (`navigator.vibrate`)
- * - iOS: via a hidden `<input type="checkbox" switch>` toggle that triggers the Taptic Engine
+ * Delegates to the `web-haptics` package, which uses the Web Vibration API
+ * (`navigator.vibrate`). That API is implemented by Chromium, so in practice haptics are
+ * available on Chromium-based Android browsers and nowhere else. iOS Safari has no
+ * vibration API, and WebKit's position on the specification is `oppose`. Firefox removed
+ * its implementation in Firefox 129.
  *
- * Silently no-ops on desktop and unsupported devices — always safe to call unconditionally.
+ * Calls are a no-op wherever the API is absent, so `haptic()` is always safe to call
+ * unconditionally. Use {@link isHapticSupported} to decide whether to show haptic-related UI.
  *
- * **User gesture requirement (Android + iOS):** Both platforms require haptic calls to occur
- * within a synchronous user gesture context. Always call `haptic()` before any `await` or
- * `.then()` — once execution goes async, the browser's gesture token expires and the haptic
- * will be silently ignored.
+ * **User gesture requirement:** haptic calls must occur within a synchronous user gesture
+ * context. Always call `haptic()` before any `await` or `.then()` — once execution goes
+ * async, the browser's gesture token expires and the haptic is silently ignored.
  *
  * @see https://github.com/lochie/web-haptics
+ * @see https://github.com/WebKit/standards-positions/issues/267
  */
 
 import app from '../app';
@@ -22,17 +25,14 @@ import type { HapticInput } from 'web-haptics';
 export type { HapticInput };
 
 /**
- * Whether the current device supports haptic feedback.
+ * Whether the current browser can produce haptic feedback.
  *
- * `true` on Android (Web Vibration API) and iOS (Taptic Engine via checkbox trick).
- * `false` on desktop browsers.
+ * Determined by the presence of the Web Vibration API, so this is `true` on Chromium-based
+ * Android browsers and `false` on iOS, desktop, and any other browser without it.
  *
- * Useful for conditionally showing haptic-related UI (e.g. a settings toggle).
+ * Use this to conditionally show haptic-related UI (e.g. a settings toggle).
  */
-export const isHapticSupported: boolean =
-  (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') ||
-  // iOS supports haptics via the <input type="checkbox" switch> trick
-  /iP(hone|ad|od)/.test(typeof navigator !== 'undefined' ? navigator.userAgent : '');
+export const isHapticSupported: boolean = typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
 
 const _haptics = new WebHaptics();
 
@@ -55,6 +55,8 @@ const _haptics = new WebHaptics();
  * haptic([100, 50, 100]); // vibrate 100ms, pause 50ms, vibrate 100ms
  */
 export default function haptic(pattern: HapticInput = 'light'): void {
+  if (!isHapticSupported) return;
+
   if (app.session?.user && app.session.user.preferences()?.hapticFeedback === false) return;
 
   _haptics.trigger(pattern as HapticInput);

--- a/framework/core/js/src/forum/components/SettingsPage.tsx
+++ b/framework/core/js/src/forum/components/SettingsPage.tsx
@@ -14,6 +14,7 @@ import classList from '../../common/utils/classList';
 import ThemeMode from '../../common/components/ThemeMode';
 import { camelCaseToSnakeCase } from '../../common/utils/string';
 import { ComponentAttrs } from '../../common/Component';
+import { isHapticSupported } from '../../common/utils/haptic';
 
 /**
  * The `SettingsPage` component displays the user's settings control panel, in
@@ -63,6 +64,10 @@ export default class SettingsPage<CustomAttrs extends IUserPageAttrs = IUserPage
 
       if (visible && visible() === false) return;
 
+      const children = this[sectionItems]().toArray();
+
+      if (!children.length) return;
+
       items.add(
         section,
         <FieldSet
@@ -70,7 +75,7 @@ export default class SettingsPage<CustomAttrs extends IUserPageAttrs = IUserPage
           label={app.translator.trans(`core.forum.settings.${camelCaseToSnakeCase(section)}_heading`)}
           {...props}
         >
-          {this[sectionItems]().toArray()}
+          {children}
         </FieldSet>,
         100 - index * 10
       );
@@ -148,6 +153,8 @@ export default class SettingsPage<CustomAttrs extends IUserPageAttrs = IUserPage
    */
   deviceItems() {
     const items = new ItemList<Mithril.Children>();
+
+    if (!isHapticSupported) return items;
 
     items.add(
       'hapticFeedback',

--- a/framework/core/js/tests/unit/common/utils/haptic.test.ts
+++ b/framework/core/js/tests/unit/common/utils/haptic.test.ts
@@ -1,79 +1,127 @@
 import { jest } from '@jest/globals';
-import { WebHaptics } from 'web-haptics';
-import haptic, { isHapticSupported } from '../../../../src/common/utils/haptic';
 
-// haptic.ts creates `_haptics = new WebHaptics()` at module load.
-// Spying on the prototype intercepts calls on the already-created instance.
+const define = (prop: string, value: unknown) => Object.defineProperty(navigator, prop, { value, writable: true, configurable: true });
+
+const originalUserAgent = navigator.userAgent;
+
+/**
+ * `isHapticSupported` is resolved when the module is first evaluated, so each case has to
+ * set the environment up and then load the module fresh.
+ */
+async function loadHaptic(vibrate: unknown, userAgent: string = originalUserAgent) {
+  jest.resetModules();
+  define('vibrate', vibrate);
+  define('userAgent', userAgent);
+
+  const haptic = await import('../../../../src/common/utils/haptic');
+  const { WebHaptics } = await import('web-haptics');
+
+  return { ...haptic, WebHaptics };
+}
+
+afterEach(() => {
+  define('vibrate', undefined);
+  define('userAgent', originalUserAgent);
+  jest.restoreAllMocks();
+});
+
 describe('haptic', () => {
-  let mockTrigger: ReturnType<typeof jest.spyOn>;
+  describe('on a browser with the Vibration API', () => {
+    async function withSpy() {
+      const { default: haptic, WebHaptics } = await loadHaptic(jest.fn());
+      const trigger = jest.spyOn(WebHaptics.prototype, 'trigger').mockImplementation(() => Promise.resolve());
 
-  beforeEach(() => {
-    mockTrigger = jest.spyOn(WebHaptics.prototype, 'trigger').mockImplementation(() => Promise.resolve());
-  });
+      return { haptic, trigger };
+    }
 
-  afterEach(() => {
-    mockTrigger.mockRestore();
-  });
+    it('triggers the light preset by default', async () => {
+      const { haptic, trigger } = await withSpy();
 
-  describe('presets', () => {
-    it('triggers the light preset by default', () => {
       haptic();
-      expect(mockTrigger).toHaveBeenCalledWith('light');
+
+      expect(trigger).toHaveBeenCalledWith('light');
     });
 
-    it.each(['light', 'medium', 'heavy', 'success', 'warning', 'error', 'nudge'] as const)(
-      'passes preset "%s" directly to web-haptics',
-      (preset) => {
-        haptic(preset);
-        expect(mockTrigger).toHaveBeenCalledWith(preset);
-      }
-    );
-  });
+    it.each(['light', 'medium', 'heavy', 'success', 'warning', 'error', 'nudge'] as const)('passes preset "%s" through', async (preset) => {
+      const { haptic, trigger } = await withSpy();
 
-  describe('custom patterns', () => {
-    it('accepts a duration in ms', () => {
+      haptic(preset);
+
+      expect(trigger).toHaveBeenCalledWith(preset);
+    });
+
+    it('accepts a duration in ms', async () => {
+      const { haptic, trigger } = await withSpy();
+
       haptic(50);
-      expect(mockTrigger).toHaveBeenCalledWith(50);
+
+      expect(trigger).toHaveBeenCalledWith(50);
     });
 
-    it('accepts a custom pattern array', () => {
+    it('accepts a custom pattern array', async () => {
+      const { haptic, trigger } = await withSpy();
+
       haptic([100, 50, 100]);
-      expect(mockTrigger).toHaveBeenCalledWith([100, 50, 100]);
+
+      expect(trigger).toHaveBeenCalledWith([100, 50, 100]);
     });
   });
 
-  describe('unsupported devices', () => {
-    it('does not throw on any device', () => {
+  describe('on a browser without the Vibration API', () => {
+    /**
+     * Reaching the library at all is what matters here, not what it would have done.
+     * Its fallback path builds a hidden switch element and drives it from a
+     * requestAnimationFrame loop, which is wasted work on a device that cannot vibrate.
+     */
+    it('does not reach the underlying library', async () => {
+      const { default: haptic, WebHaptics } = await loadHaptic(undefined);
+      const trigger = jest.spyOn(WebHaptics.prototype, 'trigger').mockImplementation(() => Promise.resolve());
+
+      haptic('success');
+
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it('does not throw', async () => {
+      const { default: haptic } = await loadHaptic(undefined);
+
       expect(() => haptic('success')).not.toThrow();
     });
+
+    it('does not reach the library on iOS either', async () => {
+      const iOS = 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X) AppleWebKit/605.1.15';
+      const { default: haptic, WebHaptics } = await loadHaptic(undefined, iOS);
+      const trigger = jest.spyOn(WebHaptics.prototype, 'trigger').mockImplementation(() => Promise.resolve());
+
+      haptic('success');
+
+      expect(trigger).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('isHapticSupported', () => {
+  it('is true when the Vibration API is present', async () => {
+    const { isHapticSupported } = await loadHaptic(jest.fn());
+
+    expect(isHapticSupported).toBe(true);
   });
 
-  describe('isHapticSupported', () => {
-    it('is false in jsdom (no navigator.vibrate, non-iOS userAgent)', () => {
-      expect(isHapticSupported).toBe(false);
-    });
+  it('is false when the Vibration API is absent', async () => {
+    const { isHapticSupported } = await loadHaptic(undefined);
 
-    it('is true when navigator.vibrate is a function', async () => {
-      Object.defineProperty(navigator, 'vibrate', { value: jest.fn(), writable: true, configurable: true });
+    expect(isHapticSupported).toBe(false);
+  });
 
-      jest.resetModules();
-      const { isHapticSupported: supported } = await import('../../../../src/common/utils/haptic');
+  /**
+   * iOS has no Vibration API. It briefly produced haptics through an
+   * `<input type="checkbox" switch>` quirk, which WebKit closed in iOS 26.5 by requiring
+   * a trusted event, so support must not be inferred from the user agent.
+   */
+  it('is false on iOS, which has no Vibration API', async () => {
+    const iOS = 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X) AppleWebKit/605.1.15';
+    const { isHapticSupported } = await loadHaptic(undefined, iOS);
 
-      expect(supported).toBe(true);
-
-      Object.defineProperty(navigator, 'vibrate', { value: undefined, writable: true, configurable: true });
-    });
-
-    it('is true on iOS userAgent', async () => {
-      const originalUserAgent = navigator.userAgent;
-      Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)', writable: true, configurable: true });
-
-      jest.resetModules();
-      const { isHapticSupported: supported } = await import('../../../../src/common/utils/haptic');
-
-      expect(supported).toBe(true);
-
-      Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, writable: true, configurable: true });
-    });
+    expect(isHapticSupported).toBe(false);
   });
 });


### PR DESCRIPTION
**Fixes #4694**

**Changes proposed in this pull request:**

Haptics worked on iOS when they were added in #4430. Apple has since closed the mechanism, so for 2.0 the feature is scoped to where it actually works.

`isHapticSupported` claimed support for any iPhone/iPad user agent, on the basis that iOS produced haptics through an `<input type="checkbox" switch>` quirk. WebKit closed that in iOS 26.5 (`288403@main`, [bug 285120](https://bugs.webkit.org/show_bug.cgi?id=285120)) by requiring a trusted event and user activation, so a scripted click can no longer reach the Taptic Engine. I confirmed on a physical iPhone running iOS 27 beta 6 that no programmatic variant fires — hidden or rendered switch, label or input, inside or outside the gesture — while a direct tap on a real switch still does.

There is no route back for an imperative API:

- The Web Vibration API is the only programmatic option, and WebKit's standards position on it is **oppose** ([#267](https://github.com/WebKit/standards-positions/issues/267)), with Apple stating "it wouldn't even be possible to support this API on Apple's native platforms". iOS exposes discrete feedback types via `UIImpactFeedbackGenerator`, not arbitrary-duration vibration, so the spec's model has nothing to map onto.
- WebKit has no vibration implementation in tree — the only `vibrate` references in `Source/` are commented out in the notification IDLs. The one haptic API it does implement is `GamepadHapticActuator`, which needs a physical gamepad.
- Swapping libraries cannot help, since the constraint is the platform rather than the code. `ios-haptics` responded to the patch by abandoning its imperative API for pre-placed markup, which is the only technique that still works and requires the haptic to move from the action to the control.

So this stops claiming iOS support rather than pretending to have it:

- `isHapticSupported` is now pure feature detection on `navigator.vibrate`, with the user-agent test removed. That is correct going forward as well as now: it also reports `false` on Firefox, which removed `Navigator.vibrate` in Firefox 129, and it will report `true` automatically if Apple ever ships the API.
- `haptic()` returns early when unsupported. This is the substantive fix. Previously it always called into `web-haptics`, which falls back on any browser lacking `navigator.vibrate` — iOS **and desktop Safari** — by injecting a hidden `<label><input switch>` into `document.body` and driving it from a `requestAnimationFrame` loop. That work was never observable on iOS 26.5+ and never did anything on desktop.
- The haptic toggle in Settings → Device is now gated on `isHapticSupported`. It was previously shown to every logged-in user on every platform, including desktop, where it has never been able to do anything. `isHapticSupported` was exported and documented for exactly this but never used.
- A section whose item list comes back empty no longer renders. `FieldSet` always renders its label, so gating the toggle alone would leave a "Device" heading with nothing under it. Gating the item rather than the section keeps `deviceItems()` useful as an extension point — an extension adding a device setting still gets its section.

Android is unaffected, and all eleven `haptic()` call sites across core and the bundled extensions are unchanged. Third-party extensions calling `haptic()` (FoF Reactions, FoF Drafts) keep working exactly where they already worked.

Impacted: `framework/core/js/src/common/utils/haptic.ts`, `framework/core/js/src/forum/components/SettingsPage.tsx`.

**Reviewers should focus on:**

- **The empty-section change touches every settings section**, not just Device. Worth confirming the other four still render for a normal user.
- **Whether hiding the toggle on unsupported devices is the right call.** The preference is stored per user rather than per device despite the "Device" heading, so someone on desktop can no longer pre-set it for their phone. I think a control that cannot do anything is worse than that, but it is a trade.
- **`web-haptics` is kept for now.** With the iOS path unreachable, the only parts still used are the preset table, pattern normalisation, and the intensity-to-PWM conversion. Dropping it would remove an unmaintained `0.0.x` dependency and about 2 KB gzipped, but it also means owning `HapticInput`, which is currently re-exported from the package and documented as such. That felt like the wrong change for an RC, so it is left for 2.1.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — a declarative overlay that places a real switch inside each control does still work on iOS 27 beta 6, but it only ever yields a single tick with no patterns, cannot express outcome-based haptics such as the post-`confirm()` calls in `PostControls`, and moves the haptic from the action to the control at every call site including third-party ones. Not something to take on during an RC.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — `haptic()` and the settings toggle are core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green — 429 tests across 73 suites.
- [x] Frontend changes: tests have been added — `haptic.test.ts` is restructured around the capability check, and gains cases that `haptic()` does not reach the library when unsupported, including on an iOS user agent. Against the previous code these fail hard: `haptic()` enters the `requestAnimationFrame` fallback, which the test environment's synchronous `requestAnimationFrame` shim turns into unbounded recursion, so the process exits with `RangeError: Maximum call stack size exceeded`.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added — no backend changes.
- [ ] Where applicable, changes are suitable for all supported database drivers — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: the haptics page still lists iOS under Platform Support and documents an `isHapticSupported` contract core was not honouring. Following separately.
