### PR TITLE
[2.x] Sort the monorepo extensions list alphabetically

### DIFF
--- a/flarum-monorepo.json
+++ b/flarum-monorepo.json
@@ -67,6 +67,11 @@
         "mainBranch": "2.x"
       },
       {
+        "name": "messages",
+        "gitRemote": "git@github.com:flarum/messages.git",
+        "mainBranch": "2.x"
+      },
+      {
         "name": "nicknames",
         "gitRemote": "git@github.com:flarum/nicknames.git",
         "mainBranch": "2.x"
@@ -109,11 +114,6 @@
       {
         "name": "tags",
         "gitRemote": "git@github.com:flarum/tags.git",
-        "mainBranch": "2.x"
-      },
-      {
-        "name": "messages",
-        "gitRemote": "git@github.com:flarum/messages.git",
         "mainBranch": "2.x"
       }
     ],


### PR DESCRIPTION
**Changes proposed in this pull request:**

The extensions list in `flarum-monorepo.json` was alphabetical by `name` apart from `messages`, which sat at the end. This moves it into place between `mentions` and `nicknames` so the whole list is ordered.

Cosmetic only — the split tooling keys off `gitRemote`, not list position, so nothing about the split is affected.

**Reviewers should focus on:**

- That `messages` is the only entry that moved and the list is now sorted by `name`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered? — n/a, ordering a list.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — it's the monorepo manifest.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — n/a.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [ ] Backend changes: tests are green (run `composer test`). — no code change.
- [ ] Backend changes: tests have been added, or are not appropriate here. — n/a.
- [ ] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — n/a.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
