### PR TITLE
feat: move mobile search into the drawer and index toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - (core) validate the table prefix against the database driver's identifier limit by @imorland [#4961]
 - (core) break ties in sorted listings by primary key so paginated results are stable by @imorland [#4962]
 - (core) tune wide-screen reading width and sidebar widths by @imorland [#4964]
+- (core) move mobile search into the drawer and index toolbar by @imorland [#4968]
 
 ### Security
 

--- a/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
+++ b/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
@@ -11,11 +11,6 @@ export interface SearchAttrs extends ComponentAttrs {
   state: SearchState;
   label: string;
   a11yRoleLabel: string;
-  /**
-   * Render as a compact control for the fixed mobile navigation strip: an icon
-   * button rather than the full-width prompt, with no drawer to close first.
-   */
-  navigation?: boolean;
 }
 
 /**
@@ -106,20 +101,14 @@ export default abstract class AbstractGlobalSearch<T extends SearchAttrs = Searc
       app.modal.show(() => import('../../common/components/SearchModal'), { searchState: this.searchState, sources: this.sourceItems().toArray() });
     };
 
-    const navigation = !!this.attrs.navigation;
-
     return (
-      <div
-        role="search"
-        className={classList('Search', { 'Search--active': !!value, 'Search--navigation': navigation })}
-        aria-label={this.attrs.a11yRoleLabel}
-      >
+      <div role="search" className={classList('Search', { 'Search--active': !!value })} aria-label={this.attrs.a11yRoleLabel}>
         <button
           type="button"
           // `Button--flat` rather than `Button--link`: this sits among the
           // notification and message controls, which are flat buttons, and
           // should pick up the same hover and focus treatment as them.
-          className={classList('Search-input Button Button--flat', { 'Button--icon': navigation })}
+          className="Search-input Button Button--flat"
           aria-label={
             value
               ? extractText(app.translator.trans('core.lib.search.search_active_button_accessible_label', { query: value }))
@@ -127,13 +116,6 @@ export default abstract class AbstractGlobalSearch<T extends SearchAttrs = Searc
           }
           title={value || extractText(this.attrs.label)}
           onclick={() => {
-            if (navigation) {
-              // This control sits in the fixed mobile strip, not the drawer, so
-              // there is nothing to close first.
-              openSearchModal();
-              return;
-            }
-
             // On phones the search button lives inside the slide-out drawer. Close the drawer as soon as
             // search is activated, before the modal is shown, so it isn't left open behind (and overlapping)
             // the full-screen search modal as it animates in. Hiding it here rather than in `openSearchModal`

--- a/framework/core/js/src/common/components/Navigation.tsx
+++ b/framework/core/js/src/common/components/Navigation.tsx
@@ -20,8 +20,6 @@ import ItemList from '../utils/ItemList';
  *
  * - `className` The name of a class to set on the root element.
  * - `drawer` Whether or not to show a button to toggle the app's drawer.
- * - `search` A rendered search control to include in `drawer` mode, so search
- *   is reachable from the fixed mobile strip on every page.
  */
 export default class Navigation extends Component {
   view() {
@@ -40,23 +38,13 @@ export default class Navigation extends Component {
 
   /**
    * The controls shown in the navigation, as an ItemList so that other parts of
-   * the app — and extensions — can contribute their own. The forum app adds a
-   * search control here in `drawer` mode.
+   * the app — and extensions — can contribute their own.
    */
   items(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
     if (this.attrs.drawer) {
       items.add('drawer', this.getDrawerButton(), 100);
-
-      // A search control supplied by the frontend — the forum passes one, so
-      // search is reachable on every page from the fixed mobile strip rather
-      // than only from inside the drawer. Kept generic (a rendered child, not a
-      // component reference) so this common component stays free of any
-      // forum-only import.
-      if (this.attrs.search) {
-        items.add('search', this.attrs.search, 95);
-      }
     }
 
     if (app.history?.canGoBack()) {

--- a/framework/core/js/src/forum/ForumApplication.tsx
+++ b/framework/core/js/src/forum/ForumApplication.tsx
@@ -5,7 +5,6 @@ import Pane from './utils/Pane';
 import DiscussionPage from './components/DiscussionPage';
 import HeaderPrimary from './components/HeaderPrimary';
 import HeaderSecondary from './components/HeaderSecondary';
-import GlobalSearch from './components/GlobalSearch';
 import DiscussionRenamedNotification from './components/DiscussionRenamedNotification';
 import CommentPost from './components/CommentPost';
 import DiscussionRenamedPost from './components/DiscussionRenamedPost';
@@ -119,7 +118,7 @@ export default class ForumApplication extends Application {
     // We mount navigation and header components after the page, so components
     // like the back button can access the updated state when rendering.
     m.mount(document.getElementById('app-navigation')!, {
-      view: () => <Navigation className="App-backControl" drawer search={<GlobalSearch state={this.search.state} navigation />} />,
+      view: () => <Navigation className="App-backControl" drawer />,
     });
     m.mount(document.getElementById('header-navigation')!, Navigation);
     m.mount(document.getElementById('header-primary')!, HeaderPrimary);

--- a/framework/core/js/src/forum/components/IndexPage.tsx
+++ b/framework/core/js/src/forum/components/IndexPage.tsx
@@ -7,6 +7,7 @@ import WelcomeHero from './WelcomeHero';
 import DiscussionPage from './DiscussionPage';
 import Dropdown from '../../common/components/Dropdown';
 import Button from '../../common/components/Button';
+import GlobalSearch from './GlobalSearch';
 import extractText from '../../common/utils/extractText';
 import type Mithril from 'mithril';
 import type Discussion from '../../common/models/Discussion';
@@ -205,6 +206,17 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
    */
   actionItems() {
     const items = new ItemList<Mithril.Children>();
+
+    // Search is reachable from the drawer everywhere, but on the index — where
+    // people most often search — surface it directly in the toolbar on phones,
+    // where the header has no room for the search prompt shown on wider screens.
+    items.add(
+      'search',
+      <div className="IndexPage-toolbar-search">
+        <GlobalSearch state={app.search.state} />
+      </div>,
+      110
+    );
 
     items.add(
       'refresh',

--- a/framework/core/js/tests/integration/common/components/Navigation.test.ts
+++ b/framework/core/js/tests/integration/common/components/Navigation.test.ts
@@ -69,20 +69,6 @@ describe('Navigation', () => {
     expect(nav).toHaveElement('.Navigation-back');
   });
 
-  test('a supplied search control is shown in drawer mode', () => {
-    const nav = mq(Navigation, { drawer: true, search: m('button', { className: 'my-search' }) });
-
-    expect(nav).toHaveElement('.my-search');
-  });
-
-  test('a supplied search control is ignored outside drawer mode', () => {
-    // The desktop header carries its own search; the strip control is a
-    // mobile-only affordance.
-    const nav = mq(Navigation, { search: m('button', { className: 'my-search' }) });
-
-    expect(nav).not.toHaveElement('.my-search');
-  });
-
   test('an extension can add its own control to the group', () => {
     extend(Navigation.prototype, 'items', (items: ItemList<Mithril.Children>) => {
       items.add('custom', m('button', { className: 'my-nav-control' }), 5);

--- a/framework/core/js/tests/integration/forum/components/IndexPage.test.ts
+++ b/framework/core/js/tests/integration/forum/components/IndexPage.test.ts
@@ -97,4 +97,16 @@ describe('IndexPage', () => {
       expect(page).toContainRaw('Discussion 2');
     });
   });
+
+  test('the toolbar carries a search control', () => {
+    const page = mq(IndexPage, {});
+
+    return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+      page.redraw();
+
+      // Mobile searches from the toolbar rather than the nav strip; the control
+      // is present here (its visibility is scoped to phones in CSS).
+      expect(page).toHaveElement('.IndexPage-toolbar-search');
+    });
+  });
 });

--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -192,38 +192,3 @@
 }
 
 
-// The mobile navigation strip carries its own search control, so the copy that
-// lives in the drawer (part of the secondary header) is redundant there and is
-// hidden on phones. It remains on wider screens, where the secondary header is
-// the top bar rather than the drawer.
-@media @phone {
-  .Header-secondary .Search {
-    display: none;
-  }
-}
-
-// The search control in the fixed mobile navigation strip: an icon button
-// sitting alongside the drawer toggle and back button, matching their size and
-// flat treatment rather than the full-width prompt shown elsewhere. When a
-// search is active the clear button sits beside it, so the query can be cleared
-// in one tap rather than by reopening the modal.
-.Search--navigation {
-  .Search-input {
-    .Button--icon();
-  }
-
-  // The clear button reads as part of the search control, not a separate one,
-  // so it tucks against the magnifier rather than sitting a full icon-width
-  // away. It is also a touch smaller — it is a secondary affordance next to the
-  // control it belongs to.
-  .Search-clear {
-    .Button--icon();
-    width: auto;
-    margin-left: -8px;
-    padding: 8px 4px;
-
-    .Button-icon {
-      font-size: 13px;
-    }
-  }
-}

--- a/framework/core/less/forum/IndexPage.less
+++ b/framework/core/less/forum/IndexPage.less
@@ -33,3 +33,70 @@
 .IndexPage-toolbar-action {
   margin-inline-start: auto;
 }
+// On phones the toolbar can carry more than fits one row (sort, an author or
+// other filter, search, mark-as-read). Let it wrap instead of clipping, and let
+// the view group's own controls wrap too so a wide filter doesn't force it.
+@media @phone {
+  .IndexPage-toolbar {
+    flex-wrap: wrap;
+  }
+  .IndexPage-toolbar-view {
+    flex-wrap: wrap;
+  }
+}
+// Search sits in the header prompt on wider screens, so the toolbar copy is
+// only for phones, where that prompt isn't shown. There it is an icon button,
+// matching the other toolbar actions and leaving room for the sort/filter
+// controls beside it.
+.IndexPage-toolbar-search {
+  display: none;
+
+  @media @phone {
+    display: block;
+
+    // GlobalSearch renders a flat, full-width, pill-shaped prompt. Idle, the
+    // toolbar copy should read as an icon button matching the sort/action
+    // controls beside it — same fill and the standard corner radius, not a pill.
+    .Search-input {
+      .Button--icon();
+      background: var(--button-bg);
+      border-radius: var(--border-radius);
+    }
+
+    // Active, it mirrors the desktop header state: the running query is shown
+    // (truncated) with a clear button, and the control takes the primary accent
+    // to signal that results are filtered — the body-side equivalent of the
+    // accent the header search picks up from its own colour when active.
+    .Search--active {
+      display: flex;
+
+      .Search-input {
+        width: auto;
+        max-width: 160px;
+        padding: 8px 13px;
+        color: var(--link-color);
+
+        .Button-icon {
+          color: var(--link-color);
+        }
+
+        .Button-label {
+          display: flex;
+          overflow: hidden;
+        }
+
+        .Button-labelText {
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+
+      .Search-clear {
+        display: flex;
+        color: var(--link-color);
+        background: var(--button-bg);
+        border-radius: var(--border-radius);
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**

Follow-up to the mobile search work in #4937, iterating on where search lives on phones.

Putting the search control in the fixed mobile nav strip crammed the left side of the header — drawer toggle, search, and back button all fighting for space next to the centred title. The upshot was that the title's dropdown overlapped the back button's tap target, so inside a discussion the back button only worked if you hit the very top of it. This was only ever visible on the nightly deploy, not a release.

So search moves off the strip:

- It's back in the burger drawer, reachable from any page as before.
- On the index — where people most often search — it also sits in the toolbar next to the sort/filter controls, on phones only (wider screens keep the header prompt). It's an icon button when idle, matching the other toolbar controls; when a search is active it shows the query with a clear button and takes the primary accent, the same way the header search does, so it's clear the list is filtered and easy to undo.

The mobile toolbar can now carry a few controls at once (sort, an author or other filter, search, mark-as-read), so it wraps instead of clipping when there isn't room for one row. Desktop is unchanged.

With search gone from the strip the header has room again and the back button gets its full tap target back.

Impacted: `AbstractGlobalSearch`, `Navigation`, `ForumApplication`, `IndexPage`, and the search/index LESS.

**Reviewers should focus on:**

- The back button on a discussion, on a real phone — its whole target should now be tappable, not just the top edge.
- The active-search state in the index toolbar in both light and dark, next to the sort/filter controls.
- The toolbar wrapping on a narrow screen with several controls present.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — keeping search in the strip but fixing the overlap was considered; moving it out removes the crowding at the source and puts search where it's most used.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — this is core's mobile navigation and index layout.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation, across phone widths.
- [x] Frontend changes: tests are green (`yarn test` in `js/`).
- [x] Frontend changes: tests have been added — the index toolbar carries the search control, and the stale nav-strip search tests are replaced.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added — no backend changes.
- [ ] Where applicable, changes are suitable for all supported database drivers — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
