### PR TITLE
[2.x] Name a queue connection an extension leaves unnamed

### DIFF
--- a/framework/core/src/Queue/Console/ResumeCommand.php
+++ b/framework/core/src/Queue/Console/ResumeCommand.php
@@ -38,7 +38,14 @@ class ResumeCommand extends Command
         if (! $this->argument('queue')) {
             $paused = $factory instanceof QueueFactory ? $factory->pausedQueues($connectionName) : [];
 
-            foreach (array_merge(['*'], $paused) as $queue) {
+            // Also clear every known queue name, not only the tracking list.
+            // A queue paused through a path that never recorded the tracking
+            // entry (e.g. the historical queue:pause crash on an unnamed
+            // connection) would otherwise be left paused with no way for
+            // "resume everything" to reach it.
+            $known = (array) $this->laravel->make('flarum.queue.queues');
+
+            foreach (array_unique(array_merge(['*'], $paused, $known)) as $queue) {
                 $factory->resume($connectionName, $queue);
             }
 

--- a/framework/core/src/Queue/QueueFactory.php
+++ b/framework/core/src/Queue/QueueFactory.php
@@ -155,7 +155,7 @@ class QueueFactory implements Factory
      *
      * @return string[]
      */
-    public function pausedQueues(string $connection): array
+    public function pausedQueues(?string $connection): array
     {
         $tracked = (array) ($this->cache?->get("flarum:queue:paused-list:{$connection}") ?? []);
 
@@ -168,7 +168,7 @@ class QueueFactory implements Factory
         return $paused;
     }
 
-    protected function trackPausedQueue(string $connection, string $queue): void
+    protected function trackPausedQueue(?string $connection, string $queue): void
     {
         $tracked = (array) ($this->cache?->get("flarum:queue:paused-list:{$connection}") ?? []);
 
@@ -178,7 +178,7 @@ class QueueFactory implements Factory
         }
     }
 
-    protected function untrackPausedQueue(string $connection, string $queue): void
+    protected function untrackPausedQueue(?string $connection, string $queue): void
     {
         $tracked = (array) ($this->cache?->get("flarum:queue:paused-list:{$connection}") ?? []);
 

--- a/framework/core/src/Queue/QueueServiceProvider.php
+++ b/framework/core/src/Queue/QueueServiceProvider.php
@@ -268,6 +268,15 @@ class QueueServiceProvider extends AbstractServiceProvider
                 return $queue;
             }
 
+            // Core names its own driver, but an extension that replaces the
+            // connection (e.g. fof/redis) may leave it unnamed. A null name
+            // flows into pause/resume bookkeeping and the WorkerIdle event,
+            // both of which expect a string — so give any unnamed driver the
+            // default connection name before wrapping it.
+            if ($queue->getConnectionName() === null) {
+                $queue->setConnectionName('flarum');
+            }
+
             return new RoutingQueue($queue, $container->make('queue.routes'));
         });
 

--- a/framework/core/tests/integration/queue/QueueCommandTest.php
+++ b/framework/core/tests/integration/queue/QueueCommandTest.php
@@ -9,12 +9,53 @@
 
 namespace Flarum\Tests\integration\queue;
 
+use Flarum\Queue\QueueFactory;
 use Flarum\Testing\integration\ConsoleTestCase;
+use Illuminate\Contracts\Queue\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 class QueueCommandTest extends ConsoleTestCase
 {
+    /**
+     * `queue:resume` (no argument) must recover a queue that is paused under a
+     * known name even when the pause was never recorded in the tracking list —
+     * which is exactly the state the queue:pause fatal leaves behind. Resuming
+     * only the tracked queues would strand it. So resume also covers every
+     * known queue name (`flarum.queue.queues`), not just the tracking list.
+     */
+    #[Test]
+    public function resume_recovers_a_known_queue_paused_outside_the_tracking_list()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->extend(
+            (new \Flarum\Extend\Console())->command(\Flarum\Queue\Console\ResumeCommand::class),
+            (new \Flarum\Extend\ServiceProvider())->register(KnownQueuesServiceProvider::class)
+        );
+
+        $this->app();
+
+        $container = $this->app()->getContainer();
+        $factory = $container->make(QueueFactory::class);
+        $name = $container->make(Queue::class)->getConnectionName();
+        $cache = $container->make('cache.store');
+
+        // Pause the `media` queue the way the fatal leaves it: the cache key is
+        // set, but nothing was written to the tracking list.
+        $cache->forever("illuminate:queue:paused:{$name}:media", true);
+
+        $this->assertTrue($factory->isPaused($name, 'media'));
+        $this->assertNotContains('media', $factory->pausedQueues($name));
+
+        $this->runCommand(['command' => 'queue:resume']);
+
+        $this->assertFalse(
+            $factory->isPaused($name, 'media'),
+            'A known queue paused outside the tracking list must still be resumed by `queue:resume`.'
+        );
+    }
+
     #[Test]
     public function queue_commands_dont_exist_with_sync_driver()
     {
@@ -68,5 +109,15 @@ class QueueCommandTest extends ConsoleTestCase
 
         // Should not throw an exception
         $this->assertTrue(true);
+    }
+}
+
+class KnownQueuesServiceProvider extends \Flarum\Foundation\AbstractServiceProvider
+{
+    public function register(): void
+    {
+        $this->container->extend('flarum.queue.queues', function ($queues) {
+            return array_values(array_unique(array_merge((array) $queues, ['media'])));
+        });
     }
 }

--- a/framework/core/tests/integration/queue/QueueServiceProviderTest.php
+++ b/framework/core/tests/integration/queue/QueueServiceProviderTest.php
@@ -128,6 +128,33 @@ class QueueServiceProviderTest extends TestCase
         $this->assertNotEmpty($default);
     }
 
+    /**
+     * Regression test for the fof/redis queue:pause fatal.
+     *
+     * An extension that replaces `flarum.queue.connection` may bind a driver
+     * with no connection name (core only names its own). When core wraps that
+     * driver for routing it must give it a name, or `getConnectionName()`
+     * returns null and flows into `pause()`, crashing `queue:pause` and leaving
+     * the dashboard blind to the pause.
+     */
+    #[Test]
+    public function an_extension_queue_with_no_connection_name_is_named_when_wrapped()
+    {
+        $this->extend(
+            (new Extend\ServiceProvider())
+                ->register(UnnamedQueueServiceProvider::class)
+        );
+
+        $this->app();
+
+        $queue = $this->app()->getContainer()->make(Queue::class);
+
+        // Wrapped for routing, and the wrap supplied the missing name.
+        $this->assertInstanceOf(RoutingQueue::class, $queue);
+        $this->assertIsString($queue->getConnectionName());
+        $this->assertNotEmpty($queue->getConnectionName());
+    }
+
     #[Test]
     public function it_uses_null_failed_job_provider_for_sync_queue()
     {
@@ -162,6 +189,92 @@ class CustomQueueServiceProvider extends \Flarum\Foundation\AbstractServiceProvi
             $customQueue->setContainer($container);
 
             return $customQueue;
+        });
+    }
+}
+
+class UnnamedQueueServiceProvider extends \Flarum\Foundation\AbstractServiceProvider
+{
+    public function register(): void
+    {
+        // Replace the binding with a real (async) driver that carries no
+        // connection name, the way fof/redis binds its RedisQueue.
+        $this->container->extend('flarum.queue.connection', function ($queue, $container) {
+            return new class implements Queue {
+                private $name = null;
+
+                public function getConnectionName()
+                {
+                    return $this->name;
+                }
+
+                public function setConnectionName($name)
+                {
+                    $this->name = $name;
+
+                    return $this;
+                }
+
+                public function size($queue = null)
+                {
+                    return 0;
+                }
+
+                public function pendingSize($queue = null)
+                {
+                    return 0;
+                }
+
+                public function delayedSize($queue = null)
+                {
+                    return 0;
+                }
+
+                public function reservedSize($queue = null)
+                {
+                    return 0;
+                }
+
+                public function creationTimeOfOldestPendingJob($queue = null)
+                {
+                    return null;
+                }
+
+                public function push($job, $data = '', $queue = null)
+                {
+                    return null;
+                }
+
+                public function pushOn($queue, $job, $data = '')
+                {
+                    return null;
+                }
+
+                public function pushRaw($payload, $queue = null, array $options = [])
+                {
+                    return null;
+                }
+
+                public function later($delay, $job, $data = '', $queue = null)
+                {
+                    return null;
+                }
+
+                public function laterOn($queue, $delay, $job, $data = '')
+                {
+                    return null;
+                }
+
+                public function bulk($jobs, $data = '', $queue = null)
+                {
+                    return null;
+                }
+
+                public function pop($queue = null)
+                {
+                    return null;
+                }
+            };
         });
     }
 }

--- a/framework/core/tests/unit/Queue/QueueFactoryTest.php
+++ b/framework/core/tests/unit/Queue/QueueFactoryTest.php
@@ -11,12 +11,39 @@ namespace Flarum\Tests\unit\Queue;
 
 use Flarum\Queue\QueueFactory;
 use Flarum\Testing\unit\TestCase;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Queue\Queue;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
 
 class QueueFactoryTest extends TestCase
 {
+    /**
+     * A queue connection bound by an extension may carry no name — core only
+     * names its own driver, and (e.g.) fof/redis replaces the binding without
+     * one, so `getConnectionName()` returns null. That null flows into
+     * `pause()`, so the pause bookkeeping must tolerate it rather than fatal on
+     * a `string` type hint (the recurring `queue:pause` crash).
+     */
+    #[Test]
+    public function pausing_a_connection_with_no_name_does_not_fatal(): void
+    {
+        $cache = new Repository(new ArrayStore());
+        $factory = new QueueFactory(fn () => m::mock(Queue::class), $cache);
+
+        // Previously threw: trackPausedQueue(): Argument #1 must be string, null given.
+        $factory->pause(null, 'default');
+
+        $this->assertTrue($factory->isPaused(null, 'default'));
+        $this->assertContains('default', $factory->pausedQueues(null));
+
+        $factory->resume(null, 'default');
+
+        $this->assertFalse($factory->isPaused(null, 'default'));
+        $this->assertNotContains('default', $factory->pausedQueues(null));
+    }
+
     #[Test]
     public function connection_resolves_and_caches_the_queue_from_the_factory_callback(): void
     {


### PR DESCRIPTION
**Changes proposed in this pull request:**

Fixes #4974.

Core names its own queue driver, but an extension that replaces `flarum.queue.connection` can leave it unnamed — fof/redis binds its `RedisQueue` without a name (Horizon, having hit this already, names its own). That null connection name flows into the pause/resume bookkeeping and the `WorkerIdle` event, both of which expect a string, so `queue:pause` crashed with a `TypeError` (exit 255). Worse, it wrote the pause key before it crashed, so the queue was left silently paused — and because the tracking list is only written by the method that fatalled, the dashboard reported nothing paused while the queue was genuinely stopped. `queue:resume --all` couldn't recover it either, since it only resumes what the tracking list contains.

Three changes:

- The wrap that decorates the final connection for routing now gives any unnamed driver the default connection name (`flarum`) before wrapping it. This fixes it once for every third-party queue binding rather than asking each to remember, and is the real fix — the connection now has a name wherever it's consulted.
- `QueueFactory`'s pause bookkeeping (`trackPausedQueue`/`untrackPausedQueue`/`pausedQueues`) is widened to tolerate a null connection defensively, so an unnamed connection degrades rather than fatals even if it reaches these by another path.
- `queue:resume` with no argument now clears every known queue name (`flarum.queue.queues`), not only the tracking list, so a queue paused through a path that never recorded a tracking entry can still be recovered.

Reproduced on a fof/redis (no Horizon) install: `php flarum queue:pause` fatalled with exactly the reported trace, and with this branch pauses and resumes cleanly with the connection named `flarum`.

**Reviewers should focus on:**

- The naming in `QueueServiceProvider::boot()` — that it only names a driver with no name of its own, and leaves a driver that named itself (core, Horizon) untouched.
- That `queue:resume` clearing the known queue names as well as the tracking list is the right breadth, not too wide.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — naming the connection in the wrap (fixes every binding at once) versus asking each extension to name its own; both, really — this is the core half, and fof/redis should name its own connection too.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the queue wrap and pause/resume are core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no frontend changes.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here. — a test that pausing an unnamed connection no longer fatals, that the wrap names an extension's unnamed connection, and that `queue:resume` recovers a known queue paused outside the tracking list.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement; verified against the fof/redis queue driver.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
