### PR TITLE
feat: experimental CJK search mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - (audit) audit queue pause and resume by @imorland [#4845]
 - (tags) let a tag set the sort its discussion list opens with by @imorland [#4922]
 - (core) show links back to the forum as the discussion they point at by @imorland [#4924]
+- (core) add an experimental opt-in CJK search mode by @imorland [#4965]
 
 ### Changed
 

--- a/framework/core/js/src/admin/components/AdvancedPage.tsx
+++ b/framework/core/js/src/admin/components/AdvancedPage.tsx
@@ -85,6 +85,8 @@ export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> e
   searchDrivers() {
     const hasOtherDrivers = Object.keys(this.searchDriverOptions).some((model) => Object.keys(this.searchDriverOptions[model]).length > 1);
 
+    const cjkCapableDriver = app.data.dbDriver === DatabaseDriver.MySQL || app.data.dbDriver === DatabaseDriver.MariaDB;
+
     return (
       <FormSection label={app.translator.trans('core.admin.advanced.search.section_label')}>
         {hasOtherDrivers ? (
@@ -110,6 +112,16 @@ export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> e
           <InfoTile icon="fas fa-database" className="InfoTile--warning">
             {app.translator.trans('core.admin.advanced.search.no_other_drivers')}
           </InfoTile>
+        )}
+        {cjkCapableDriver && (
+          <Form>
+            {this.buildSettingComponent({
+              type: 'switch',
+              setting: 'search_cjk_mode',
+              label: app.translator.trans('core.admin.advanced.search.cjk_mode_label'),
+              help: app.translator.trans('core.admin.advanced.search.cjk_mode_help'),
+            })}
+          </Form>
         )}
       </FormSection>
     );

--- a/framework/core/js/src/common/SearchManager.ts
+++ b/framework/core/js/src/common/SearchManager.ts
@@ -1,3 +1,4 @@
+import app from './app';
 import SearchState from './states/SearchState';
 import GambitManager from './GambitManager';
 
@@ -6,6 +7,24 @@ export default class SearchManager<State extends SearchState = SearchState> {
    * The minimum query length before sources are searched.
    */
   public static MIN_SEARCH_LEN = 3;
+
+  /**
+   * Whether experimental CJK search mode is enabled.
+   */
+  public static isCjkMode(): boolean {
+    const settings = app.data.settings as Record<string, unknown> | undefined;
+
+    return (settings?.['search_cjk_mode'] as unknown as boolean | undefined) ?? false;
+  }
+
+  /**
+   * The minimum query length for the current forum. Experimental CJK search mode
+   * drops it to 1, since a single character is often a whole word in languages
+   * without word spaces; the substring match backing that mode has no minimum.
+   */
+  public static minSearchLength(): number {
+    return this.isCjkMode() ? 1 : this.MIN_SEARCH_LEN;
+  }
 
   /**
    * Time to wait (in milliseconds) after the user stops typing before triggering a search.

--- a/framework/core/js/src/common/components/SearchModal.tsx
+++ b/framework/core/js/src/common/components/SearchModal.tsx
@@ -311,7 +311,7 @@ export default class SearchModal<CustomAttrs extends ISearchModalAttrs = ISearch
     this.searchTimeout = window.setTimeout(() => {
       if (source.isCached(query)) return;
 
-      if (query.length >= SearchManager.MIN_SEARCH_LEN) {
+      if (query.length >= SearchManager.minSearchLength()) {
         if (!source.search) return;
 
         this.loadingSources.push(source.resource);

--- a/framework/core/js/src/forum/components/Search.tsx
+++ b/framework/core/js/src/forum/components/Search.tsx
@@ -7,6 +7,7 @@ import extractText from '../../common/utils/extractText';
 import KeyboardNavigatable from '../../common/utils/KeyboardNavigatable';
 import Icon from '../../common/components/Icon';
 import SearchState from '../../common/states/SearchState';
+import SearchManager from '../../common/SearchManager';
 import DiscussionsSearchSource from './DiscussionsSearchSource';
 import UsersSearchSource from './UsersSearchSource';
 import type Mithril from 'mithril';
@@ -61,6 +62,14 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
    * The minimum query length before sources are searched.
    */
   protected static MIN_SEARCH_LEN = 3;
+
+  /**
+   * The minimum query length for the current forum. Experimental CJK search mode
+   * drops it to 1; otherwise the (subclass-overridable) MIN_SEARCH_LEN applies.
+   */
+  static minSearchLength(): number {
+    return SearchManager.isCjkMode() ? 1 : this.MIN_SEARCH_LEN;
+  }
 
   /**
    * The instance of `SearchState` for this component.
@@ -228,7 +237,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
         search.searchTimeout = window.setTimeout(() => {
           if (state.isCached(query)) return;
 
-          if (query.length >= (search.constructor as typeof Search).MIN_SEARCH_LEN) {
+          if (query.length >= (search.constructor as typeof Search).minSearchLength()) {
             search.sources?.map((source) => {
               if (!source.search) return;
 

--- a/framework/core/js/tests/unit/common/SearchManager.test.ts
+++ b/framework/core/js/tests/unit/common/SearchManager.test.ts
@@ -1,0 +1,43 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from '../../../src/forum/app';
+import SearchManager from '../../../src/common/SearchManager';
+
+/**
+ * The minimum query length is a frontend gate deciding when a search actually
+ * fires. Experimental CJK search mode lowers it to 1, because a single
+ * character is often a whole word in languages without word spaces and the
+ * substring match backing that mode has no minimum token length. Every other
+ * forum keeps the default so a stray keystroke does not fire a search.
+ */
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+});
+
+function setCjkMode(enabled: boolean | undefined): void {
+  (app.data.settings as Record<string, unknown>) = enabled === undefined ? {} : { search_cjk_mode: enabled };
+}
+
+describe('SearchManager min search length', () => {
+  it('defaults to the standard minimum when CJK mode is off', () => {
+    setCjkMode(false);
+
+    expect(SearchManager.isCjkMode()).toBe(false);
+    expect(SearchManager.minSearchLength()).toBe(SearchManager.MIN_SEARCH_LEN);
+    expect(SearchManager.minSearchLength()).toBe(3);
+  });
+
+  it('defaults to the standard minimum when the setting is absent', () => {
+    setCjkMode(undefined);
+
+    expect(SearchManager.isCjkMode()).toBe(false);
+    expect(SearchManager.minSearchLength()).toBe(3);
+  });
+
+  it('drops to 1 when CJK mode is on', () => {
+    setCjkMode(true);
+
+    expect(SearchManager.isCjkMode()).toBe(true);
+    expect(SearchManager.minSearchLength()).toBe(1);
+  });
+});

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -99,6 +99,8 @@ core:
         driver_options:
           default: Default database search
         no_other_drivers: No search drivers are available yet. Install a search driver extension to be able to configure it.
+        cjk_mode_label: Optimise search for CJK languages
+        cjk_mode_help: Enable if your forum is primarily in Chinese, Japanese, or Korean. The database's word-based search cannot match parts of CJK text, so this switches to a substring match that can. It is slower on very large forums.
       title: Advanced
 
     # These translations are used in the Appearance page.

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -100,7 +100,7 @@ core:
           default: Default database search
         no_other_drivers: No search drivers are available yet. Install a search driver extension to be able to configure it.
         cjk_mode_label: Optimise search for CJK languages
-        cjk_mode_help: Enable if your forum is primarily in Chinese, Japanese, or Korean. The database's word-based search cannot match parts of CJK text, so this switches to a substring match that can. It is slower on very large forums.
+        cjk_mode_help: Enable if your forum is primarily in Chinese, Japanese, or Korean. The database's word-based search cannot match parts of CJK text, so this switches to a substring match that can. It is slower on very large forums, where configuring a CJK-aware fulltext parser at the database level (such as MySQL/MariaDB's ngram parser) is a faster alternative.
       title: Advanced
 
     # These translations are used in the Appearance page.

--- a/framework/core/src/Discussion/Search/FulltextFilter.php
+++ b/framework/core/src/Discussion/Search/FulltextFilter.php
@@ -61,14 +61,11 @@ class FulltextFilter extends AbstractFulltextFilter
             $query->where('discussions.title', 'like', "%$value%")
                 ->orWhereExists(function (QueryBuilder $query) use ($state, $value) {
                     $query->selectRaw('1')
-                        ->from(
-                            Post::whereVisibleTo($state->getActor())
-                                ->whereColumn('discussion_id', 'discussions.id')
-                                ->where('type', 'comment')
-                                ->where('content', 'like', "%$value%")
-                                ->limit(1)
-                                ->toBase()
-                        );
+                        ->from('posts')
+                        ->whereColumn('posts.discussion_id', 'discussions.id')
+                        ->where('posts.type', 'comment')
+                        ->where('posts.content', 'like', "%$value%")
+                        ->whereIn('posts.id', Post::whereVisibleTo($state->getActor())->select('posts.id')->toBase());
                 });
         });
     }

--- a/framework/core/src/Discussion/Search/FulltextFilter.php
+++ b/framework/core/src/Discussion/Search/FulltextFilter.php
@@ -57,17 +57,30 @@ class FulltextFilter extends AbstractFulltextFilter
     {
         $query = $state->getQuery();
 
-        $query->where(function (Builder $query) use ($state, $value) {
-            $query->where('discussions.title', 'like', "%$value%")
-                ->orWhereExists(function (QueryBuilder $query) use ($state, $value) {
-                    $query->selectRaw('1')
-                        ->from('posts')
-                        ->whereColumn('posts.discussion_id', 'discussions.id')
-                        ->where('posts.type', 'comment')
-                        ->where('posts.content', 'like', "%$value%")
-                        ->whereIn('posts.id', Post::whereVisibleTo($state->getActor())->select('posts.id')->toBase());
-                });
-        });
+        $matchingComments = function (QueryBuilder $query) use ($state, $value): QueryBuilder {
+            return $query
+                ->from('posts')
+                ->whereColumn('posts.discussion_id', 'discussions.id')
+                ->where('posts.type', 'comment')
+                ->where('posts.content', 'like', "%$value%")
+                ->whereIn('posts.id', Post::whereVisibleTo($state->getActor())->select('posts.id')->toBase());
+        };
+
+        // Keep parity with the fulltext drivers so the mostRelevantPost include
+        // still resolves: the earliest matching comment, falling back to the
+        // discussion's first post when only the title matched.
+        $query
+            ->selectSub(function (QueryBuilder $query) use ($matchingComments) {
+                $matchingComments($query)->selectRaw('coalesce(min(posts.id), discussions.first_post_id)');
+            }, 'most_relevant_post_id')
+            ->where(function (Builder $query) use ($value, $matchingComments) {
+                $query->where('discussions.title', 'like', "%$value%")
+                    ->orWhereExists(function (QueryBuilder $query) use ($matchingComments) {
+                        $matchingComments($query)->selectRaw('1');
+                    });
+            });
+
+        $state->setDefaultSort(fn (Builder $query) => $query->orderByDesc('discussions.last_posted_at'));
     }
 
     protected function mysql(DatabaseSearchState $state, string $value): void

--- a/framework/core/src/Discussion/Search/FulltextFilter.php
+++ b/framework/core/src/Discussion/Search/FulltextFilter.php
@@ -56,6 +56,7 @@ class FulltextFilter extends AbstractFulltextFilter
     protected function like(DatabaseSearchState $state, string $value): void
     {
         $query = $state->getQuery();
+        $grammar = $query->getGrammar();
 
         $matchingComments = function (QueryBuilder $query) use ($state, $value): QueryBuilder {
             return $query
@@ -69,9 +70,11 @@ class FulltextFilter extends AbstractFulltextFilter
         // Keep parity with the fulltext drivers so the mostRelevantPost include
         // still resolves: the earliest matching comment, falling back to the
         // discussion's first post when only the title matched.
+        $coalesce = 'coalesce(min('.$grammar->wrap('posts.id').'), '.$grammar->wrap('discussions.first_post_id').')';
+
         $query
-            ->selectSub(function (QueryBuilder $query) use ($matchingComments) {
-                $matchingComments($query)->selectRaw('coalesce(min(posts.id), discussions.first_post_id)');
+            ->selectSub(function (QueryBuilder $query) use ($matchingComments, $coalesce) {
+                $matchingComments($query)->selectRaw($coalesce);
             }, 'most_relevant_post_id')
             ->where(function (Builder $query) use ($value, $matchingComments) {
                 $query->where('discussions.title', 'like', "%$value%")

--- a/framework/core/src/Discussion/Search/FulltextFilter.php
+++ b/framework/core/src/Discussion/Search/FulltextFilter.php
@@ -32,6 +32,14 @@ class FulltextFilter extends AbstractFulltextFilter
 
     public function search(SearchState $state, string $value): void
     {
+        // Fulltext tokenisers can't segment CJK, so substring queries only work
+        // via a LIKE match (as SQLite always does).
+        if ($this->settings->get('search_cjk_mode')) {
+            $this->like($state, $value);
+
+            return;
+        }
+
         match ($state->getQuery()->getConnection()->getDriverName()) {
             'mysql', 'mariadb' => $this->mysql($state, $value),
             'pgsql' => $this->pgsql($state, $value),
@@ -41,6 +49,11 @@ class FulltextFilter extends AbstractFulltextFilter
     }
 
     protected function sqlite(DatabaseSearchState $state, string $value): void
+    {
+        $this->like($state, $value);
+    }
+
+    protected function like(DatabaseSearchState $state, string $value): void
     {
         $query = $state->getQuery();
 

--- a/framework/core/src/Post/Filter/FulltextFilter.php
+++ b/framework/core/src/Post/Filter/FulltextFilter.php
@@ -28,6 +28,12 @@ class FulltextFilter extends AbstractFulltextFilter
 
     public function search(SearchState $state, string $value): void
     {
+        if ($this->settings->get('search_cjk_mode')) {
+            $this->like($state, $value);
+
+            return;
+        }
+
         match ($state->getQuery()->getConnection()->getDriverName()) {
             'mysql', 'mariadb' => $this->mysql($state, $value),
             'pgsql' => $this->pgsql($state, $value),
@@ -37,6 +43,11 @@ class FulltextFilter extends AbstractFulltextFilter
     }
 
     protected function sqlite(DatabaseSearchState $state, string $value): void
+    {
+        $this->like($state, $value);
+    }
+
+    protected function like(DatabaseSearchState $state, string $value): void
     {
         $state->getQuery()->where('content', 'like', "%$value%");
     }

--- a/framework/core/src/Settings/SettingsServiceProvider.php
+++ b/framework/core/src/Settings/SettingsServiceProvider.php
@@ -39,6 +39,7 @@ class SettingsServiceProvider extends AbstractServiceProvider
                 'search_driver_Flarum\Post\Post' => 'default',
                 'search_driver_Flarum\Http\AccessToken' => 'default',
                 'pgsql_search_configuration' => 'english',
+                'search_cjk_mode' => false,
             ]);
         });
 

--- a/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
+++ b/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
@@ -197,13 +197,21 @@ class ListWithFulltextSearchTest extends TestCase
 
         $response = $this->send(
             $this->request('GET', '/api/discussions')
-                ->withQueryParams(['filter' => ['q' => '中文']])
+                ->withQueryParams([
+                    'filter' => ['q' => '中文'],
+                    'include' => 'mostRelevantPost',
+                ])
         );
 
-        $ids = Arr::pluck(json_decode($response->getBody()->getContents(), true)['data'], 'id');
+        $data = json_decode($response->getBody()->getContents(), true);
+        $ids = Arr::pluck($data['data'], 'id');
 
         // Discussion 6 (title 支持中文吗) and discussion 2 (post 7, content 支持中文吗).
         $this->assertEqualsCanonicalizing(['2', '6'], $ids, 'CJK substring should be found with CJK search mode.');
+
+        // The mostRelevantPost include must still resolve, as it does for the
+        // fulltext drivers — post 7 is the matching comment in discussion 2.
+        $this->assertContains('7', Arr::pluck($data['included'], 'id'), 'mostRelevantPost include must resolve in CJK mode.');
     }
 
     #[Test]

--- a/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
+++ b/framework/core/tests/integration/api/discussions/ListWithFulltextSearchTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\api\discussions;
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
@@ -164,6 +165,64 @@ class ListWithFulltextSearchTest extends TestCase
 
         $this->assertEqualsCanonicalizing(['2', '6'], $ids, 'IDs do not match');
         $this->assertEqualsCanonicalizing(['7'], Arr::pluck($data['included'], 'id'));
+    }
+
+    #[Test]
+    public function cannot_search_cjk_substring_by_default()
+    {
+        if ($this->database()->getDriverName() === 'sqlite') {
+            return $this->markTestSkipped('SQLite already searches by substring.');
+        }
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['filter' => ['q' => '中文']])
+        );
+
+        $ids = Arr::pluck(json_decode($response->getBody()->getContents(), true)['data'], 'id');
+
+        $this->assertEquals([], $ids, 'CJK substring should not be found without CJK search mode.');
+    }
+
+    #[Test]
+    public function can_search_cjk_substring_with_cjk_mode()
+    {
+        if ($this->database()->getDriverName() === 'sqlite') {
+            return $this->markTestSkipped('SQLite already searches by substring.');
+        }
+
+        // setUp() has already booted the app, so the pre-boot setting() stash is
+        // ignored; write straight to the repository the request reads.
+        $this->app()->getContainer()->make(SettingsRepositoryInterface::class)->set('search_cjk_mode', '1');
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['filter' => ['q' => '中文']])
+        );
+
+        $ids = Arr::pluck(json_decode($response->getBody()->getContents(), true)['data'], 'id');
+
+        // Discussion 6 (title 支持中文吗) and discussion 2 (post 7, content 支持中文吗).
+        $this->assertEqualsCanonicalizing(['2', '6'], $ids, 'CJK substring should be found with CJK search mode.');
+    }
+
+    #[Test]
+    public function cjk_mode_leaves_latin_search_working()
+    {
+        if ($this->database()->getDriverName() === 'sqlite') {
+            return $this->markTestSkipped('No fulltext search in SQLite.');
+        }
+
+        $this->app()->getContainer()->make(SettingsRepositoryInterface::class)->set('search_cjk_mode', '1');
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['filter' => ['q' => 'lightsail']])
+        );
+
+        $ids = Arr::pluck(json_decode($response->getBody()->getContents(), true)['data'], 'id');
+
+        $this->assertEqualsCanonicalizing(['1', '2', '3'], $ids, 'Latin search must still work with CJK mode on.');
     }
 
     #[Test]

--- a/framework/core/tests/integration/api/posts/ListWithFulltextSearchTest.php
+++ b/framework/core/tests/integration/api/posts/ListWithFulltextSearchTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\posts;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\Test;
+
+class ListWithFulltextSearchTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->database()->rollBack();
+
+        // FULLTEXT indexing does not happen inside a transaction, so this data is
+        // inserted outside one and cleaned up explicitly in tearDown().
+        $this->database()->table('discussions')->insert($this->rowsThroughFactory(Discussion::class, [
+            ['id' => 1, 'title' => 'first', 'user_id' => 1],
+            ['id' => 2, 'title' => 'second', 'user_id' => 1],
+        ]));
+
+        $this->database()->table('posts')->insert($this->rowsThroughFactory(Post::class, [
+            ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
+            ['id' => 2, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>nothing relevant here</p></t>'],
+            ['id' => 3, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>支持中文吗</p></t>'],
+        ]));
+
+        $this->database()->beginTransaction();
+
+        $this->populateDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->database()->table('discussions')->delete();
+        $this->database()->table('posts')->delete();
+    }
+
+    #[Test]
+    public function can_search_posts_by_content()
+    {
+        if ($this->database()->getDriverName() === 'sqlite') {
+            return $this->markTestSkipped('No fulltext search in SQLite.');
+        }
+
+        $ids = $this->searchPosts('lightsail');
+
+        $this->assertEqualsCanonicalizing(['1'], $ids);
+    }
+
+    #[Test]
+    public function cannot_search_cjk_substring_by_default()
+    {
+        if ($this->database()->getDriverName() === 'sqlite') {
+            return $this->markTestSkipped('SQLite already searches by substring.');
+        }
+
+        $this->assertEquals([], $this->searchPosts('中文'), 'CJK substring should not be found without CJK search mode.');
+    }
+
+    #[Test]
+    public function can_search_cjk_substring_with_cjk_mode()
+    {
+        if ($this->database()->getDriverName() === 'sqlite') {
+            return $this->markTestSkipped('SQLite already searches by substring.');
+        }
+
+        $this->app()->getContainer()->make(SettingsRepositoryInterface::class)->set('search_cjk_mode', '1');
+
+        $this->assertEqualsCanonicalizing(['3'], $this->searchPosts('中文'), 'CJK substring should be found with CJK search mode.');
+    }
+
+    #[Test]
+    public function cjk_mode_leaves_normal_search_working()
+    {
+        if ($this->database()->getDriverName() === 'sqlite') {
+            return $this->markTestSkipped('No fulltext search in SQLite.');
+        }
+
+        $this->app()->getContainer()->make(SettingsRepositoryInterface::class)->set('search_cjk_mode', '1');
+
+        $this->assertEqualsCanonicalizing(['1'], $this->searchPosts('lightsail'));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function searchPosts(string $query): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 1])
+                ->withQueryParams(['filter' => ['q' => $query]])
+        );
+
+        return Arr::pluck(json_decode($response->getBody()->getContents(), true)['data'], 'id');
+    }
+}

--- a/framework/core/tests/integration/api/posts/ListWithFulltextSearchTest.php
+++ b/framework/core/tests/integration/api/posts/ListWithFulltextSearchTest.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Tests\integration\api\posts;
 
-use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;


### PR DESCRIPTION
**Fixes #4914**

**Changes proposed in this pull request:**

An initial, experimental CJK search mode. It's opt-in and off by default; consider it a first setup we can build on, not a finished CJK search solution.

CJK search is broken on the fulltext drivers. MySQL/MariaDB and PostgreSQL tokenise on word boundaries, and CJK doesn't use spaces, so a run of characters is one token — you can't find `中文` inside `支持中文吗`, you have to type the whole thing. This is what the linked issue and several forum threads are reporting.

There's no free fix. The `ngram` fulltext parser handles CJK *and* keeps using the index (so it stays fast at scale), but it degrades short Latin queries (a plain `MATCH` for `cat` stops matching), is MySQL/MariaDB-only, and is an index-level property that needs a manual `ALTER TABLE ... WITH PARSER ngram` — so it can't be a core default. A pluggable/external search driver is the proper long-term answer, but that's later.

For that reason this mode's help text points admins of large CJK forums at the ngram parser as the faster, index-using alternative, and ngram + an external driver are the natural follow-ups for a fuller CJK search story.

So this is the simple, opt-in version, in two parts:

1. **A `search_cjk_mode` setting.** When it's on, the discussion and post fulltext filters do a substring `LIKE` match instead of `MATCH ... AGAINST` — the same thing SQLite already does, which is why SQLite has never had this problem. The discussion path keeps parity with the fulltext drivers: it still resolves `mostRelevantPost` and orders results, so the response shape doesn't change for clients or extensions. Off by default, so nothing changes for existing forums.

2. **A lower minimum search length in that mode.** The frontend only fires a search once the query reaches `MIN_SEARCH_LEN` (3), which mirrors the default fulltext minimum token size. In CJK a single character is frequently a whole word, and the `LIKE` match has no minimum, so with the mode on the minimum drops to 1 — otherwise the substring backend would work but the frontend would never send short CJK queries. It stays at 3 for everyone else.

The setting shows up in Admin → Advanced → Search Drivers, only on MySQL/MariaDB (SQLite already searches by substring). The help text is honest about the trade-off: `LIKE '%...%'` can't use the index, so it's slower on very large forums. For a primarily-CJK forum that's the right trade; for everyone else it stays off.

Impacted: the two fulltext filters, the setting default, the admin page, and the frontend search min-length gate.

**Reviewers should focus on:**

- The disabled path is unchanged — the setting guard returns early before the existing `match()`, and the frontend min-length stays 3 unless the setting is on.
- Extensibility: the LIKE discussion path returns the same shape as the fulltext drivers (`mostRelevantPost` + ordering), and `Search.MIN_SEARCH_LEN` stays overridable by subclasses; the CJK override centralises through `SearchManager.isCjkMode()`.
- Whether we want the toggle exposed for PostgreSQL too. The filter code already applies to pgsql (the guard short-circuits before the driver match), so it's a one-line UI change — I left it MySQL/MariaDB for now since that's the reported case.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — ngram (degrades Latin, MySQL-only) and an external driver (later) were both weighed; the opt-in LIKE fallback is the low-risk fix that works now across drivers.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the fulltext filters, search settings, and search min-length gate are core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (`yarn test` in `js/`).
- [x] Frontend changes: tests have been added — `SearchManager` min-length unit tests cover the default, absent-setting, and CJK-on cases.
- [x] Backend changes: tests are green (run against the full MySQL/MariaDB/PostgreSQL/SQLite matrix, including prefixed).
- [x] Backend changes: tests have been added — CJK substring cases for both discussion and post search (post fulltext search had no coverage at all before this), plus checks that Latin search and the mostRelevantPost include still work with the mode on. All fail without the change and pass with it.
- [x] Where applicable, changes are suitable for all supported database drivers — verified green across the whole matrix, prefixed and unprefixed.
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
