### PR TITLE
[2.x] chore: prepare v2.0.0-rc.7 changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v2.0.0-rc.7](https://github.com/flarum/framework/compare/v2.0.0-rc.6...v2.0.0-rc.7)
+
+### Fixed
+
+- (core) route internal links correctly on a forum installed in a subdirectory by @ekumanov [#4976]
+- (core) name a queue connection an extension leaves unnamed, so pause/resume no longer fatals by @imorland [#4977]
+- (subscriptions) delete the reply notification job when its post is gone by @karl-bullock [#4975]
+- (audit) break the audit/geoip circular dependency that aborts the upgrade by @imorland [#4978]
+- (tags) align an icon-less tag's square with its label by @imorland [#4979]
+
 ## [v2.0.0-rc.6](https://github.com/flarum/framework/compare/v2.0.0-rc.5...v2.0.0-rc.6)
 
 ### Added

--- a/extensions/akismet/composer.json
+++ b/extensions/akismet/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "^2.0.0-rc.7",
         "flarum/approval": "^2.0"
     },
     "autoload": {
@@ -75,7 +75,7 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     },
     "repositories": [
         {

--- a/extensions/approval/composer.json
+++ b/extensions/approval/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "^2.0.0-rc.7",
         "flarum/flags": "^2.0"
     },
     "autoload": {
@@ -92,6 +92,6 @@
     "require-dev": {
         "flarum/audit": "*",
         "flarum/tags": "*",
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     }
 }

--- a/extensions/audit/composer.json
+++ b/extensions/audit/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "^2.0.0-rc.7",
         "ext-json": "*"
     },
     "autoload": {
@@ -88,7 +88,7 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
         "flarum/approval": "*",
         "flarum/flags": "*",
         "flarum/lock": "*",

--- a/extensions/bbcode/composer.json
+++ b/extensions/bbcode/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/embed/composer.json
+++ b/extensions/embed/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/emoji/composer.json
+++ b/extensions/emoji/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "extra": {
         "branch-alias": {

--- a/extensions/flags/composer.json
+++ b/extensions/flags/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -80,7 +80,7 @@
         "flarum/audit": "*",
         "flarum/core": "*@dev",
         "flarum/tags": "*@dev",
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     },
     "repositories": [
         {

--- a/extensions/gdpr/composer.json
+++ b/extensions/gdpr/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "^2.0.0-rc.7",
         "nelexa/zip": "^4.0.2"
     },
     "autoload": {
@@ -91,8 +91,8 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6",
-        "flarum/phpstan": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
+        "flarum/phpstan": "^2.0.0-rc.7",
         "flarum/audit": "*"
     }
 }

--- a/extensions/lang-english/composer.json
+++ b/extensions/lang-english/composer.json
@@ -7,7 +7,7 @@
     ],
     "license": "MIT",
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "extra": {
         "branch-alias": {

--- a/extensions/likes/composer.json
+++ b/extensions/likes/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -89,6 +89,6 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     }
 }

--- a/extensions/lock/composer.json
+++ b/extensions/lock/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -90,7 +90,7 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
         "flarum/audit": "*"
     }
 }

--- a/extensions/markdown/composer.json
+++ b/extensions/markdown/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "extra": {
         "branch-alias": {

--- a/extensions/mentions/composer.json
+++ b/extensions/mentions/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -80,7 +80,7 @@
         "flarum/tags": "*@dev",
         "flarum/approval": "*@dev",
         "flarum/flags": "*@dev",
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     },
     "repositories": [
         {

--- a/extensions/messages/composer.json
+++ b/extensions/messages/composer.json
@@ -7,7 +7,7 @@
     "type": "flarum-extension",
     "license": "MIT",
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "authors": [
         {
@@ -79,6 +79,6 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     }
 }

--- a/extensions/nicknames/composer.json
+++ b/extensions/nicknames/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -70,7 +70,7 @@
         "test:setup": "@php tests/integration/setup.php"
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
         "flarum/core": "2.x-dev",
         "flarum/audit": "*"
     },

--- a/extensions/package-manager/composer.json
+++ b/extensions/package-manager/composer.json
@@ -22,11 +22,11 @@
         "source": "https://github.com/flarum/extension-manager"
     },
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "^2.0.0-rc.7",
         "composer/composer": "^2.7"
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
         "flarum/tags": "*"
     },
     "extra": {

--- a/extensions/pusher/composer.json
+++ b/extensions/pusher/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "^2.0.0-rc.7",
         "pusher/pusher-php-server": "^7.2"
     },
     "require-dev": {

--- a/extensions/realtime/composer.json
+++ b/extensions/realtime/composer.json
@@ -24,7 +24,7 @@
     ],
     "type": "flarum-extension",
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "^2.0.0-rc.7",
         "plesk/ratchetphp": "v1.0.4",
         "pusher/pusher-php-server": "^7.2.0"
     },
@@ -87,8 +87,8 @@
         "flarum/flags": "^2.0.0",
         "flarum/tags": "^2.0.0",
         "fof/reactions": "^2.0.0",
-        "flarum/phpstan": "^2.0.0-rc.6",
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/phpstan": "^2.0.0-rc.7",
+        "flarum/testing": "^2.0.0-rc.7",
         "flarum/messages": "^2.0.0",
         "fof/discussion-views": "^2.0.0"
     },

--- a/extensions/statistics/composer.json
+++ b/extensions/statistics/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -76,7 +76,7 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     },
     "repositories": [
         {

--- a/extensions/sticky/composer.json
+++ b/extensions/sticky/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -93,6 +93,6 @@
     "require-dev": {
         "flarum/audit": "*",
         "flarum/tags": "*@dev",
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     }
 }

--- a/extensions/subscriptions/composer.json
+++ b/extensions/subscriptions/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -89,7 +89,7 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
         "flarum/approval": "@dev",
         "flarum/markdown": "@dev"
     }

--- a/extensions/suspend/composer.json
+++ b/extensions/suspend/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -90,6 +90,6 @@
     },
     "require-dev": {
         "flarum/audit": "*",
-        "flarum/testing": "^2.0.0-rc.6"
+        "flarum/testing": "^2.0.0-rc.7"
     }
 }

--- a/extensions/tags/composer.json
+++ b/extensions/tags/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.6"
+        "flarum/core": "^2.0.0-rc.7"
     },
     "autoload": {
         "psr-4": {
@@ -83,7 +83,7 @@
     },
     "require-dev": {
         "flarum/core": "*@dev",
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
         "flarum/suspend": "^2.0",
         "flarum/audit": "*"
     },

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -96,7 +96,7 @@
         "wikimedia/less.php": "^5.3"
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.6",
+        "flarum/testing": "^2.0.0-rc.7",
         "symfony/var-dumper": "^7.4"
     },
     "autoload": {

--- a/framework/core/src/Foundation/Application.php
+++ b/framework/core/src/Foundation/Application.php
@@ -27,7 +27,7 @@ class Application extends IlluminateContainer implements LaravelApplication
      *
      * @var string
      */
-    public const VERSION = '2.0.0-rc.6';
+    public const VERSION = '2.0.0-rc.7';
 
     protected bool $booted = false;
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

Prepares the `v2.0.0-rc.7` release.

- Bumps `Application::VERSION` to `2.0.0-rc.7`.
- Raises the `flarum/core` and `flarum/testing` constraints to `^2.0.0-rc.7` across core and all bundled extensions.
- Adds the `v2.0.0-rc.7` changelog section covering the five fixes merged since rc.6 (milestone 68):
  - break the audit/geoip circular dependency that aborts the upgrade (#4978)
  - name a queue connection an extension leaves unnamed (#4977)
  - route internal links correctly on a subdirectory install (#4976)
  - delete the subscriptions reply-notification job when its post is gone (#4975)
  - align an icon-less tag's square with its label (#4979)

**Reviewers should focus on:**

- That the changelog matches milestone 68 (five PRs, all `type/bug`).
- That every bundled extension's constraint was bumped consistently.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — routine release prep.
- [ ] If applicable, have various options for solving this problem been considered? — n/a.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — release prep for the monorepo.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no code changes.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`). — version/constraint/changelog only, no logic changes.
- [x] Backend changes: tests have been added, or are not appropriate here. — n/a for release prep.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
