### PR TITLE
[2.x] fix: tune wide-screen reading width and sidebar widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - (core) don't treat an unreadable package manifest as an empty extension list by @imorland [#4958]
 - (core) validate the table prefix against the database driver's identifier limit by @imorland [#4961]
 - (core) break ties in sorted listings by primary key so paginated results are stable by @imorland [#4962]
+- (core) tune wide-screen reading width and sidebar widths by @imorland [#4964]
 
 ### Security
 

--- a/framework/core/less/common/root.less
+++ b/framework/core/less/common/root.less
@@ -179,11 +179,11 @@
   // (or pin them all to one value) without re-declaring media queries.
   --container-hd:                  1200px;
   --container-xl:                  1300px;
-  --container-xxl:                 1600px;
+  --container-xxl:                 1500px;
 
   // Readability cap for the discussion post stream on wide screens: the
   // container keeps growing, prose does not. See DiscussionPage.less.
-  --discussion-content-max-width:  1000px;
+  --discussion-content-max-width:  860px;
 
   --primary-color:                 @primary-color;
   --secondary-color:               @secondary-color;

--- a/framework/core/less/common/root.less
+++ b/framework/core/less/common/root.less
@@ -182,8 +182,12 @@
   --container-xxl:                 1500px;
 
   // Readability cap for the discussion post stream on wide screens: the
-  // container keeps growing, prose does not. See DiscussionPage.less.
-  --discussion-content-max-width:  860px;
+  // container keeps growing, prose does not. Font-relative so the line length
+  // holds as font size or zoom changes. See DiscussionPage.less.
+  --discussion-content-max-width:  100ch;
+
+  // Post body font size, bumped up on wide screens where there is room.
+  --post-font-size:                14px;
 
   --primary-color:                 @primary-color;
   --secondary-color:               @secondary-color;
@@ -287,7 +291,7 @@
   @media @phone { --flarum-screen: phone; }
   @media @tablet { --flarum-screen: tablet; }
   @media @desktop { --flarum-screen: desktop; }
-  @media @desktop-hd { --flarum-screen: desktop-hd; }
+  @media @desktop-hd { --flarum-screen: desktop-hd; --post-font-size: 15px; }
 
   // ---------------------------------
   // COMPONENT LAYOUTS

--- a/framework/core/less/common/sideNav.less
+++ b/framework/core/less/common/sideNav.less
@@ -60,6 +60,13 @@
 
     &, > ul {
       width: 190px;
+
+      @media @desktop-hd {
+        width: 260px;
+      }
+      @media @desktop-xxl {
+        width: 280px;
+      }
     }
     > ul {
       &.affix {

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -71,9 +71,11 @@
 }
 
 // Cap the post stream for readability on wide screens and centre it, so the
-// slack splits around the column instead of pooling beside the sidebar.
+// slack splits around the column instead of pooling beside the sidebar. The cap
+// is in ch, measured against the column's own (wide-screen) font size.
 @media @desktop-hd {
   .DiscussionPage .Page-content {
+    font-size: var(--post-font-size);
     max-width: var(--discussion-content-max-width);
     margin-left: auto;
     margin-right: auto;

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -70,13 +70,12 @@
   }
 }
 
-// On the widest bands the container keeps growing but prose should not: long
-// text lines get hard to read. Cap the post stream and let the slack sit
-// between it and the scrubber sidebar (the container is row-reversed, so the
-// auto margin on the content's main-start side absorbs the slack).
-@media @desktop-xl {
+// Cap the post stream for readability on wide screens and centre it, so the
+// slack splits around the column instead of pooling beside the sidebar.
+@media @desktop-hd {
   .DiscussionPage .Page-content {
     max-width: var(--discussion-content-max-width);
+    margin-left: auto;
     margin-right: auto;
   }
 }

--- a/framework/core/less/forum/PageStructure.less
+++ b/framework/core/less/forum/PageStructure.less
@@ -21,6 +21,11 @@
   --content-width: 100%;
   --sidebar-width: 190px;
   --gap: 50px;
+
+  @media @desktop-hd {
+    --sidebar-width: 230px;
+    --gap: 56px;
+  }
   padding-bottom: var(--page-bottom-padding);
 
   &-container {

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -87,7 +87,7 @@
 }
 
 .Post-body {
-  font-size: 14px;
+  font-size: var(--post-font-size);
   line-height: 1.7;
   position: relative;
   overflow: auto;


### PR DESCRIPTION
**Changes proposed in this pull request:**

rc.6 introduces wider breakpoints so large displays make fuller use of their space. This refines that work — while the new breakpoints are still in the same release — so the *reading* measure stays comfortable and the wide layout doesn't leave an awkward gap.

- **The discussion reading column is capped tighter and centred.** As it stood, the post stream was capped at 1000px only from the xl band (≥1600px) and pinned to one side with `margin-right: auto`, which pushed the slack into a single large gap next to the scrubber sidebar. It is now capped at 860px, applied from the hd band (≥1100px), and centred — so the leftover space splits evenly around the column instead of pooling on one side. That keeps prose near the ~65-character comfortable line length while the container still grows for the rest of the layout.
- **The discussion (scrubber) sidebar and layout gap get a little more room on wide screens** — sidebar 190→230px, gap 50→56px, from the hd band up.
- **The index left nav widens on wide screens** — 190→260px from the hd band, and 280px on the widest (xxl) band — since it holds tag names that benefit from the extra width when the space is there.
- **The xxl container is reined in** from 1600→1500px, so on ultrawide displays the layout doesn't grow wider than the content needs.

Every change is scoped to ≥1100px (`@desktop-hd` and up). Phone, tablet, and small-desktop (992–1099px) layouts are untouched — the base values still apply there — so nothing narrows or shifts on smaller screens.

All of the widths remain CSS custom properties / theme-overridable, so a theme or forum can retune (or restore) any of them with a few lines of CSS.

Impacted: `less/common/root.less`, `less/common/sideNav.less`, `less/forum/DiscussionPage.less`, `less/forum/PageStructure.less`.

**Reviewers should focus on:**

- **The centring of the discussion content column.** Centring (`margin-left: auto` + `margin-right: auto`) rather than pinning is what closes the wide-screen gap; the reading cap alone would have made it worse. Worth confirming it reads well across the hd / xl / xxl bands.
- **The scoping.** The sidebar/gap/nav bumps live in `@desktop-hd` (and `@desktop-xxl`) blocks so they don't affect the 992–1099px small-desktop band; the base declarations are unchanged.
- **The chosen widths** (content 860, scrubber 230, index nav 260/280, container-xxl 1500). These were tuned by eye on a real forum across 1366 / 1600 / 1920 / 2560 viewports; they're all tokens, so retuning is cheap.

**Screenshot**

Tuned and verified on a development forum across 1366 / 1600 / 1920 / 2560px, on both the index and a prose-heavy discussion: reading width lands near the ~65-character target, the wide-screen gap is gone, and nothing below 1100px changes.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — an admin setting was considered and set aside: reading width has a genuine right answer (~65 characters), the values are already theme-overridable via CSS variables, and a setting for one layout dimension is more surface than it's worth.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — these are core layout defaults.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green — CSS-only; no JS to test.
- [ ] Frontend changes: tests have been added, or are not appropriate here. — a breakpoint/layout change with no meaningful unit-test surface; verified visually across viewports instead.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added — no backend changes.
- [ ] Where applicable, changes are suitable for all supported database drivers — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
