### PR TITLE
[2.x] fix: don't treat an unreadable package manifest as an empty extension list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - (statistics) populate the previous period series on the chart by @drewmt [#4952]
 - (statistics) count the whole custom range in the per-entity period totals by @imorland [#4956]
 - (core) scope haptic feedback to browsers with the Vibration API, and hide its setting elsewhere by @imorland [#4957]
+- (core) don't treat an unreadable package manifest as an empty extension list by @imorland [#4958]
 
 ### Security
 

--- a/framework/core/src/Extension/Exception/UnreadableManifestException.php
+++ b/framework/core/src/Extension/Exception/UnreadableManifestException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension\Exception;
+
+use RuntimeException;
+
+class UnreadableManifestException extends RuntimeException
+{
+    public function __construct(
+        public string $path,
+        string $reason
+    ) {
+        parent::__construct("Cannot read the installed package manifest at $path: $reason. Flarum cannot determine which extensions are installed until this is resolved, which usually means completing or re-running `composer install`.");
+    }
+
+    public static function missing(string $path): self
+    {
+        return new self($path, 'the file does not exist');
+    }
+
+    public static function unparsable(string $path): self
+    {
+        return new self($path, 'the file is not valid JSON, so it may be corrupt or only partially written');
+    }
+}

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -16,6 +16,7 @@ use Flarum\Extension\Event\Enabled;
 use Flarum\Extension\Event\Enabling;
 use Flarum\Extension\Event\Uninstalled;
 use Flarum\Extension\Exception\CircularDependenciesException;
+use Flarum\Extension\Exception\UnreadableManifestException;
 use Flarum\Foundation\MaintenanceMode;
 use Flarum\Foundation\Paths;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -45,14 +46,28 @@ class ExtensionManager
 
     public function getExtensions(): Collection
     {
-        if (is_null($this->extensions) && $this->filesystem->exists($this->paths->vendor.'/composer/installed.json')) {
+        if (is_null($this->extensions)) {
+            $manifest = $this->paths->vendor.'/composer/installed.json';
+
+            if (! $this->filesystem->exists($manifest)) {
+                throw UnreadableManifestException::missing($manifest);
+            }
+
             $extensions = new Collection();
 
             // Load all packages installed by composer.
-            $installed = json_decode($this->filesystem->get($this->paths->vendor.'/composer/installed.json'), true);
+            $installed = json_decode($this->filesystem->get($manifest), true);
+
+            if (! is_array($installed)) {
+                throw UnreadableManifestException::unparsable($manifest);
+            }
 
             // Composer 2.0 changes the structure of the installed.json manifest
             $installed = $installed['packages'] ?? $installed;
+
+            if (! is_array($installed)) {
+                throw UnreadableManifestException::unparsable($manifest);
+            }
 
             // We calculate and store a set of composer package names for all installed Flarum extensions,
             // so we know what is and isn't a flarum extension in `calculateDependencies`.

--- a/framework/core/tests/unit/Extension/ExtensionManagerManifestTest.php
+++ b/framework/core/tests/unit/Extension/ExtensionManagerManifestTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Extension;
+
+use Flarum\Database\Migrator;
+use Flarum\Extension\Exception\UnreadableManifestException;
+use Flarum\Extension\ExtensionManager;
+use Flarum\Foundation\MaintenanceMode;
+use Flarum\Foundation\Paths;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\Test;
+
+class ExtensionManagerManifestTest extends TestCase
+{
+    private string $vendor;
+
+    /**
+     * Every `extensions_enabled` write the manager makes, so a test can assert that the
+     * setting was left alone.
+     */
+    private array $writes = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vendor = sys_get_temp_dir().'/flarum-manifest-test-'.bin2hex(random_bytes(6)).'/vendor';
+
+        (new Filesystem())->makeDirectory($this->vendor.'/composer', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->deleteDirectory(dirname($this->vendor));
+
+        parent::tearDown();
+    }
+
+    private function manager(?string $manifest): ExtensionManager
+    {
+        $path = $this->vendor.'/composer/installed.json';
+
+        if ($manifest === null) {
+            @unlink($path);
+        } else {
+            file_put_contents($path, $manifest);
+        }
+
+        $settings = $this->createStub(SettingsRepositoryInterface::class);
+        $settings->method('get')->willReturnCallback(function (string $key) {
+            return $key === 'extensions_enabled' ? '["flarum-tags","flarum-markdown"]' : null;
+        });
+        $settings->method('set')->willReturnCallback(function (string $key, $value) {
+            $this->writes[] = [$key, $value];
+        });
+
+        return new ExtensionManager(
+            $settings,
+            new Paths([
+                'base' => dirname($this->vendor),
+                'public' => dirname($this->vendor),
+                'storage' => dirname($this->vendor),
+                'vendor' => $this->vendor,
+            ]),
+            $this->createStub(Container::class),
+            $this->createStub(Migrator::class),
+            $this->createStub(Dispatcher::class),
+            new Filesystem(),
+            $this->createStub(MaintenanceMode::class),
+        );
+    }
+
+    #[Test]
+    public function throws_when_the_manifest_is_missing(): void
+    {
+        $this->expectException(UnreadableManifestException::class);
+
+        $this->manager(null)->getExtensions();
+    }
+
+    #[Test]
+    public function throws_when_the_manifest_is_not_valid_json(): void
+    {
+        $this->expectException(UnreadableManifestException::class);
+
+        $this->manager('{"packages":[{"name":"flarum/tags","type":"flarum-ext')->getExtensions();
+    }
+
+    /**
+     * A manifest that cannot be parsed says nothing about which extensions are installed.
+     * Treating it as an empty list makes the manager prune every enabled extension and
+     * persist that, so an interrupted composer run would silently disable the forum.
+     */
+    #[Test]
+    public function does_not_touch_enabled_extensions_when_the_manifest_cannot_be_read(): void
+    {
+        foreach ([null, '{"packages":[{"name":"flarum/tags","type":"flarum-ext', 'not json at all'] as $manifest) {
+            $this->writes = [];
+
+            try {
+                $this->manager($manifest)->getExtensions();
+            } catch (UnreadableManifestException $e) {
+                // expected
+            }
+
+            $this->assertSame([], $this->writes, 'Expected no settings write for manifest: '.var_export($manifest, true));
+        }
+    }
+
+    /**
+     * A manifest that parses is authoritative. If it lists no extensions then the enabled
+     * ones really are gone, and pruning them is the existing self-healing behaviour.
+     */
+    #[Test]
+    public function prunes_enabled_extensions_when_the_manifest_is_readable_and_empty(): void
+    {
+        $extensions = $this->manager('{"packages":[]}')->getExtensions();
+
+        $this->assertCount(0, $extensions);
+        $this->assertSame([['extensions_enabled', '[]']], $this->writes);
+    }
+
+    #[Test]
+    public function reads_extensions_from_a_valid_manifest(): void
+    {
+        $extensions = $this->manager(json_encode(['packages' => [
+            [
+                'name' => 'flarum/tags',
+                'type' => 'flarum-extension',
+                'extra' => ['flarum-extension' => ['title' => 'Tags']],
+            ],
+            [
+                'name' => 'psr/log',
+                'type' => 'library',
+            ],
+        ]]))->getExtensions();
+
+        $this->assertCount(1, $extensions, 'Only flarum-extension packages are extensions');
+        $this->assertNotNull($extensions->get('flarum-tags'));
+    }
+}


### PR DESCRIPTION
Follow-up to #4946, which reported that `getExtensions()` returns `null` when `vendor/composer/installed.json` is absent. That report was correct; the fix proposed there was not, because returning an empty collection turns the failure into silent data loss. This takes the opposite approach.

**Changes proposed in this pull request:**

`getExtensions()` treats an unreadable manifest as a manifest listing nothing. Those are not the same claim, and conflating them destroys data.

When the manifest parses, it is authoritative: if an enabled extension is not in it, the extension really has been removed, and the `$needsReset` branch prunes it from `extensions_enabled`. That is deliberate self-healing and this PR leaves it alone.

When the manifest *cannot* be parsed, it says nothing at all about what is installed — but the code reaches the same branch. `json_decode` returns `null`, `foreach (null)` warns and skips, the extension collection ends up empty, every enabled extension is treated as removed, and `extensions_enabled` is overwritten with `[]`. An interrupted `composer` write silently disables the whole forum, and recovering means knowing to re-enable everything in the right dependency order.

Demonstrated on `2.x` with three extensions enabled and a truncated manifest:

```
### manifest TRUNCATED (invalid JSON)
  getExtensions() -> count=0
  writes after getExtensions(): [["extensions_enabled","[]"]]
```

So the manifest is now validated before anything is derived from it, and both unreadable cases raise `UnreadableManifestException` naming the file and what is wrong with it:

- missing — previously `TypeError: ...Return value must be of type Collection, null returned`
- present but not valid JSON — previously the silent prune above

The missing-file case is worth being explicit about: this **does not** change availability. `ExtensionManager::extend()` calls `getEnabledExtensions()` during boot, so a missing manifest already takes the site down with the `TypeError`. All this does there is replace an opaque type error with a message that names the file and says what to do about it. The behavioural fix is the invalid-JSON case.

Impacted: `framework/core/src/Extension/ExtensionManager.php`, plus a new `Flarum\Extension\Exception\UnreadableManifestException`.

**Reviewers should focus on:**

- **The distinction the guards draw.** Readable-and-empty must keep pruning, unreadable must not. `prunes_enabled_extensions_when_the_manifest_is_readable_and_empty` is the test that stops a future change from collapsing the two again.
- **Whether refusing to boot is the right call for a missing manifest.** I think it is — a forum mid-composer-operation is broken, and an empty extension list means no extenders run, so the site would render without tags, markdown or mentions and could be cached and crawled in that state. Serving a wrong forum is worse than serving an error. If we ever want the admin panel to survive that window, it needs to go through maintenance mode rather than through a falsified extension list, and that is a separate piece of work.
- **The second `is_array` check** after the Composer 1/2 shape normalisation, which catches a manifest whose `packages` key holds something other than an array.

Thanks to @karl-bullock for finding the original defect.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — returning an empty collection was proposed in #4946 and rejected: it reaches `setEnabledExtensions([])` via `syncExtensionOrder()`, which `MigrateCommand` calls, so `php flarum migrate` after an interrupted composer run would persist "no extensions enabled".
- [x] For core PRs, does this need to be in core, or could it be in an extension? — `ExtensionManager` is core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no frontend changes.
- [ ] Frontend changes: tests are green — no frontend changes.
- [ ] Frontend changes: tests have been added — no frontend changes.
- [x] Backend changes: tests are green — 417 unit tests, PHPStan level 6 clean.
- [x] Backend changes: tests have been added — `ExtensionManagerManifestTest` covers missing, truncated, invalid, readable-and-empty, and valid manifests, and asserts that no `extensions_enabled` write happens in the unreadable cases. Against the current code three of the five fail, one of them on the data-loss assertion.
- [x] Where applicable, changes are suitable for all supported database drivers — settings access only, no driver-specific behaviour.
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.
