### PR TITLE
fix: restore the gap between the index sidebar and the discussion list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - (core) tune wide-screen reading width and sidebar widths by @imorland [#4964]
 - (core) move mobile search into the drawer and index toolbar by @imorland [#4968]
 - (realtime) stamp typing events on arrival instead of trusting the sender's clock by @ekumanov [#4966]
+- (core) restore the gap between the index sidebar and the discussion list by @imorland [#4971]
 
 ### Security
 

--- a/framework/core/less/common/sideNav.less
+++ b/framework/core/less/common/sideNav.less
@@ -58,15 +58,11 @@
   .sideNav {
     flex-shrink: 0;
 
+    // Fill the sidebar column so the nav never overflows into the gap between it
+    // and the content. Falls back to the base width outside the Page layout,
+    // where the column variable isn't defined.
     &, > ul {
-      width: 190px;
-
-      @media @desktop-hd {
-        width: 260px;
-      }
-      @media @desktop-xxl {
-        width: 280px;
-      }
+      width: var(--sidebar-width, 190px);
     }
     > ul {
       &.affix {

--- a/framework/core/less/forum/PageStructure.less
+++ b/framework/core/less/forum/PageStructure.less
@@ -23,8 +23,11 @@
   --gap: 50px;
 
   @media @desktop-hd {
-    --sidebar-width: 230px;
+    --sidebar-width: 260px;
     --gap: 56px;
+  }
+  @media @desktop-xxl {
+    --sidebar-width: 280px;
   }
   padding-bottom: var(--page-bottom-padding);
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

Follow-up to the wide-screen work in #4964. Widening the index sidebar left it sitting almost flush against the discussion list, with barely any gap between the two.

The cause was two widths that had drifted apart: `.sideNav` was set to 260/280px, but the `.Page` sidebar column it lives in (`--sidebar-width`) was only 230px. So the nav was wider than its column and spilled ~30px into the 56px flex gap, leaving about 26px of visible separation instead of the intended 56.

This makes `--sidebar-width` the single source of truth — it carries the 260/280px band widths — and `.sideNav` fills its column from that variable instead of hardcoding its own. Column and nav are the same width again, so the nav no longer eats into the gap and the spacing is back.

`.sideNav` keeps a fallback to its base width for the contexts outside the `Page` layout where the variable isn't defined.

Impacted: `less/common/sideNav.less`, `less/forum/PageStructure.less`.

**Reviewers should focus on:**

- The gap between the index nav and the discussion list, at both the hd and ultrawide bands.
- That `.sideNav` still looks right where it's used outside the `Page` layout, via the fallback width.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — bumping the column to match the nav, versus adding a separate gap; unifying on one width variable is the fix that stops the two drifting again.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — core layout.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation, at the hd and ultrawide widths.
- [ ] Frontend changes: tests are green — CSS-only, no JS to test.
- [ ] Frontend changes: tests have been added, or are not appropriate here. — a layout/width change with no meaningful unit-test surface; verified visually.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added — no backend changes.
- [ ] Where applicable, changes are suitable for all supported database drivers — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
