### PR TITLE
[2.x] fix: break ties in sorted listings by primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - (core) scope haptic feedback to browsers with the Vibration API, and hide its setting elsewhere by @imorland [#4957]
 - (core) don't treat an unreadable package manifest as an empty extension list by @imorland [#4958]
 - (core) validate the table prefix against the database driver's identifier limit by @imorland [#4961]
+- (core) break ties in sorted listings by primary key so paginated results are stable by @imorland [#4962]
 
 ### Security
 

--- a/framework/core/src/Api/Endpoint/Index.php
+++ b/framework/core/src/Api/Endpoint/Index.php
@@ -24,6 +24,7 @@ use Flarum\Database\Eloquent\Collection;
 use Flarum\Search\SearchCriteria;
 use Flarum\Search\SearchManager;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Psr\Http\Message\ResponseInterface as Response;
 use RuntimeException;
 use Tobyz\JsonApiServer\Exception\BadRequestException;
@@ -211,29 +212,49 @@ class Index extends Endpoint
 
     final protected function applySorts($query, Context $context, ?array $sort): void
     {
-        if (! $sort) {
-            return;
+        if ($sort) {
+            $collection = $context->collection;
+
+            if (! $collection instanceof AbstractResource) {
+                throw new RuntimeException('The collection '.$collection::class.' must extend '.AbstractResource::class);
+            }
+
+            $sorts = $collection->resolveSorts();
+
+            foreach ($sort as $name => $direction) {
+                foreach ($sorts as $field) {
+                    if ($field->name === $name && $field->isVisible($context)) {
+                        $field->apply($query, $direction, $context);
+                        continue 2;
+                    }
+                }
+
+                throw (new BadRequestException("Invalid sort: $name"))->setSource([
+                    'parameter' => 'sort',
+                ]);
+            }
         }
 
-        $collection = $context->collection;
+        // Sorting by a column that isn't unique leaves the order of tied rows to the
+        // database, and results are paginated by offset, so an unstable order can repeat a
+        // row on one page and skip it on the next. Ending every sort on the primary key
+        // makes the order total. Applies with no sort too: unordered pagination has the
+        // same problem.
+        //
+        // The direction follows the last ordering already applied, because an InnoDB
+        // secondary index carries the primary key: `column DESC, id DESC` is still answered
+        // by an index on `column` alone, where mixing directions forces a filesort.
+        if ($query instanceof EloquentBuilder) {
+            $direction = 'asc';
 
-        if (! $collection instanceof AbstractResource) {
-            throw new RuntimeException('The collection '.$collection::class.' must extend '.AbstractResource::class);
-        }
-
-        $sorts = $collection->resolveSorts();
-
-        foreach ($sort as $name => $direction) {
-            foreach ($sorts as $field) {
-                if ($field->name === $name && $field->isVisible($context)) {
-                    $field->apply($query, $direction, $context);
-                    continue 2;
+            foreach (array_reverse($query->getQuery()->orders ?? []) as $order) {
+                if (isset($order['direction'])) {
+                    $direction = $order['direction'];
+                    break;
                 }
             }
 
-            throw (new BadRequestException("Invalid sort: $name"))->setSource([
-                'parameter' => 'sort',
-            ]);
+            $query->orderBy($query->getModel()->getQualifiedKeyName(), $direction);
         }
     }
 

--- a/framework/core/src/Search/Database/AbstractSearcher.php
+++ b/framework/core/src/Search/Database/AbstractSearcher.php
@@ -45,6 +45,9 @@ abstract class AbstractSearcher implements SearcherInterface
             $mutator($search, $criteria);
         }
 
+        // After the mutators, since one may have rewritten the query into a union.
+        $this->applyTieBreaker($search);
+
         $query = $search->getQuery();
 
         // Execute the search query and retrieve the results. We get one more
@@ -93,6 +96,55 @@ abstract class AbstractSearcher implements SearcherInterface
                 }
             }
         }
+    }
+
+    /**
+     * Order rows the requested sort leaves tied.
+     *
+     * Sorting by a column that isn't unique leaves the order of tied rows to the database,
+     * which is free to differ between engines, versions and even executions. Results are
+     * then paginated by offset, so an unstable order can repeat a row on one page and skip
+     * it on the next. Ending every sort on the primary key makes the order total.
+     */
+    protected function applyTieBreaker(DatabaseSearchState $state): void
+    {
+        $query = $state->getQuery();
+        $base = $query->getQuery();
+        $model = $query->getModel();
+
+        if (! empty($base->unions)) {
+            // A union's ordering resolves against the columns of the result, so it cannot
+            // name a table.
+            $base->unionOrders[] = [
+                'column' => $model->getKeyName(),
+                'direction' => static::lastOrderDirection($base->unionOrders),
+            ];
+
+            return;
+        }
+
+        $query->orderBy(
+            $model->getQualifiedKeyName(),
+            static::lastOrderDirection($base->orders)
+        );
+    }
+
+    /**
+     * The direction of the last ordering in a list, or ascending if it has none.
+     *
+     * The tie breaker follows it rather than always ascending: an InnoDB secondary index
+     * already carries the primary key, so `column DESC, id DESC` is still answered by an
+     * index on `column` alone, where mixing the two directions forces a filesort.
+     */
+    protected static function lastOrderDirection(?array $orders): string
+    {
+        foreach (array_reverse($orders ?? []) as $order) {
+            if (isset($order['direction'])) {
+                return $order['direction'];
+            }
+        }
+
+        return 'asc';
     }
 
     protected function applyOffset(DatabaseSearchState $state, int $offset): void

--- a/framework/core/tests/integration/api/discussions/ListPaginationStabilityTest.php
+++ b/framework/core/tests/integration/api/discussions/ListPaginationStabilityTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\discussions;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+
+/**
+ * Results are paginated by offset, so the order has to be total. Sorting by a column that
+ * isn't unique leaves tied rows in whatever order the database happens to return, which
+ * differs between engines and versions, and can differ between two executions of the same
+ * query. When it does, a row can appear on one page and again on the next while another is
+ * never returned at all.
+ */
+class ListPaginationStabilityTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * Enough discussions to span several pages, deliberately tied on every sortable column:
+     * one `last_posted_at`, one `comment_count` and one `title` shared by all of them.
+     */
+    protected const COUNT = 24;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tied = Carbon::parse('2026-01-01 12:00:00')->toDateTimeString();
+
+        $discussions = [];
+
+        for ($id = 1; $id <= self::COUNT; $id++) {
+            $discussions[] = [
+                'id' => $id,
+                'title' => 'Tied title',
+                'created_at' => $tied,
+                'last_posted_at' => $tied,
+                'user_id' => 1,
+                'first_post_id' => 0,
+                'comment_count' => 1,
+                'is_private' => 0,
+            ];
+        }
+
+        $this->prepareDatabase([
+            User::class => [$this->normalUser()],
+            Discussion::class => $discussions,
+        ]);
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function idsOnPage(int $offset, int $limit, ?string $sort): array
+    {
+        $params = ['page' => ['offset' => $offset, 'limit' => $limit]];
+
+        if ($sort !== null) {
+            $params['sort'] = $sort;
+        }
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 1])
+                ->withQueryParams($params)
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return array_map('intval', Arr::pluck(
+            json_decode($response->getBody()->getContents(), true)['data'],
+            'id'
+        ));
+    }
+
+    #[Test]
+    #[TestWith([null], 'default sort')]
+    #[TestWith(['-lastPostedAt'], 'lastPostedAt descending')]
+    #[TestWith(['lastPostedAt'], 'lastPostedAt ascending')]
+    #[TestWith(['-commentCount'], 'commentCount descending')]
+    #[TestWith(['createdAt'], 'createdAt ascending')]
+    #[TestWith(['title'], 'title ascending')]
+    public function paging_through_a_tied_sort_returns_every_discussion_exactly_once(?string $sort): void
+    {
+        $limit = 5;
+        $seen = [];
+
+        for ($offset = 0; $offset < self::COUNT; $offset += $limit) {
+            $seen = array_merge($seen, $this->idsOnPage($offset, $limit, $sort));
+        }
+
+        $duplicates = array_keys(array_filter(array_count_values($seen), fn ($n) => $n > 1));
+        $missing = array_values(array_diff(range(1, self::COUNT), $seen));
+
+        $this->assertSame([], $duplicates, 'No discussion should appear on more than one page');
+        $this->assertSame([], $missing, 'Every discussion should appear on some page');
+        $this->assertCount(self::COUNT, $seen);
+    }
+
+    /**
+     * The order also has to be the same each time it is asked for, or paging through it is
+     * unsound however complete any single pass looks.
+     */
+    #[Test]
+    public function the_order_is_repeatable(): void
+    {
+        $first = $this->idsOnPage(0, self::COUNT, '-lastPostedAt');
+        $second = $this->idsOnPage(0, self::COUNT, '-lastPostedAt');
+
+        $this->assertSame($first, $second);
+    }
+
+    /**
+     * With every sortable column tied, the primary key is what is left to order by. It
+     * follows the direction of the sort it is breaking ties for, so that an index on the
+     * sorted column still answers the ordering.
+     */
+    #[Test]
+    public function ties_are_ordered_by_primary_key(): void
+    {
+        $this->assertSame(
+            array_reverse(range(1, self::COUNT)),
+            $this->idsOnPage(0, self::COUNT, '-lastPostedAt'),
+            'A descending sort should break ties descending'
+        );
+
+        $this->assertSame(
+            range(1, self::COUNT),
+            $this->idsOnPage(0, self::COUNT, 'lastPostedAt'),
+            'An ascending sort should break ties ascending'
+        );
+    }
+}

--- a/framework/core/tests/integration/extenders/ApiResourceTest.php
+++ b/framework/core/tests/integration/extenders/ApiResourceTest.php
@@ -27,7 +27,6 @@ use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
-use Illuminate\Database\PostgresConnection;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Attributes\Test;
 use Tobyz\JsonApiServer\Schema\Field\Field;
@@ -572,11 +571,10 @@ class ApiResourceTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        if ($this->database() instanceof PostgresConnection) {
-            $this->assertEquals([2, 1, 4, 5, 6, 3], Arr::pluck($payload['data'], 'id'));
-        } else {
-            $this->assertEquals([2, 6, 5, 4, 1, 3], Arr::pluck($payload['data'], 'id'));
-        }
+        // Discussions 1, 4, 5 and 6 all belong to user 2, so `-userId` alone does not order
+        // them. Every sort ends on the primary key, in the same direction, which makes the
+        // order total and the same on every driver.
+        $this->assertEquals([2, 6, 5, 4, 1, 3], Arr::pluck($payload['data'], 'id'));
     }
 
     #[Test]


### PR DESCRIPTION
Found while validating the reworked CI matrix in #4959, where `ApiResourceTest::custom_sort_field_works_if_set` failed on MariaDB 10.3.

**Changes proposed in this pull request:**

Listings are sorted and then paginated by offset. Neither sort path appends a tie breaker, so sorting by a column that isn't unique leaves the order of tied rows entirely to the database — and offset pagination on top of an unstable order can return a row on one page, return it again on the next, and never return another one at all.

The failing test made this concrete. It sorts six discussions by `-userId`, where four of them share `user_id = 2`, and asserts an exact sequence of IDs. It already carried a driver-specific branch:

```php
if ($this->database() instanceof PostgresConnection) {
    $this->assertEquals([2, 1, 4, 5, 6, 3], ...);
} else {
    $this->assertEquals([2, 6, 5, 4, 1, 3], ...);
}
```

That branch was the previous encounter with this, papered over per driver. MariaDB 10.3 returns a third order and falls into the `else`. More tellingly, running the suite against a local MySQL 8.4 produced `[2, 1, 4, 5, 6, 3]` — the PostgreSQL order — while CI's MySQL 8.4 produced `[2, 6, 5, 4, 1, 3]`. Same engine, same version, different order. Nothing was guaranteeing either.

So every sort now ends on the primary key, in both places sorting is applied:

- `AbstractSearcher::applySort`, the searcher path, which is what `/api/discussions` and other searchable resources actually use.
- `Index::applySorts`, for everything else. This runs even when no sort was requested, since unordered pagination has exactly the same problem.

**The tie breaker follows the direction of the sort it is breaking**, which is what keeps this from costing anything. An InnoDB secondary index already carries the primary key, so an index on `last_posted_at` answers `last_posted_at DESC, id DESC` — but not `last_posted_at DESC, id ASC`, where the mixed directions force a filesort. Measured on MySQL 8.4 over 20,000 rows with an index on `last_posted_at`:

```
ORDER BY last_posted_at DESC              Backward index scan; Using index
ORDER BY last_posted_at DESC, id ASC      Using index; Using filesort      <- naive tie breaker
ORDER BY last_posted_at DESC, id DESC     Backward index scan; Using index <- this PR
ORDER BY last_posted_at ASC, id ASC       Using index
```

Matching the direction means no query plan changes and no new indexes are needed.

**Tests**

`ListPaginationStabilityTest` seeds 24 discussions deliberately tied on every sortable column — one `last_posted_at`, one `comment_count`, one `title` — and pages through them five at a time across six sorts including the default. It asserts that every discussion appears exactly once: no duplicates, no omissions. It also asserts the order is repeatable between identical requests, and that ties land in primary key order following the sort's direction.

Being honest about what goes red without the fix: only `ties_are_ordered_by_primary_key` fails reliably, because the bug is undefined behaviour rather than wrong behaviour. On an engine that happens to return a stable order the pagination assertions pass either way — that is exactly why this went unnoticed, and why the guarantee has to be asserted directly rather than inferred from a single pass. The coverage tests earn their place as regressions on the engines where the order is not stable.

`custom_sort_field_works_if_set` loses its driver branch and asserts one sequence for every driver.

Impacted: `framework/core/src/Search/Database/AbstractSearcher.php`, `framework/core/src/Api/Endpoint/Index.php`.

**Reviewers should focus on:**

- **`Index::applySorts` now applies an ordering even with no sort requested.** Previously it returned early. An unordered listing was equally unsound, but it does mean endpoints that requested nothing now come back in primary key order rather than whatever the database offered.
- **The direction-matching behaviour is observable.** A descending sort breaks ties descending, so `-lastPostedAt` over tied rows returns the newest IDs first. That is the choice that keeps the index usable; ascending ties under a descending sort would look tidier and cost a filesort.
- **Extensions with their own searchers** inherit this through `AbstractSearcher::applySort`. Any that override `applySort` will not, which is worth being aware of rather than something to fix here.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — loosening the test assertion to tolerate any tie order was the alternative, and it would have left pagination unsound; adding composite `(column, id)` indexes is unnecessary once the directions match.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — both sort paths are core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation — no frontend changes.
- [ ] Frontend changes: tests are green — no frontend changes.
- [ ] Frontend changes: tests have been added — no frontend changes.
- [x] Backend changes: tests are green — all 869 core integration tests against MySQL 8.4, 423 unit tests, PHPStan clean. No existing test depended on the old ordering.
- [x] Backend changes: tests have been added — `ListPaginationStabilityTest`, eight cases.
- [x] Where applicable, changes are suitable for all supported database drivers — the point of the change is that the result no longer varies by driver; #4959's matrix covers MySQL 5.7/8.4/9.7, MariaDB 10.3/11.8/12.3, PostgreSQL 10/15/18 and SQLite.
- [ ] Core developer confirmed locally this works as intended.
- [ ] The description above is written by me and describes what this pull request actually does.
