### PR TITLE
[2.x] fix(realtime): stamp typing events on arrival instead of trusting the sender's clock

### DIFF
--- a/extensions/realtime/js/jest.config.cjs
+++ b/extensions/realtime/js/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = require('@flarum/jest-config')({
+  moduleNameMapper: {
+    '^flarum/(.*)$': '<rootDir>/../../../framework/core/js/src/$1',
+  },
+});

--- a/extensions/realtime/js/package.json
+++ b/extensions/realtime/js/package.json
@@ -17,7 +17,8 @@
         "build-typings": "yarn run clean-typings && ([ -e src/@types ] && cp -r src/@types dist-typings/@types || true) && tsc && yarn run post-build-typings",
         "post-build-typings": "find dist-typings -type f -name '*.d.ts' -print0 | xargs -0 sed -i 's,../src/@types,@types,g'",
         "check-typings": "tsc --noEmit --emitDeclarationOnly false",
-        "check-typings-coverage": "typescript-coverage-report"
+        "check-typings-coverage": "typescript-coverage-report",
+        "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
     },
     "devDependencies": {
         "prettier": "^3.2.2",
@@ -25,6 +26,7 @@
         "flarum-webpack-config": "^3.0.0",
         "webpack": "^5.104.1",
         "webpack-cli": "^4.9.1",
+        "@flarum/jest-config": "^2.0.0",
         "@flarum/prettier-config": "^1.0.0",
         "flarum-tsconfig": "^2.0.0",
         "typescript": "^4.5.4",

--- a/extensions/realtime/js/src/forum/states/TypingState.ts
+++ b/extensions/realtime/js/src/forum/states/TypingState.ts
@@ -12,6 +12,14 @@ export interface TypingData {
    */
   displayName: string | null;
   discloseOnline: boolean;
+  /**
+   * When the sender believed they were typing, from their own `Date.now()`.
+   *
+   * Kept on the wire for compatibility, but never compared against our clock:
+   * it comes from another machine, and any skew between the two would be read
+   * as the event being that much older (or newer) than it is. Expiry is stamped
+   * on arrival instead — see {@link TypingState.add}.
+   */
   time: number;
 }
 
@@ -50,7 +58,12 @@ export default class TypingState {
         : extractText(app.translator.trans('flarum-realtime.forum.typing-indicator.hidden-user', { username: data.displayName }))
       : extractText(app.translator.trans('flarum-realtime.forum.typing-indicator.anonymous-user'));
 
-    this.usersTyping[name] = data.time;
+    // Our own clock, not `data.time`. A sender whose clock is slow would
+    // otherwise have every event arrive already past EXPIRY_MS and be pruned on
+    // the first read — the indicator would never light up — while a fast clock
+    // would leave them typing forever. IndexTypingState stamps on arrival for
+    // the same reason.
+    this.usersTyping[name] = Date.now();
     m.redraw();
   }
 
@@ -76,7 +89,7 @@ export default class TypingState {
     }
 
     if (latestTime) {
-      this.truncationTimer = setTimeout(() => m.redraw(), latestTime - Date.now());
+      this.truncationTimer = setTimeout(() => m.redraw(), latestTime + EXPIRY_MS - Date.now());
     }
 
     return this.usersTyping;

--- a/extensions/realtime/js/tests/unit/forum/states/TypingState.test.ts
+++ b/extensions/realtime/js/tests/unit/forum/states/TypingState.test.ts
@@ -1,0 +1,135 @@
+import { jest } from '@jest/globals';
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import TypingState from '../../../../src/forum/states/TypingState';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const coreJsDir = resolve(testDir, '../../../../../../../framework/core/js');
+
+/** Mirrors the private EXPIRY_MS in TypingState. */
+const EXPIRY_MS = 6000;
+
+beforeAll(() => {
+  const cwd = process.cwd();
+
+  try {
+    // bootstrap reads core's locale file relative to the working directory.
+    process.chdir(coreJsDir);
+    bootstrapForum();
+  } finally {
+    process.chdir(cwd);
+  }
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+/**
+ * A `client-typing` payload as it arrives off the socket. `time` is stamped by
+ * the *sender*, so `clockOffset` models how far that machine's clock sits from
+ * ours: negative for a slow clock, positive for a fast one.
+ */
+function typingEvent(displayName: string, clockOffset = 0) {
+  return { displayName, discloseOnline: true, time: Date.now() + clockOffset };
+}
+
+describe('TypingState', () => {
+  it('registers a typer whose clock matches ours', () => {
+    const state = new TypingState();
+
+    state.add(typingEvent('Alice'));
+
+    expect(Object.keys(state.active())).toEqual(['Alice']);
+
+    state.dispose();
+  });
+
+  // Regression: expiry used to compare the sender's `data.time` against our own
+  // `Date.now()`. A typer whose clock ran ~51s slow had every event arrive
+  // already past EXPIRY_MS, so it was pruned on the first read and the
+  // indicator never lit up — while the discussion-list dot, which stamps on
+  // arrival, worked fine.
+  it('registers a typer whose clock is far behind ours', () => {
+    const state = new TypingState();
+
+    state.add(typingEvent('Alice', -51_000));
+
+    expect(Object.keys(state.active())).toEqual(['Alice']);
+
+    state.dispose();
+  });
+
+  // The mirror image: a fast sender clock used to produce an entry that could
+  // never expire, leaving them "typing" forever.
+  it('expires a typer whose clock is far ahead of ours', () => {
+    jest.useFakeTimers();
+
+    const state = new TypingState();
+
+    state.add(typingEvent('Alice', 51_000));
+    jest.advanceTimersByTime(EXPIRY_MS + 1);
+
+    expect(state.active()).toEqual({});
+
+    state.dispose();
+  });
+
+  it('keeps a typer active until the expiry window elapses', () => {
+    jest.useFakeTimers();
+
+    const state = new TypingState();
+
+    state.add(typingEvent('Alice'));
+    jest.advanceTimersByTime(EXPIRY_MS - 1);
+
+    expect(Object.keys(state.active())).toEqual(['Alice']);
+
+    jest.advanceTimersByTime(2);
+
+    expect(state.active()).toEqual({});
+
+    state.dispose();
+  });
+
+  // Regression: the self-clearing redraw was scheduled `latestTime - Date.now()`
+  // ms out — always negative, so it fired immediately and re-armed itself
+  // through the view, spinning for the whole window instead of waiting it out.
+  it('schedules the self-clearing redraw for the expiry, not for right away', () => {
+    jest.useFakeTimers();
+
+    const state = new TypingState();
+    state.add(typingEvent('Alice'));
+
+    const redraw = jest.spyOn(m, 'redraw').mockImplementation(() => {});
+
+    try {
+      state.active();
+
+      jest.advanceTimersByTime(EXPIRY_MS - 100);
+      expect(redraw).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(200);
+      expect(redraw).toHaveBeenCalled();
+    } finally {
+      redraw.mockRestore();
+      state.dispose();
+    }
+  });
+
+  it('drops its pending timer when disposed', () => {
+    jest.useFakeTimers();
+
+    const state = new TypingState();
+    state.add(typingEvent('Alice'));
+    state.active();
+
+    expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+    state.dispose();
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
### Fixes

Fixes #4967.

The in-discussion typing indicator silently stops working whenever the person typing has a device clock more than 6 seconds off. The discussion-list dot keeps working, which makes it look like a rendering or connectivity problem rather than a clock one.

### Changes

`TypingState.add()` recorded each incoming `client-typing` event under `data.time` — a `Date.now()` taken on the **sender's** machine — and `TypingState.active()` then pruned entries against `Date.now() - EXPIRY_MS` on the **receiver's**. Those two clocks are unrelated, so any skew between them is read as the event being that much older (or newer) than it actually is.

I hit this on a production forum. A user was typing with a clock running **50.63s slow** (constant across every sample, so a clock offset rather than latency):

```
15:03:39.598  client-typing  {"displayName":"…","discloseOnline":true,"time":1787497368967}  ← 15:02:48.967
15:03:44.587  client-typing  {"displayName":"…","discloseOnline":true,"time":1787497373960}  ← 15:02:53.960
```

Every event therefore landed ~45s past the 6s expiry window and was deleted on the first `active()` read, so `TypingIndicator` rendered "No one is typing" the whole time — for every viewer, since the fault travels with the sender. Meanwhile the ambient dot on the discussion list was correct throughout, because `IndexTypingState.set()` stamps arrival with the receiver's own clock and ignores the payload timestamp.

A clock running *fast* produces the mirror-image failure: the entry can never satisfy the expiry comparison, so the user shows as typing indefinitely.

This stamps on receipt, matching `IndexTypingState`. `time` stays in the payload for compatibility, but is no longer used for expiry and is documented as untrustworthy for it.

While in the same method, `active()` scheduled its self-clearing redraw with:

```ts
setTimeout(() => m.redraw(), latestTime - Date.now());
```

`latestTime` is always in the past, so that delay is always negative: the timer fired immediately, the view called `active()` again, and it re-armed — spinning for the full 6s window after every keystroke ping instead of waiting it out. `IndexTypingState` gets this right with `latestTime - invalidateWhen`; the `+ EXPIRY_MS` is added here.

### Testing

The realtime extension had no JS test setup, so this adds one (`jest.config.cjs` + `test` script, mirroring `embed`/`statistics`) plus `tests/unit/forum/states/TypingState.test.ts`.

Six tests. Three are regressions and fail on the current code; three are controls that pass either way:

```
✓ registers a typer whose clock matches ours
✕ registers a typer whose clock is far behind ours
✕ expires a typer whose clock is far ahead of ours
✓ keeps a typer active until the expiry window elapses
✕ schedules the self-clearing redraw for the expiry, not for right away
✓ drops its pending timer when disposed
```

All six pass with the fix. `check-typings` and `prettier --check` are clean. No `js/dist` changes committed.

### Required changes

- [ ] Yes, this PR includes a changelog entry.

