### PR TITLE
[2.x] Break the audit/geoip circular dependency that aborts the upgrade

### DIFF
--- a/extensions/audit/composer.json
+++ b/extensions/audit/composer.json
@@ -39,10 +39,7 @@
                 "name": "fas fa-book",
                 "backgroundColor": "#2563EB",
                 "color": "#fff"
-            },
-            "optional-dependencies": [
-                "fof/geoip"
-            ]
+            }
         },
         "flarum-cli": {
             "modules": {

--- a/framework/core/tests/unit/Foundation/ExtensionDependencyResolutionTest.php
+++ b/framework/core/tests/unit/Foundation/ExtensionDependencyResolutionTest.php
@@ -155,6 +155,53 @@ class ExtensionDependencyResolutionTest extends TestCase
         $this->assertSame(['flarum-tags', 'flarum-realtime'], $order);
     }
 
+    /**
+     * Regression test for https://discuss.flarum.org/d/39536 (and 39516).
+     *
+     * The moderation extensions (suspend, flags, tags, approval, gdpr) all
+     * optionally depend on audit, so they boot after it and their actions are
+     * audited. fof/ban-ips optionally depends on those moderation extensions,
+     * and fof/geoip on ban-ips. Audit additionally declaring an optional
+     * dependency on fof/geoip closed the loop —
+     *
+     *   audit -> geoip -> ban-ips -> {suspend,flags,tags,approval,gdpr} -> audit
+     *
+     * — a real circular dependency across a very common extension set, which
+     * aborted the 1.x -> 2.x upgrade migration with
+     * CircularDependenciesException. Audit never uses geoip on the backend (the
+     * IP enrichment is a frontend extension of core's IPAddress component), so
+     * the edge was dead weight; without it the set resolves cleanly.
+     */
+    #[Test]
+    public function audit_geoip_and_moderation_extensions_resolve_without_a_cycle()
+    {
+        $audit = new FakeExtension('flarum-audit', [], []);
+        $geoip = new FakeExtension('fof-geoip', [], ['fof-ban-ips']);
+        $banIps = new FakeExtension('fof-ban-ips', [], ['flarum-suspend', 'flarum-flags', 'flarum-tags', 'flarum-approval', 'flarum-gdpr']);
+        $suspend = new FakeExtension('flarum-suspend', [], ['flarum-audit']);
+        $flags = new FakeExtension('flarum-flags', [], ['flarum-audit']);
+        $tags = new FakeExtension('flarum-tags', [], ['flarum-audit']);
+        $approval = new FakeExtension('flarum-approval', [], ['flarum-audit']);
+        $gdpr = new FakeExtension('flarum-gdpr', [], ['flarum-audit']);
+
+        $resolved = ExtensionManager::resolveExtensionOrder([$audit, $geoip, $banIps, $suspend, $flags, $tags, $approval, $gdpr]);
+
+        $this->assertEmpty($resolved['circularDependencies'], 'The audit/geoip/ban-ips/moderation set must not be circular.');
+        $this->assertEmpty($resolved['missingDependencies']);
+        $this->assertCount(8, $resolved['valid']);
+
+        $order = array_map(fn ($e) => $e->getId(), $resolved['valid']);
+        $pos = array_flip($order);
+
+        // Audit boots before every extension that audits its actions.
+        foreach (['flarum-suspend', 'flarum-flags', 'flarum-tags', 'flarum-approval', 'flarum-gdpr'] as $consumer) {
+            $this->assertLessThan($pos[$consumer], $pos['flarum-audit'], "audit must boot before $consumer");
+        }
+
+        // ban-ips boots before geoip, which optionally depends on it.
+        $this->assertLessThan($pos['fof-geoip'], $pos['fof-ban-ips'], 'ban-ips must boot before geoip');
+    }
+
     #[Test]
     public function tags_with_realtime_optional_dependency_is_ordered_after_realtime()
     {


### PR DESCRIPTION
**Changes proposed in this pull request:**

Fixes a circular dependency that aborts the 1.x → 2.x upgrade for a very common extension set. Reported on the forum in [d/39536](https://discuss.flarum.org/d/39536), [d/39516](https://discuss.flarum.org/d/39516) and [d/39448](https://discuss.flarum.org/d/39448-flarum-200-rc4-released-audit-joins-core-20-stable-in-sight/64).

The moderation extensions — suspend, flags, tags, approval, gdpr — each optionally depend on audit, so they boot after it and their actions are audited. `fof/ban-ips` optionally depends on those moderation extensions, and `fof/geoip` on `fof/ban-ips`. Audit *also* declaring an optional dependency on `fof/geoip` closed the loop:

```
audit → geoip → ban-ips → {suspend, flags, tags, approval, gdpr} → audit
```

That is a genuine cycle across a mainstream set, and it aborts the upgrade migration with:

```
In ExtensionManager.php line 388:
Circular dependencies detected: Approval, Audit, Flags, FoF Ban IPs, FoF GeoIP,
GDPR Data Management, Suspend, Tags - aborting.
```

There is no reasonable workaround short of hand-editing `vendor/composer/installed.json`, which is what affected users have resorted to.

Audit never uses geoip on the backend. The IP enrichment (country flag, tooltip, lookup) is a *frontend* extension of core's `IPAddress` component — geoip extends the component that audit happens to render, resolved when the component renders, not through this boot-order edge. So the `optional-dependencies: ["fof/geoip"]` entry on audit was dead weight. Removing it breaks the cycle and leaves the enrichment untouched.

Verified on a dev install with audit + geoip (+ ban-ips + a moderation extension): the circular error is gone, and the geoip country flag still renders on an audit-log entry's IP.

**Reviewers should focus on:**

- That removing audit's optional dependency on geoip is safe — audit has no backend geoip usage, and the frontend IP enrichment does not rely on boot/bundle order.
- The regression test models the real eight-extension set and asserts it resolves with audit ahead of the extensions that audit its actions.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — removing the audit→geoip edge, versus reversing it to geoip→audit; audit consumes nothing from geoip on the backend, so there is no ordering to preserve and the edge is simply removed.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — audit is a bundled core extension; the offending declaration is in its composer.json.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no frontend code changes; the geoip flag enrichment was verified still rendering on dev.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here. — a regression test for the eight-extension resolution.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
