### PR TITLE
[2.x] Harden the updater: authenticate it against the database credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 
 - (core) stop email values being parsed as markup by @imorland [#4874]
 - (core) declare token models' keys as strings (harden GHSA-55f2-h36g-96c3) by @imorland [#4935]
+- (core) authenticate the updater against the database credentials by @imorland [#4972]
 
 ### Performance
 

--- a/framework/core/src/Update/Controller/IndexController.php
+++ b/framework/core/src/Update/Controller/IndexController.php
@@ -40,9 +40,17 @@ class IndexController extends AbstractHtmlController
     {
         $view = $this->view->make('flarum.update::app')->with('title', 'Update Flarum');
 
+        // SQLite has no username or password, so the updater verifies against
+        // the database file's name instead. Only then does the form need that
+        // field — the same condition the verification uses, kept in step so the
+        // form never asks for something the check ignores, or omits something
+        // it requires.
+        $usesDatabaseName = (string) $this->config['database.username'] === ''
+            && (string) $this->config['database.password'] === '';
+
         $view->with('content', $this->view->make('flarum.update::update')->with(
-            'needsPassword',
-            $this->config['database.password'] !== null
+            'usesDatabaseName',
+            $usesDatabaseName
         ));
 
         return $view;

--- a/framework/core/src/Update/Controller/UpdateController.php
+++ b/framework/core/src/Update/Controller/UpdateController.php
@@ -33,11 +33,8 @@ class UpdateController implements RequestHandlerInterface
     {
         $input = $request->getParsedBody();
 
-        if (
-            $this->databaseHasPassword()
-            && Arr::get($input, 'databasePassword') !== $this->config['database.password']
-        ) {
-            return new HtmlResponse('Incorrect database password.', 500);
+        if (! $this->verifyCredentials(is_array($input) ? $input : [])) {
+            return new HtmlResponse('Incorrect database credentials.', 500);
         }
 
         $body = fopen('php://temp', 'wb+');
@@ -53,8 +50,45 @@ class UpdateController implements RequestHandlerInterface
         return new Response($body, 200);
     }
 
-    private function databaseHasPassword(): bool
+    /**
+     * Confirm the caller is the admin, by the only means available before the
+     * app can authenticate anyone: echoing back the database credentials that
+     * config.php holds.
+     *
+     * For MySQL, MariaDB and PostgreSQL the username and password must both
+     * match. On a passwordless database the password half is an empty string
+     * on both sides, so the username is what a passing visitor would not know —
+     * and checking it unconditionally is what closed the old hole, where a null
+     * password meant no check ran at all.
+     *
+     * SQLite has neither a username nor a password — it is a file, not a
+     * network service. There the database file's name stands in as the secret:
+     * still something an admin knows and an anonymous visitor does not.
+     *
+     * @param array<string, mixed> $input
+     */
+    private function verifyCredentials(array $input): bool
     {
-        return $this->config['database.password'] !== null;
+        $username = (string) $this->config['database.username'];
+        $password = (string) $this->config['database.password'];
+
+        if ($username === '' && $password === '') {
+            // No credentials to check — this is SQLite. Fall back to the
+            // database name, the one thing in its config an outsider would not
+            // know. It is a weak secret (defaults like `flarum.sqlite` are
+            // guessable), but a weak check is worth more than none, and it
+            // closes the bodyless-POST hole for this driver too.
+            $database = (string) $this->config['database.database'];
+
+            return hash_equals($database, (string) Arr::get($input, 'databaseName', ''));
+        }
+
+        // Both comparisons are evaluated before they are combined, so a failed
+        // username check does not short-circuit the password check and reveal,
+        // through timing, which half was wrong.
+        $usernameOk = hash_equals($username, (string) Arr::get($input, 'databaseUsername', ''));
+        $passwordOk = hash_equals($password, (string) Arr::get($input, 'databasePassword', ''));
+
+        return $usernameOk && $passwordOk;
     }
 }

--- a/framework/core/tests/unit/Update/IndexControllerTest.php
+++ b/framework/core/tests/unit/Update/IndexControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Update;
+
+use Flarum\Foundation\Config;
+use Flarum\Testing\unit\TestCase;
+use Flarum\Update\Controller\IndexController;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Laminas\Diactoros\ServerRequest;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The updater form asks for whatever config.php can prove ownership with, and
+ * that differs by driver: a username and password for MySQL/MariaDB/PostgreSQL,
+ * the database file's name for SQLite, which has neither.
+ *
+ * The form must ask for exactly what the controller then checks — no more, no
+ * less — so this pins the flag the view branches on to the same condition the
+ * verification uses.
+ */
+class IndexControllerTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    private function usesDatabaseNameFor(array $database): bool
+    {
+        $captured = false;
+
+        // The update view records the value it is handed for `usesDatabaseName`.
+        $updateView = m::mock(View::class);
+        $updateView->shouldReceive('with')
+            ->with('usesDatabaseName', m::capture($captured))
+            ->andReturnSelf();
+
+        // The outer app view is passed through untouched.
+        $appView = m::mock(View::class);
+        $appView->shouldReceive('with')->andReturnSelf();
+        $appView->shouldReceive('render')->andReturn('');
+
+        $factory = m::mock(Factory::class);
+        $factory->shouldReceive('make')->with('flarum.update::app')->andReturn($appView);
+        $factory->shouldReceive('make')->with('flarum.update::update')->andReturn($updateView);
+
+        $config = new Config(['url' => 'http://flarum.test', 'database' => $database]);
+
+        (new IndexController($factory, $config))->render(new ServerRequest());
+
+        return $captured;
+    }
+
+    #[Test]
+    public function sqlite_asks_for_the_database_name()
+    {
+        $this->assertTrue($this->usesDatabaseNameFor([
+            'driver' => 'sqlite',
+            'database' => 'flarum.sqlite',
+            'username' => null,
+            'password' => null,
+        ]));
+    }
+
+    #[Test]
+    public function a_credentialed_database_asks_for_username_and_password()
+    {
+        $this->assertFalse($this->usesDatabaseNameFor([
+            'driver' => 'mysql',
+            'database' => 'flarum',
+            'username' => 'flarum',
+            'password' => 's3cret',
+        ]));
+    }
+
+    #[Test]
+    public function a_passwordless_credentialed_database_still_asks_for_the_username()
+    {
+        // MySQL/MariaDB over a socket has a username but no password. It is not
+        // SQLite, so it must still use the credential form, not the
+        // database-name one.
+        $this->assertFalse($this->usesDatabaseNameFor([
+            'driver' => 'mysql',
+            'database' => 'flarum',
+            'username' => 'flarum',
+            'password' => null,
+        ]));
+    }
+}

--- a/framework/core/tests/unit/Update/UpdateControllerTest.php
+++ b/framework/core/tests/unit/Update/UpdateControllerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Update;
+
+use Flarum\Database\Console\MigrateCommand;
+use Flarum\Foundation\Config;
+use Flarum\Testing\unit\TestCase;
+use Flarum\Update\Controller\UpdateController;
+use Laminas\Diactoros\ServerRequest;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The updater runs before the app can authenticate anyone: `settings.version`
+ * has drifted, the schema may be mid-change, and there is no session to trust.
+ * The one thing available is `config.php`, so the caller proves they are the
+ * admin by echoing back the database credentials it holds.
+ *
+ * Previously only the password was checked, and only when it was non-null — so
+ * an install with no database password (which our own installer produces by
+ * pressing Enter at the prompt) had no check at all, and an anonymous POST ran
+ * every pending migration.
+ *
+ * Now the username is checked too, on every install. On a passwordless
+ * database the password half matches an empty field, but the username still
+ * has to be right — something a passing visitor has no reason to know.
+ */
+class UpdateControllerTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, string|null> $database  what config.php holds
+     * @param array<string, string>|null $input     the submitted form body
+     */
+    private function attempt(array $database, ?array $input): int
+    {
+        $command = m::mock(MigrateCommand::class);
+
+        // A blocked request must never reach the migrator; an allowed one runs
+        // it exactly once. The count is the real assertion — the status code
+        // only confirms what the caller is told.
+        $command->shouldReceive('run')
+            ->with(m::type(InputInterface::class), m::type(OutputInterface::class))
+            ->andReturn(0);
+
+        $config = new Config([
+            'url' => 'http://flarum.test',
+            'database' => $database,
+        ]);
+
+        $controller = new UpdateController($command, $config);
+
+        $request = (new ServerRequest())->withParsedBody($input);
+
+        return $controller->handle($request)->getStatusCode();
+    }
+
+    private function ran(array $database, ?array $input): bool
+    {
+        $command = m::mock(MigrateCommand::class);
+        $ran = false;
+        $command->shouldReceive('run')->andReturnUsing(function () use (&$ran) {
+            $ran = true;
+
+            return 0;
+        });
+
+        $config = new Config([
+            'url' => 'http://flarum.test',
+            'database' => $database,
+        ]);
+
+        (new UpdateController($command, $config))
+            ->handle((new ServerRequest())->withParsedBody($input));
+
+        return $ran;
+    }
+
+    #[Test]
+    public function correct_username_and_password_runs_the_migration()
+    {
+        $this->assertTrue($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 's3cret']
+        ));
+    }
+
+    #[Test]
+    public function a_wrong_password_is_refused()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 'wrong']
+        ));
+    }
+
+    #[Test]
+    public function a_wrong_username_is_refused_even_with_the_right_password()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'attacker', 'databasePassword' => 's3cret']
+        ));
+    }
+
+    #[Test]
+    public function a_passwordless_database_runs_when_the_password_field_is_blank()
+    {
+        // The heart of the fix: no password to check, so a blank field matches
+        // — but the username still has to be the real one.
+        $this->assertTrue($this->ran(
+            ['username' => 'flarum', 'password' => ''],
+            ['databaseUsername' => 'flarum', 'databasePassword' => '']
+        ));
+    }
+
+    #[Test]
+    public function a_null_password_behaves_the_same_as_an_empty_one()
+    {
+        // Our installer stores null when the admin leaves the prompt blank.
+        // Null and '' must be indistinguishable here, or the old "skip the
+        // check entirely" hole reopens.
+        $this->assertTrue($this->ran(
+            ['username' => 'flarum', 'password' => null],
+            ['databaseUsername' => 'flarum', 'databasePassword' => '']
+        ));
+    }
+
+    #[Test]
+    public function a_passwordless_database_is_refused_when_a_password_is_guessed()
+    {
+        // An attacker who submits any password against a passwordless database
+        // no longer matches — the empty config value only matches an empty
+        // field.
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => ''],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 'anything']
+        ));
+    }
+
+    #[Test]
+    public function a_passwordless_database_still_needs_the_right_username()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => ''],
+            ['databaseUsername' => 'wrong', 'databasePassword' => '']
+        ));
+    }
+
+    #[Test]
+    public function sqlite_verifies_against_the_database_name_when_there_is_no_username()
+    {
+        // SQLite has no username and no password — both are absent from config.
+        // The only thing an admin knows that a passing visitor does not is the
+        // database file, so that stands in as the secret.
+        $this->assertTrue($this->ran(
+            ['driver' => 'sqlite', 'database' => 'flarum.sqlite', 'username' => null, 'password' => null],
+            ['databaseName' => 'flarum.sqlite']
+        ));
+    }
+
+    #[Test]
+    public function sqlite_is_refused_when_the_database_name_is_wrong()
+    {
+        $this->assertFalse($this->ran(
+            ['driver' => 'sqlite', 'database' => 'flarum.sqlite', 'username' => null, 'password' => null],
+            ['databaseName' => 'wrong.sqlite']
+        ));
+    }
+
+    #[Test]
+    public function sqlite_is_refused_when_nothing_is_submitted()
+    {
+        // The reported hole was a bodyless POST running migrations. On SQLite
+        // that must now be blocked too.
+        $this->assertFalse($this->ran(
+            ['driver' => 'sqlite', 'database' => 'flarum.sqlite', 'username' => null, 'password' => null],
+            []
+        ));
+    }
+
+    #[Test]
+    public function a_credentialed_database_ignores_the_database_name_field()
+    {
+        // MySQL/Postgres verify by username + password. The database-name
+        // fallback must not become a second way in — submitting the right
+        // database name but the wrong password is still refused.
+        $this->assertFalse($this->ran(
+            ['driver' => 'mysql', 'database' => 'flarum', 'username' => 'flarum', 'password' => 's3cret'],
+            ['databaseName' => 'flarum', 'databaseUsername' => 'flarum', 'databasePassword' => 'wrong']
+        ));
+    }
+
+    #[Test]
+    public function a_credentialed_database_still_runs_with_the_right_username_and_password()
+    {
+        // And the database-name field, if present, does not interfere with the
+        // normal credentialed path.
+        $this->assertTrue($this->ran(
+            ['driver' => 'mysql', 'database' => 'flarum', 'username' => 'flarum', 'password' => 's3cret'],
+            ['databaseName' => 'anything', 'databaseUsername' => 'flarum', 'databasePassword' => 's3cret']
+        ));
+    }
+
+    #[Test]
+    public function an_empty_submission_is_refused()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            []
+        ));
+    }
+
+    #[Test]
+    public function a_missing_body_is_refused()
+    {
+        $this->assertFalse($this->ran(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            null
+        ));
+    }
+
+    #[Test]
+    public function a_refused_request_returns_a_generic_error()
+    {
+        // Wrong password and wrong username must be indistinguishable from
+        // outside, so the response cannot say which was wrong.
+        $wrongPassword = $this->attempt(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'flarum', 'databasePassword' => 'wrong']
+        );
+
+        $wrongUsername = $this->attempt(
+            ['username' => 'flarum', 'password' => 's3cret'],
+            ['databaseUsername' => 'wrong', 'databasePassword' => 's3cret']
+        );
+
+        $this->assertSame(500, $wrongPassword);
+        $this->assertSame($wrongPassword, $wrongUsername);
+    }
+}

--- a/framework/core/views/install/update.php
+++ b/framework/core/views/install/update.php
@@ -1,19 +1,33 @@
 <h2>Update Flarum</h2>
 
-<?php if ($needsPassword): ?>
-<p>Enter your database password to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
+<?php if ($usesDatabaseName): ?>
+<p>Enter your database name to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
 <?php else: ?>
-<p>Click the button below to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
+<p>Enter your database username and password to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If your database has no password, leave that field blank. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
 <?php endif; ?>
 
 <form method="post">
   <div id="error" style="display:none"></div>
 
-  <?php if ($needsPassword): ?>
+  <?php if ($usesDatabaseName): ?>
+  <div class="FormGroup">
+    <div class="FormField">
+      <label>Database Name</label>
+      <input class="FormControl" type="text" name="databaseName" autocomplete="off">
+    </div>
+  </div>
+  <?php else: ?>
+  <div class="FormGroup">
+    <div class="FormField">
+      <label>Database Username</label>
+      <input class="FormControl" type="text" name="databaseUsername" autocomplete="off">
+    </div>
+  </div>
+
   <div class="FormGroup">
     <div class="FormField">
       <label>Database Password</label>
-      <input class="FormControl" type="password" name="databasePassword">
+      <input class="FormControl" type="password" name="databasePassword" autocomplete="off">
     </div>
   </div>
   <?php endif; ?>


### PR DESCRIPTION
**Changes proposed in this pull request:**

Re-lands the authentication half of #4930, which was reverted in #4933 to unblock nightly.

The updater is served while the code is ahead of the database — between new files landing and their migrations running. In that window it ran pending migrations for anyone who submitted the right database password, but it only checked the password when one was set. An install with no database password — which our own installer produces, and which is valid for socket-auth MySQL, MariaDB and Postgres — had no check at all, so a bodyless POST ran every pending migration.

The username is now verified too, on every install, so a passwordless database is still gated by the username the installer always requires. SQLite has neither a username nor a password, so it falls back to the database file's name. The comparison uses `hash_equals`, and every failure returns the same generic error so it cannot be used as an oracle. The updater page and its form are kept in step with the check, so it never asks for a field the verification ignores, or omits one it requires.

This is the auth part of #4930 only. The queue-pause part — pausing workers around a migration — is left out here, because that is what broke nightly: it wraps every `php flarum migrate` run, including the one our nightly deploy performs, and that interaction still needs working out. It will come back as its own PR. Authentication is the security fix and stands on its own; `php flarum migrate` on the CLI is untouched, so this cannot re-break nightly.

The SQLite fallback is a weak secret — default names like `flarum.sqlite` are guessable — and I've said so in the code. It closes the anonymous-POST hole for that driver, which is the point, but it is not a real credential. The proper fix for the passwordless case is a per-install secret in `config.php`, which is 2.1 work, not something to land at the end of RC.

Impacted files: `UpdateController`, `IndexController`, the updater view, and two new unit test files.

**Reviewers should focus on:**

- `verifyCredentials()` — the three driver cases (credentialed, passwordless, SQLite) and that a failed check on one half never short-circuits the other.
- That the updater page asks for the right field on each driver, matching what the check verifies.
- That nothing here touches the CLI migrate path or the queue.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — re-land the whole of #4930 vs. just the auth half; splitting keeps the security fix out of whatever broke nightly.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the updater is core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no JS; the updater view is server-rendered PHP.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here. — 18 unit tests covering the anonymous POST, passwordless-still-needs-username, the SQLite fallback, and the generic-error oracle.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
