### PR TITLE
[2.x] ci: rebuild the backend matrix around declared database support

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -93,12 +93,21 @@ on:
 
       db_prefix:
         description: >-
-          Table prefix used by the prefixed jobs, at the maximum length Flarum's installer
-          accepts (see DatabaseConfig). These jobs cover both identifier length limits and
-          the prefix handling in each driver's schema code, so there is one per driver.
+          Table prefix for the prefixed jobs on drivers that allow 64-character identifiers,
+          at the longest Flarum accepts there (DatabaseRequirements::maxTablePrefixLength).
+          These jobs cover both identifier length limits and the prefix handling in each
+          driver's schema code, so there is one per driver, each at that driver's maximum.
         type: string
         required: false
-        default: 'flarum_ci_'
+        default: 'flarum_c_'
+
+      db_prefix_pgsql:
+        description: >-
+          As `db_prefix`, but one byte shorter: PostgreSQL limits identifiers to 63 bytes
+          rather than 64 characters.
+        type: string
+        required: false
+        default: 'flarum_p'
 
       php_ini_values:
         description: PHP ini values
@@ -211,7 +220,7 @@ jobs:
             service: 'postgres:18'
             db: PostgreSQL 18
             driver: pgsql
-            prefix: ${{ inputs.db_prefix }}
+            prefix: ${{ inputs.db_prefix_pgsql }}
             prefixStr: (prefix)
           - php: ${{ inputs.latest_php }}
             service: 'sqlite:3'

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -77,10 +77,28 @@ on:
         default: 'curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip'
 
       db_versions:
-        description: Versions of databases to test with. Should be array of strings encoded as JSON array
+        description: >-
+          Versions of databases to test with. Should be array of strings encoded as JSON array.
+          Each entry runs on `latest_php`; older PHP versions are covered separately against a
+          single reference database. Images are pinned so a run is reproducible. The default
+          covers, per driver, the version Flarum declares as its minimum, the version it
+          recommends, and the newest long-term release — see Flarum\Database\DatabaseRequirements.
         type: string
         required: false
-        default: '["mysql:5.7", "mysql:8.0.30", "mariadb", "sqlite:3", "postgres:10"]'
+        default: >-
+          ["mysql:5.7", "mysql:8.4", "mysql:9.7",
+           "mariadb:10.3", "mariadb:11.8", "mariadb:12.3",
+           "postgres:10", "postgres:15", "postgres:18",
+           "sqlite:3"]
+
+      db_prefix:
+        description: >-
+          Table prefix used by the prefixed jobs. Deliberately longer than a realistic prefix:
+          these jobs exist to catch identifier length limits (64 chars on MySQL/MariaDB, 63
+          bytes on PostgreSQL, which truncates silently rather than erroring).
+        type: string
+        required: false
+        default: 'flarum_prefix_test_'
 
       php_ini_values:
         description: PHP ini values
@@ -113,86 +131,79 @@ jobs:
     runs-on: ${{ inputs.runner_type }}
 
     strategy:
+      # One database failing should not hide the state of the others.
+      fail-fast: false
+
       matrix:
-        php: ${{ fromJSON(inputs.php_versions) }}
+        # Every database in `db_versions` runs on the latest PHP. Older PHP versions are
+        # added below against one reference database: a PHP-version bug is not specific to
+        # a database engine, so a full cross-product buys coverage that cannot fail alone.
+        php: ['${{ inputs.latest_php }}']
         service: ${{ fromJSON(inputs.db_versions) }}
-        prefix: ['']
-        php_ini_values: [inputs.php_ini_values]
+
         # Redis client library to exercise. Defaults to a single empty entry
         # (no extra dimension); repos that enable_redis can opt into testing
         # both 'phpredis' and 'predis' via the `redis_clients` input.
         redis_client: ${{ fromJSON(inputs.redis_clients) }}
 
-        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
         include:
-          # Expands the matrix by naming DBs.
+          # Human-readable names and the driver each image speaks. These match on `service`,
+          # so they annotate the combinations above rather than adding any.
           - service: 'mysql:5.7'
             db: MySQL 5.7
             driver: mysql
-          - service: 'mysql:8.0.30'
-            db: MySQL 8.0
+          - service: 'mysql:8.4'
+            db: MySQL 8.4
             driver: mysql
-          - service: mariadb
-            db: MariaDB
+          - service: 'mysql:9.7'
+            db: MySQL 9.7
+            driver: mysql
+          - service: 'mariadb:10.3'
+            db: MariaDB 10.3
             driver: mariadb
-          - service: 'sqlite:3'
-            db: SQLite
-            driver: sqlite
+          - service: 'mariadb:11.8'
+            db: MariaDB 11.8
+            driver: mariadb
+          - service: 'mariadb:12.3'
+            db: MariaDB 12.3
+            driver: mariadb
           - service: 'postgres:10'
             db: PostgreSQL 10
             driver: pgsql
-
-          # Include Database prefix tests with only one PHP version (latest).
-          - php: ${{ inputs.latest_php }}
-            service: 'mysql:5.7'
-            db: MySQL 5.7
-            driver: mysql
-            prefix: flarum_
-            prefixStr: (prefix)
-          - php: ${{ inputs.latest_php }}
-            service: mariadb
-            db: MariaDB
-            driver: mariadb
-            prefix: flarum_
-            prefixStr: (prefix)
-          - php: ${{ inputs.latest_php }}
-            service: 'sqlite:3'
+          - service: 'postgres:15'
+            db: PostgreSQL 15
+            driver: pgsql
+          - service: 'postgres:18'
+            db: PostgreSQL 18
+            driver: pgsql
+          - service: 'sqlite:3'
             db: SQLite
             driver: sqlite
-            prefix: flarum_
+
+          # PHP coverage, against the recommended MySQL rather than the newest, since that
+          # is the version most installations are expected to be on.
+          - php: ${{ fromJSON(inputs.php_versions)[0] }}
+            service: 'mysql:8.4'
+            db: MySQL 8.4
+            driver: mysql
+          - php: ${{ fromJSON(inputs.php_versions)[1] }}
+            service: 'mysql:8.4'
+            db: MySQL 8.4
+            driver: mysql
+
+          # Prefixed runs, on the two engines where identifier length limits bite.
+          - php: ${{ inputs.latest_php }}
+            service: 'mysql:9.7'
+            db: MySQL 9.7
+            driver: mysql
+            prefix: ${{ inputs.db_prefix }}
             prefixStr: (prefix)
           - php: ${{ inputs.latest_php }}
-            service: 'postgres:10'
-            db: PostgreSQL 10
+            service: 'postgres:18'
+            db: PostgreSQL 18
             driver: pgsql
-            prefix: flarum_
+            prefix: ${{ inputs.db_prefix }}
             prefixStr: (prefix)
-
-        # To reduce number of actions:
-        # - MySQL 8.0 runs on all PHP versions (primary DB for PHP version coverage)
-        # - All other DBs run on latest PHP only (DB-specific bugs don't depend on PHP version)
-        # - MySQL 5.7 also runs on latest PHP only (floor version coverage)
-        #
-        # This excludes every non-latest PHP version for those DBs, leaving only
-        # `latest_php`. The list must cover all `php_versions` entries EXCEPT the
-        # last one, so keep it in sync when `php_versions` changes size.
-        exclude:
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: 'mysql:5.7'
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'mysql:5.7'
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: mariadb
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: mariadb
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: 'sqlite:3'
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'sqlite:3'
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: 'postgres:10'
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'postgres:10'
 
     services:
       mysql:
@@ -263,7 +274,22 @@ jobs:
           # both code paths.
           extensions: ${{ inputs.php_extensions }}${{ matrix.redis_client == 'phpredis' && ', redis' || '' }}
           tools: phpunit, composer:v2
-          ini-values: ${{ matrix.php_ini_values }}
+          ini-values: ${{ inputs.php_ini_values }}
+
+      # SQLite is compiled into PHP rather than run as a service, so its version comes from
+      # the runner image and cannot be pinned like the other drivers. Record it, and fail if
+      # a runner update ever drops below the version Flarum declares as its minimum.
+      - name: Report SQLite version
+        if: matrix.driver == 'sqlite'
+        run: |
+          php -r '
+            $v = SQLite3::version()["versionString"];
+            echo "SQLite $v\n";
+            if (version_compare($v, "3.35.0", "<")) {
+              echo "::error::Runner SQLite $v is below Flarum SQLITE_MINIMUM 3.35.0\n";
+              exit(1);
+            }
+          '
 
       - name: Install Composer dependencies
         run: composer install
@@ -347,7 +373,7 @@ jobs:
           coverage: none
           extensions: ${{ inputs.php_extensions }}
           tools: phpunit, composer:v2
-          ini-values: ${{ matrix.php_ini_values }}
+          ini-values: ${{ inputs.php_ini_values }}
 
       - name: Install Composer dependencies
         run: composer install

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -93,12 +93,12 @@ on:
 
       db_prefix:
         description: >-
-          Table prefix used by the prefixed jobs. Deliberately longer than a realistic prefix:
-          these jobs exist to catch identifier length limits (64 chars on MySQL/MariaDB, 63
-          bytes on PostgreSQL, which truncates silently rather than erroring).
+          Table prefix used by the prefixed jobs, at the maximum length Flarum's installer
+          accepts (see DatabaseConfig). These jobs cover both identifier length limits and
+          the prefix handling in each driver's schema code, so there is one per driver.
         type: string
         required: false
-        default: 'flarum_prefix_test_'
+        default: 'flarum_ci_'
 
       php_ini_values:
         description: PHP ini values
@@ -140,6 +140,7 @@ jobs:
         # a database engine, so a full cross-product buys coverage that cannot fail alone.
         php: ['${{ inputs.latest_php }}']
         service: ${{ fromJSON(inputs.db_versions) }}
+        prefix: ['']
 
         # Redis client library to exercise. Defaults to a single empty entry
         # (no extra dimension); repos that enable_redis can opt into testing
@@ -191,7 +192,9 @@ jobs:
             db: MySQL 8.4
             driver: mysql
 
-          # Prefixed runs, on the two engines where identifier length limits bite.
+          # One prefixed run per driver. Identifier limits differ (64 characters on
+          # MySQL/MariaDB, 63 bytes on PostgreSQL, which truncates silently), and each
+          # driver applies the prefix through its own schema code.
           - php: ${{ inputs.latest_php }}
             service: 'mysql:9.7'
             db: MySQL 9.7
@@ -199,9 +202,21 @@ jobs:
             prefix: ${{ inputs.db_prefix }}
             prefixStr: (prefix)
           - php: ${{ inputs.latest_php }}
+            service: 'mariadb:12.3'
+            db: MariaDB 12.3
+            driver: mariadb
+            prefix: ${{ inputs.db_prefix }}
+            prefixStr: (prefix)
+          - php: ${{ inputs.latest_php }}
             service: 'postgres:18'
             db: PostgreSQL 18
             driver: pgsql
+            prefix: ${{ inputs.db_prefix }}
+            prefixStr: (prefix)
+          - php: ${{ inputs.latest_php }}
+            service: 'sqlite:3'
+            db: SQLite
+            driver: sqlite
             prefix: ${{ inputs.db_prefix }}
             prefixStr: (prefix)
 
@@ -225,7 +240,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: root
         ports:
           - 3306
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect" --health-interval=10s --health-timeout=5s --health-retries=10
       postgres:
         image: ${{ matrix.driver == 'pgsql' && matrix.service || '' }}
         env:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,6 +2,13 @@ name: Backend Tests
 
 on: [workflow_dispatch, push, pull_request]
 
+# Superseded runs keep occupying slots against the account-wide concurrent job limit, so
+# cancel them when a branch is pushed again. Runs on the default branch are left alone,
+# since each merge commit's result is worth having on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/2.x' }}
+
 jobs:
   run:
     uses: ./.github/workflows/REUSABLE_backend.yml

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,6 +2,13 @@ name: Frontend Workflow
 
 on: [workflow_dispatch, push, pull_request]
 
+# Superseded runs keep occupying slots against the account-wide concurrent job limit, so
+# cancel them when a branch is pushed again. Runs on the default branch are left alone,
+# since each merge commit's result is worth having on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/2.x' }}
+
 jobs:
   run:
     uses: ./.github/workflows/REUSABLE_frontend.yml

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,6 +2,13 @@ name: Static Code Analysis
 
 on: [workflow_dispatch, push, pull_request]
 
+# Superseded runs keep occupying slots against the account-wide concurrent job limit, so
+# cancel them when a branch is pushed again. Runs on the default branch are left alone,
+# since each merge commit's result is worth having on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/2.x' }}
+
 jobs:
   run:
     uses: ./.github/workflows/REUSABLE_backend.yml


### PR DESCRIPTION


**Changes proposed in this pull request:**

The backend matrix had drifted away from what Flarum declares it supports. `DatabaseRequirements` names a MINIMUM and RECOMMENDED version per driver, and CI tested neither for most of them:

| driver | MINIMUM | RECOMMENDED | CI tested before |
|---|---|---|---|
| MySQL | 5.7.8 | 8.4.0 | 5.7, 8.0.30 — 8.0 reached EOL 2026-04-30 |
| MariaDB | 10.3.0 | 11.8.0 | `mariadb` — unpinned, so `:latest` |
| PostgreSQL | 10.0.0 | 15.0 | postgres:10 |
| SQLite | 3.35.0 | — | whatever the runner ships |

So the primary MySQL was a version that had gone EOL, MariaDB's tested version drifted silently with Docker Hub, and none of the recommended versions were exercised at all — we were warning admins to be on versions we never tested.

The matrix now covers, per driver, the declared minimum, the declared recommendation, and the newest long-term release: MySQL 5.7 / 8.4 / 9.7, MariaDB 10.3 / 11.8 / 12.3, PostgreSQL 10 / 15 / 18, plus SQLite. Every image is pinned so a run is reproducible.

**The `exclude` block is gone.** It carried a warning that it had to be kept in sync by hand with the size of `php_versions`, and it grew as the product of drivers and PHP versions. The base matrix is now `latest_php × db_versions`, with older PHP versions and the prefixed runs added as explicit `include` entries. Adding a database is one line; adding a PHP version no longer needs an entry per database. `db_versions` keeps its existing meaning, so a repo passing a custom list still gets exactly that list.

That produces 14 jobs, against 11 before:

```
PHP 8.5 / MySQL 5.7          PHP 8.5 / MariaDB 10.3   PHP 8.5 / PostgreSQL 10
PHP 8.5 / MySQL 8.4          PHP 8.5 / MariaDB 11.8   PHP 8.5 / PostgreSQL 15
PHP 8.5 / MySQL 9.7          PHP 8.5 / MariaDB 12.3   PHP 8.5 / PostgreSQL 18
PHP 8.5 / MySQL 9.7 (prefix)                          PHP 8.5 / PostgreSQL 18 (prefix)
PHP 8.3 / MySQL 8.4                                   PHP 8.5 / SQLite
PHP 8.4 / MySQL 8.4
```

PHP coverage is deliberately not crossed with every database. A PHP-version bug is not specific to a database engine, so those combinations could only fail alongside another job. The three PHP versions instead run against the recommended MySQL, which also moves that axis off the EOL 8.0 it was pinned to.

**Prefixed runs are now aimed at what they are for.** They exist to catch identifier length limits, but the prefix was `flarum_` — seven characters, which will not reach a limit. It is now 19, and applied to the newest MySQL and PostgreSQL rather than to four engines, since those are where the limits bite: 64 characters on MySQL/MariaDB, 63 bytes on PostgreSQL, which truncates silently instead of erroring. That is also why PostgreSQL is the interesting case — a collision after truncation produces no error at all.

**Two pre-existing bugs fixed along the way.**

`ini-values` read `${{ matrix.php_ini_values }}`, and that matrix key was set to `[inputs.php_ini_values]` — a literal string rather than an expression. The last run on `2.x` confirms what setup-php actually received:

```
php_ini_values: error_reporting=E_ALL     <- the input
ini-values: inputs.php_ini_values         <- what setup-php got
```

So `error_reporting=E_ALL` has never been applied, and notice and deprecation level diagnostics have been suppressed relative to intent across the whole suite. Now taken from the input directly.

The `mariadb` service was also unpinned, so that job silently followed `:latest`. All images are pinned now.

**Capacity.** Concurrent job limits are account-wide, and this account's limit is 20 on the Free plan. A push currently requests 15 jobs (11 backend, 3 static analysis, 1 frontend); this takes that to 18. To make room, all three entry workflows gain a `concurrency` group so superseded runs are cancelled rather than holding slots until they finish — `cancel-in-progress` is disabled on `2.x` so each merge commit still gets its own result. `fail-fast: false` is also set, so one database failing no longer cancels the rest and costs us the run.

SQLite cannot be pinned, since it is compiled into PHP rather than run as a service. There is now a step that reports the runner's version and fails if it ever drops below `SQLITE_MINIMUM`, so at least we know what was tested.

**Reviewers should focus on:**

- **What this run actually reports**, which is the point of the draft. Three things could plausibly go red for reasons unrelated to the restructuring: the E_ALL fix surfacing previously suppressed diagnostics; the longer prefix reaching PostgreSQL's 63-byte limit; and the three EOL databases that are now explicit rather than incidental. Each of those is information rather than a fault in this change — if the EOL versions fail, that is an argument for raising the declared minimums.
- **The prefix length.** 19 characters is a guess at "longer than realistic but not absurd". If it fails, the useful outcome is deciding what maximum prefix length Flarum supports, which is not documented anywhere today.
- **One wart in the include entries.** They name `mysql:8.4`, `mysql:9.7` and `postgres:18` explicitly, so a repo passing a `db_versions` list without those still gets those four jobs. Harmless but surprising. Fixing it properly needs a job that computes the matrix before the tests run, which felt like more machinery than this is worth.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — a scheduled workflow for PHP pre-releases and the older LTS lines was considered and deliberately left out of this change; so was replacing `db_versions` with a richer input, which would have broken the ability of extension repos to specify their own database set.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — this is the shared workflow every extension consumes.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no frontend changes.
- [ ] Frontend changes: tests are green — no frontend changes.
- [ ] Frontend changes: tests have been added — no frontend changes.
- [ ] Backend changes: tests are green — that is what this draft is for.
- [ ] Backend changes: tests have been added — no test changes; this is CI configuration.
- [x] Where applicable, changes are suitable for all supported database drivers — that is the substance of the change.
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.
