### PR TITLE
[2.x] fix: validate the table prefix against the driver's identifier limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - (statistics) count the whole custom range in the per-entity period totals by @imorland [#4956]
 - (core) scope haptic feedback to browsers with the Vibration API, and hide its setting elsewhere by @imorland [#4957]
 - (core) don't treat an unreadable package manifest as an empty extension list by @imorland [#4958]
+- (core) validate the table prefix against the database driver's identifier limit by @imorland [#4961]
 
 ### Security
 

--- a/framework/core/src/Database/DatabaseRequirements.php
+++ b/framework/core/src/Database/DatabaseRequirements.php
@@ -59,6 +59,43 @@ class DatabaseRequirements
     public const SQLITE_MINIMUM = '3.35.0';
 
     /**
+     * How long an identifier each driver accepts. MySQL and MariaDB count characters;
+     * PostgreSQL counts bytes. SQLite imposes no practical limit.
+     */
+    public const IDENTIFIER_LIMITS = [
+        'mysql' => 64,
+        'mariadb' => 64,
+        'pgsql' => 63,
+    ];
+
+    /**
+     * Length of the longest index or foreign key name any migration in core or the bundled
+     * extensions generates, currently `dialog_message_mentions_group_dialog_message_id_foreign`
+     * from flarum/messages.
+     *
+     * Laravel prepends the table prefix to generated index and foreign key names as well as
+     * to table names, so this plus the prefix has to fit inside the driver's limit. Because
+     * migrations are immutable and a new installation replays all of them, this is set by
+     * migration history rather than by the current schema — renaming a table later does not
+     * change it.
+     *
+     * flarum/testing asserts this against the migrations actually being run, so a migration
+     * introducing a longer name fails there rather than in someone's installation.
+     */
+    public const LONGEST_MIGRATION_IDENTIFIER = 55;
+
+    /**
+     * Longest table prefix, in bytes, that leaves room for every identifier the migrations
+     * generate. Null where the driver has no meaningful limit.
+     */
+    public static function maxTablePrefixLength(string $driver): ?int
+    {
+        $limit = self::IDENTIFIER_LIMITS[$driver] ?? null;
+
+        return $limit === null ? null : $limit - self::LONGEST_MIGRATION_IDENTIFIER;
+    }
+
+    /**
      * The result of comparing a version against the tiers.
      */
     public const OK = 'ok';

--- a/framework/core/src/Database/DatabaseServiceProvider.php
+++ b/framework/core/src/Database/DatabaseServiceProvider.php
@@ -11,6 +11,7 @@ namespace Flarum\Database;
 
 use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
+use Flarum\Database\Exception\TablePrefixTooLong;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Paths;
 use Illuminate\Container\Container as ContainerImplementation;
@@ -37,6 +38,14 @@ class DatabaseServiceProvider extends AbstractServiceProvider
             $manager = new Manager($container);
 
             $config = $container['flarum']->config('database');
+
+            // Only the installer validates the prefix, so an installation that was upgraded
+            // from 1.x or had its config.php edited by hand has never had this checked.
+            $maxPrefix = DatabaseRequirements::maxTablePrefixLength($config['driver']);
+
+            if ($maxPrefix !== null && strlen($config['prefix'] ?? '') > $maxPrefix) {
+                throw new TablePrefixTooLong($config['prefix'], $config['driver']);
+            }
 
             if (in_array($config['driver'], ['mysql', 'mariadb'])) {
                 $config['engine'] = 'InnoDB';

--- a/framework/core/src/Database/Exception/TablePrefixTooLong.php
+++ b/framework/core/src/Database/Exception/TablePrefixTooLong.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Database\Exception;
+
+use Flarum\Database\DatabaseRequirements;
+use RuntimeException;
+
+class TablePrefixTooLong extends RuntimeException
+{
+    public function __construct(
+        public string $prefix,
+        public string $driver
+    ) {
+        $max = DatabaseRequirements::maxTablePrefixLength($driver);
+        $limit = DatabaseRequirements::IDENTIFIER_LIMITS[$driver] ?? null;
+        $length = strlen($prefix);
+
+        parent::__construct(
+            "The database table prefix '$prefix' is $length bytes long, but $driver allows at most $max. ".
+            "Identifiers on $driver cannot exceed $limit, the longest index name Flarum's migrations generate is ".
+            DatabaseRequirements::LONGEST_MIGRATION_IDENTIFIER.', and the prefix is prepended to index and foreign key '.
+            'names as well as to table names. A longer prefix will stop migrations running. Shorten the `prefix` value '.
+            'in config.php and rename the existing tables to match.'
+        );
+    }
+}

--- a/framework/core/src/Install/DatabaseConfig.php
+++ b/framework/core/src/Install/DatabaseConfig.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Install;
 
+use Flarum\Database\DatabaseRequirements;
 use Flarum\Foundation\Paths;
 use Illuminate\Contracts\Support\Arrayable;
 
@@ -72,8 +73,10 @@ class DatabaseConfig implements Arrayable
                 throw new ValidationFailed('The prefix may only contain characters and underscores.');
             }
 
-            if (strlen($this->prefix) > 10) {
-                throw new ValidationFailed('The prefix should be no longer than 10 characters.');
+            $maxPrefix = DatabaseRequirements::maxTablePrefixLength($this->driver);
+
+            if ($maxPrefix !== null && strlen($this->prefix) > $maxPrefix) {
+                throw new ValidationFailed("The prefix should be no longer than $maxPrefix characters on $this->driver.");
             }
         }
     }

--- a/framework/core/tests/unit/Database/TablePrefixLimitTest.php
+++ b/framework/core/tests/unit/Database/TablePrefixLimitTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Database;
+
+use Flarum\Database\DatabaseRequirements;
+use Flarum\Install\DatabaseConfig;
+use Flarum\Install\ValidationFailed;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class TablePrefixLimitTest extends TestCase
+{
+    /**
+     * The prefix is prepended to generated index names, so what fits depends on how long an
+     * identifier the driver accepts.
+     */
+    #[Test]
+    public function max_prefix_length_is_derived_from_the_driver_limit(): void
+    {
+        $longest = DatabaseRequirements::LONGEST_MIGRATION_IDENTIFIER;
+
+        $this->assertSame(64 - $longest, DatabaseRequirements::maxTablePrefixLength('mysql'));
+        $this->assertSame(64 - $longest, DatabaseRequirements::maxTablePrefixLength('mariadb'));
+        $this->assertSame(63 - $longest, DatabaseRequirements::maxTablePrefixLength('pgsql'));
+    }
+
+    #[Test]
+    public function sqlite_has_no_meaningful_prefix_limit(): void
+    {
+        $this->assertNull(DatabaseRequirements::maxTablePrefixLength('sqlite'));
+    }
+
+    /**
+     * PostgreSQL allows one character fewer than MySQL, so a prefix can be valid on one and
+     * not the other. The installer has to judge it against the driver being installed.
+     */
+    #[Test]
+    public function installer_accepts_a_prefix_that_fits_the_chosen_driver(): void
+    {
+        $prefix = str_repeat('a', DatabaseRequirements::maxTablePrefixLength('mysql'));
+
+        $config = new DatabaseConfig('mysql', 'localhost', 3306, 'flarum', null, 'flarum', '', $prefix);
+
+        $this->assertSame($prefix, $config->toArray()['prefix']);
+    }
+
+    #[Test]
+    public function installer_rejects_a_prefix_too_long_for_the_chosen_driver(): void
+    {
+        $prefix = str_repeat('a', DatabaseRequirements::maxTablePrefixLength('pgsql') + 1);
+
+        $this->expectException(ValidationFailed::class);
+
+        new DatabaseConfig('pgsql', 'localhost', 5432, 'flarum', null, 'flarum', '', $prefix);
+    }
+
+    /**
+     * The same prefix that PostgreSQL rejects is fine on MySQL, which is the whole reason the
+     * limit cannot be a single number.
+     */
+    #[Test]
+    public function a_prefix_can_be_valid_on_one_driver_and_not_another(): void
+    {
+        $prefix = str_repeat('a', DatabaseRequirements::maxTablePrefixLength('mysql'));
+
+        $this->assertGreaterThan(DatabaseRequirements::maxTablePrefixLength('pgsql'), strlen($prefix));
+
+        new DatabaseConfig('mysql', 'localhost', 3306, 'flarum', null, 'flarum', '', $prefix);
+
+        $this->expectException(ValidationFailed::class);
+
+        new DatabaseConfig('pgsql', 'localhost', 5432, 'flarum', null, 'flarum', '', $prefix);
+    }
+
+    /**
+     * The prefix is measured in bytes because PostgreSQL counts bytes, and the installer
+     * permits Unicode prefixes.
+     */
+    #[Test]
+    public function prefix_length_is_measured_in_bytes(): void
+    {
+        // Five characters, ten bytes.
+        $prefix = str_repeat('é', 5);
+
+        $this->assertSame(10, strlen($prefix));
+
+        $this->expectException(ValidationFailed::class);
+
+        new DatabaseConfig('pgsql', 'localhost', 5432, 'flarum', null, 'flarum', '', $prefix);
+    }
+}


### PR DESCRIPTION
Found while validating the reworked CI matrix in #4959, which runs prefixed jobs at the maximum prefix length the installer accepts. Two of those jobs failed:

```
SQLSTATE[42000]: 1059 Identifier name
'flarum_ci_dialog_message_mentions_group_dialog_message_id_foreign' is too long
```

**Changes proposed in this pull request:**

`DatabaseConfig` accepts a table prefix of up to 10 characters, and that figure is wrong for every driver.

Laravel prepends the prefix to generated index and foreign key names as well as to table names, so the prefix and the longest name any migration generates have to fit inside the driver's identifier limit together. Auditing all 181 migration files in core and the bundled extensions — driven through Laravel's own `createIndexName` rather than by pattern-matching the convention — the longest is 55 characters, `dialog_message_mentions_group_dialog_message_id_foreign` from flarum/messages. That gives:

| driver | identifier limit | longest generated name | max prefix |
|---|---|---|---|
| MySQL | 64 characters | 55 | 9 |
| MariaDB | 64 characters | 55 | 9 |
| PostgreSQL | 63 bytes | 55 | 8 |
| SQLite | none in practice | 55 | unrestricted |

So a 10-character prefix is accepted by the installer and then cannot run the migrations. On MySQL and MariaDB that is a hard `1059` and a bundled extension simply cannot be enabled. On PostgreSQL it appears to work, because PostgreSQL truncates over-long identifiers silently instead of erroring — the constraint is created under a name nobody chose, and two such names colliding after truncation is the next failure. That is also why the prefixed PostgreSQL job in #4959 passed while the MySQL one failed; a green PostgreSQL run is not evidence the schema is right.

The limit cannot be a single number, so `DatabaseRequirements` now derives it:

```php
DatabaseRequirements::maxTablePrefixLength('mysql')   // 9
DatabaseRequirements::maxTablePrefixLength('pgsql')   // 8
DatabaseRequirements::maxTablePrefixLength('sqlite')  // null
```

from two new pieces of data — `IDENTIFIER_LIMITS` per driver, and `LONGEST_MIGRATION_IDENTIFIER`, the audited 55.

It is validated in both places a prefix can arrive:

- **The installer**, against the driver being installed, so a new installation cannot reach the broken state.
- **Boot**, in `DatabaseServiceProvider` where the connection config is assembled. This is the only check that ever runs for an installation upgraded from 1.x or one whose `config.php` was edited by hand — `DatabaseConfig` is constructed by the install steps and nothing else, so those installations have never had their prefix validated at all. They get `TablePrefixTooLong`, naming the prefix, the driver, the limit and what to do, rather than MySQL's `1059` from somewhere inside a migration.

Length is measured in bytes throughout. PostgreSQL counts bytes, and the prefix pattern permits Unicode (`/^[\pL\pM\pN_]+$/u`), so a five-character Cyrillic prefix is ten bytes.

**Why the identifiers are not simply shortened instead**

That was the first attempt and it does not work. Migrations are immutable, and a new installation replays all of them, so the ceiling is set by migration *history* rather than by the current schema — renaming those tables in a later migration cannot stop the original `create` from generating a 55-character name on every new install. Raising the ceiling would mean editing migrations that have already run elsewhere, which is not on the table. The limit is what it is; this makes Flarum state it correctly and enforce it.

Naming the keys explicitly is also not a route. `prefix_indexes` is consulted only inside `Blueprint::createIndexName()`, which runs only when no name is supplied, so an explicit name is never prefixed — and foreign key constraint names must be unique per database, not per table, which is exactly the shared-database case prefixes serve. Verified on MySQL 8.4:

```
ERROR 1826 (HY000): Duplicate foreign key constraint name 'dmm_group_msg_foreign'
```

**Reviewers should focus on:**

- **This tightens what the installer accepts**, from 10 to 9 on MySQL/MariaDB and 8 on PostgreSQL. Deliberate: the previous figure could not work.
- **Existing installations at 9 or 10 will now throw at boot.** On MySQL a 9-character prefix lands on exactly 64 and works today, so throwing there is a behaviour change for a working forum — but it is one bundled extension away from a failed migration, and the alternative is that it fails later, deeper, and less legibly. On PostgreSQL, 9 and 10 are already producing truncated identifiers. This is the loud failure the issue calls for; worth confirming you want it loud for those installations rather than a warning.
- **`LONGEST_MIGRATION_IDENTIFIER` is a measured constant** and will be wrong if a migration ever introduces a longer name. The `flarum/testing` check that follows asserts it against the migrations actually being run, so that drift fails a test suite rather than an installation.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — shortening the identifiers and naming the keys explicitly were both tried and rejected for the reasons above.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the installer and the connection config are core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no frontend changes.
- [ ] Frontend changes: tests are green — no frontend changes.
- [ ] Frontend changes: tests have been added — no frontend changes.
- [x] Backend changes: tests are green — 423 unit tests, PHPStan clean across the whole configured path set.
- [x] Backend changes: tests have been added — `TablePrefixLimitTest` covers the per-driver derivation, SQLite being unrestricted, a prefix that is valid on MySQL and invalid on PostgreSQL, and byte rather than character counting.
- [x] Where applicable, changes are suitable for all supported database drivers — the change is per-driver by construction.
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.
