### PR TITLE
[2.x] fix(subscriptions): delete the reply notification job when its post is gone

### DIFF
--- a/extensions/subscriptions/src/Job/SendReplyNotification.php
+++ b/extensions/subscriptions/src/Job/SendReplyNotification.php
@@ -11,23 +11,19 @@ namespace Flarum\Subscriptions\Job;
 
 use Flarum\Notification\NotificationSyncer;
 use Flarum\Post\Post;
+use Flarum\Queue\AbstractJob;
 use Flarum\Subscriptions\Notification\NewPostBlueprint;
 use Flarum\User\User;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
 
-class SendReplyNotification implements ShouldQueue
+class SendReplyNotification extends AbstractJob
 {
-    use Queueable;
-    use SerializesModels;
-
     public function __construct(
         protected Post $post,
         protected ?int $lastPostNumber
     ) {
+        parent::__construct();
     }
 
     public function handle(NotificationSyncer $notifications): void


### PR DESCRIPTION
### Changes proposed in this pull request

`Flarum\Subscriptions\Job\SendReplyNotification` is the only queued job in the monorepo that does not extend `Flarum\Queue\AbstractJob`. It implements `ShouldQueue` and pulls in `Queueable` and `SerializesModels` itself, so it never inherits `deleteWhenMissingModels`.

That flag is stamped into the job payload at push time (`Illuminate\Queue\Queue::createObjectPayload`) and read back by the worker without unserializing. With it false, a post that was deleted between dispatch and pickup sends the job down the `fail()` path rather than being dropped, and `failed()` re-deserializes the payload, so the same `ModelNotFoundException` is thrown a second time.

The result on a live 2.x forum is a full stack trace in the log and a `failed_jobs` row every time somebody deletes a reply before the worker gets to it:

```
flarum.ERROR: Illuminate\Database\Eloquent\ModelNotFoundException: No query results
for model [Flarum\Post\CommentPost]. in .../Eloquent/Builder.php:786
#0  SerializesAndRestoresModelIdentifiers.php(112): Builder->firstOrFail()
#1  SerializesAndRestoresModelIdentifiers.php(63): SendReplyNotification->restoreModel()
...
#5  CallQueuedHandler.php(391): CallQueuedHandler->getCommand()
#6  Jobs/Job.php(254): CallQueuedHandler->failed()
#8  CallQueuedHandler.php(317): Jobs\Job->fail()
#9  CallQueuedHandler.php(74): CallQueuedHandler->handleModelNotFound()
```

Frames 9 back up to 5 are the second throw. `AbstractJob`'s own docblock already describes this exact case as the reason the property exists:

> If a serialized model on this job has been deleted between dispatch and worker pickup, treat the job as a no-op and remove it from the queue rather than calling failed(), which re-deserializes the payload and throws ModelNotFoundException a second time, producing duplicate error log entries for what is in fact a handled-correctly race.

This PR extends `AbstractJob`, matching every other job in the repo (core's notification and mail jobs, mentions, messages, gdpr, realtime, package-manager, pusher). `Queueable` and `SerializesModels` come from `AbstractJob`, so the serialized command is byte-identical (`SerializesModels::__serialize()` skips properties at their declared defaults, which covers the new flag), and payloads queued under the old class definition deserialize cleanly under the new one, so rolling deploys are safe. The class also gains `InteractsWithQueue`, same as its siblings.

One scope note: the flag is read from the payload envelope stamped at push time, so jobs already sitting in the queue when this deploys keep the old fail-twice behaviour. The fix applies to jobs pushed after it.

The wider the gap between dispatch and pickup, the more often this fires, so busy forums with a queue backlog see it most.

### Reviewers should focus on

Whether you would rather keep the class as is and set `public bool $deleteWhenMissingModels = true;` on it directly. Extending `AbstractJob` seemed better since it removes the odd one out.

Happy to add a test if you want one. There is no existing coverage of the flag to extend, and asserting it meaningfully needs a real queue driver and worker rather than the sync driver the integration suite uses.

### What I verified

To be straight about it, I have not run the suite or an end-to-end reproduction for this branch. What I did check:

- The failing trace above comes from a real 2.x forum's log, reported by a forum admin.
- On an installed 2.0.0-rc.6 forum I confirmed the payload path: `Queue::createObjectPayload()` stamps `deleteWhenMissingModels` from the job instance, and `CallQueuedHandler::handleModelNotFound()` reads it from `$job->payload()`, so a job lacking the property is failed rather than deleted.
- `SendReplyNotification` is the only job class in the monorepo that does not extend `AbstractJob` (checked every `Job`/`Jobs` class at 2.x HEAD).
- Syntax check on the changed file. The change removes no behaviour: both traits it dropped come from `AbstractJob`.

Say the word if you want the end-to-end run before this is considered.
