### PR TITLE
Fix internal links landing on the index when installed in a subdirectory

### DIFF
--- a/framework/core/js/src/forum/utils/routeInternalLinks.ts
+++ b/framework/core/js/src/forum/utils/routeInternalLinks.ts
@@ -53,8 +53,13 @@ export default function routeInternalLinks() {
 
     if (basePath && !(path === basePath || path.startsWith(basePath + '/'))) return;
 
-    // What Mithril routes on excludes the base path, since that is its prefix.
-    const route = path.slice(basePath.length) + url.search + url.hash;
+    // What Mithril routes on *includes* the base path. The forum registers its
+    // routes with the base path already baked into each pattern
+    // (`mapRoutes(routes, basePath)`) and leaves `m.route.prefix` empty, so a
+    // path with the base path taken off matches no route at all and Mithril
+    // quietly falls back to the default one — sending every internal link on a
+    // forum installed in a subdirectory to the index instead.
+    const route = path + url.search + url.hash;
 
     // A link to the exact page we are on, anchor and all, has nowhere to go.
     // Letting the browser handle it keeps same-page anchor jumps working.
@@ -62,6 +67,6 @@ export default function routeInternalLinks() {
 
     e.preventDefault();
 
-    m.route.set(route || '/');
+    m.route.set(route);
   });
 }

--- a/framework/core/js/tests/unit/forum/utils/routeInternalLinks.test.ts
+++ b/framework/core/js/tests/unit/forum/utils/routeInternalLinks.test.ts
@@ -1,0 +1,86 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from '../../../../src/forum/app';
+import routeInternalLinks from '../../../../src/forum/utils/routeInternalLinks';
+
+/**
+ * The listener hands a path to Mithril, and Mithril matches it against the
+ * routes the forum registered. Those patterns carry the base path
+ * (`mapRoutes(routes, basePath)`), so the path handed over has to carry it
+ * too — a mismatch is not an error, it is a silent fall back to the default
+ * route, which is why a subdirectory install used to send every internal link
+ * to the index.
+ */
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+
+  routeInternalLinks();
+});
+
+const ORIGIN = 'http://localhost';
+
+let routed: string | null;
+
+beforeEach(() => {
+  routed = null;
+
+  // @ts-expect-error the global mithril stub carries no route helper
+  m.route = { set: (path: string) => (routed = path) };
+
+  app.forum.data.attributes!.basePath = '';
+
+  document.body.innerHTML = '';
+});
+
+/**
+ * Click a link the way the server renders an internal one, and report both
+ * where Mithril was asked to go and whether the browser was left to do it.
+ */
+function click(href: string, init: MouseEventInit = {}): { routed: string | null; prevented: boolean } {
+  const link = document.createElement('a');
+  link.className = 'UrlLink UrlLink--internal';
+  link.href = href;
+  link.target = '_self';
+  document.body.appendChild(link);
+
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0, ...init });
+  link.dispatchEvent(event);
+
+  return { routed, prevented: event.defaultPrevented };
+}
+
+describe('routeInternalLinks', () => {
+  it('follows an internal link without reloading the page', () => {
+    expect(click(`${ORIGIN}/d/123-the-slug`)).toEqual({ routed: '/d/123-the-slug', prevented: true });
+  });
+
+  it('keeps the base path, which is part of what Mithril matches on', () => {
+    app.forum.data.attributes!.basePath = '/forum';
+
+    expect(click(`${ORIGIN}/forum/d/123-the-slug`)).toEqual({ routed: '/forum/d/123-the-slug', prevented: true });
+  });
+
+  it('carries the query string and fragment along', () => {
+    app.forum.data.attributes!.basePath = '/forum';
+
+    expect(click(`${ORIGIN}/forum/d/123-the-slug?foo=bar#post-4`).routed).toBe('/forum/d/123-the-slug?foo=bar#post-4');
+  });
+
+  it('leaves alone an address outside the forum, base path or not', () => {
+    app.forum.data.attributes!.basePath = '/forum';
+
+    expect(click(`${ORIGIN}/elsewhere/d/123`)).toEqual({ routed: null, prevented: false });
+  });
+
+  it('leaves alone another site', () => {
+    expect(click('https://example.com/d/123')).toEqual({ routed: null, prevented: false });
+  });
+
+  it('leaves a same-page anchor to the browser', () => {
+    expect(click(window.location.href)).toEqual({ routed: null, prevented: false });
+  });
+
+  it('lets a modified click open a new tab', () => {
+    expect(click(`${ORIGIN}/d/123-the-slug`, { metaKey: true })).toEqual({ routed: null, prevented: false });
+  });
+});


### PR DESCRIPTION
### Fixes an issue with internal links on forums installed in a subdirectory

`routeInternalLinks()` (new in 2.0.0-rc.6) takes the base path off the pathname before handing it to Mithril:

```ts
// What Mithril routes on excludes the base path, since that is its prefix.
const route = path.slice(basePath.length) + url.search + url.hash;

m.route.set(route || '/');
```

The base path is not Mithril's prefix, though. `ForumApplication` sets `m.route.prefix = ''` and `Application::mount()` registers every route with the base path already in the pattern:

```ts
m.route(document.getElementById('content')!, basePath + '/', mapRoutes(this.routes, basePath));
```

So on a forum at `example.com/forum`, clicking a link to `/forum/d/123-slug` asks Mithril for `/d/123-slug`. Nothing matches that, and an unmatched route is not an error — Mithril falls back to the default route, `basePath + '/'`. The reader lands on the discussion list.

That makes the outcome worse than what the feature replaced: before rc.6 the link was a full page load to the right discussion; now it is an instant navigation to the wrong page, with the address bar rewritten so Back is the only way out. Every internal discussion link in every post is affected, and `labelDiscussionLinks` has by then turned the address into a `#123` label, so there is nothing on screen to copy either.

Forums installed at a domain root are unaffected, since `basePath` is `''` there and the slice takes nothing off — which is presumably why it shipped.

Reproduced from the console on a `/forum` install:

```js
m.route.set('/d/1828-slug')        // → /forum/  (the index)
m.route.set('/forum/d/1828-slug')  // → the discussion
```

### Changes

Hand Mithril the pathname as it stands. The base-path check above it is unchanged, so nothing new becomes routable — the base path is now used only for that check.

### Reviewers should focus on

Whether `m.route.set(route || '/')` losing its `|| '/'` fallback matters. `url.pathname` is never empty, so the fallback was already unreachable; I dropped it rather than leave a branch that cannot be taken. Happy to put it back if you would rather keep it defensive.

### Confirmed

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tested on a local Flarum installation.
- [x] Backend changes: added or updated relevant tests.
- [x] Translations: added new keys to the locale files (n/a)

Tested by hand on an rc.6 install mounted at `/forum` — the same click now performs an in-app navigation to the linked discussion, scrolled to the linked post — and at the domain root, where behaviour is unchanged.

Added `tests/unit/forum/utils/routeInternalLinks.test.ts`, modelled on the existing `labelDiscussionLinks` test. Two of its seven cases fail against the current code and pass with this change; the other five cover the guards (foreign origin, outside the base path, same-page anchor, modified click) so a future change cannot quietly start hijacking clicks it should leave alone.
