### PR TITLE
[2.x] fix(jest-config): make frontend testing work in standalone extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - (subscriptions) delete the reply notification job when its post is gone by @karl-bullock [#4975]
 - (audit) break the audit/geoip circular dependency that aborts the upgrade by @imorland [#4978]
 - (tags) align an icon-less tag's square with its label by @imorland [#4979]
+- (jest-config) make frontend testing work in standalone, Composer-installed extensions by @imorland [#4983]
 
 ## [v2.0.0-rc.6](https://github.com/flarum/framework/compare/v2.0.0-rc.5...v2.0.0-rc.6)
 

--- a/framework/core/js/tests/factory.ts
+++ b/framework/core/js/tests/factory.ts
@@ -1,58 +1,8 @@
-export function makeDiscussion(data: any = {}) {
-  return makeModel('discussions', data.id, {
-    attributes: {
-      title: 'Discussion 1',
-      slug: 'discussion-1',
-      lastPostedAt: new Date().toISOString(),
-      unreadCount: 0,
-      commentCount: 0,
-      ...(data.attributes || {}),
-    },
-    relationships: {
-      firstPost: {
-        data: { type: 'posts', id: '1' },
-      },
-      user: {
-        data: { type: 'users', id: '1' },
-      },
-      ...(data.relationships || {}),
-    },
-  });
-}
+/*
+ * The frontend test factories now live in `@flarum/jest-config` so that
+ * standalone, Composer-installed extensions can use them too (core's `tests/`
+ * directory is stripped from the Composer package). Re-exported here so
+ * existing imports of `tests/factory` inside the monorepo keep working.
+ */
 
-export function makeUser(data: any = {}) {
-  return makeModel('users', data.id, {
-    attributes: {
-      id: data.id,
-      username: 'user' + data.id,
-      displayName: 'User ' + data.id,
-      email: `user${data.id}@machine.local`,
-      joinTime: '2021-01-01T00:00:00Z',
-      isEmailConfirmed: true,
-      preferences: {},
-      ...(data.attributes || {}),
-    },
-    relationships: {
-      groups: {
-        data: [],
-      },
-      ...(data.relationships || {}),
-    },
-  });
-}
-
-function makeModel(type: string | undefined | null, id: string | number | undefined | null, data: any) {
-  if (!id) {
-    throw new Error('You must provide an id when making a model');
-  }
-
-  if (!type) {
-    throw new Error('You must provide a type when making a model');
-  }
-
-  return {
-    type,
-    id,
-    ...data,
-  };
-}
+export { makeUser, makeDiscussion } from '@flarum/jest-config/factory';

--- a/js-packages/jest-config/factory.ts
+++ b/js-packages/jest-config/factory.ts
@@ -1,0 +1,68 @@
+/*
+ * Frontend test factories for building JSON:API resource payloads.
+ *
+ * These live in `@flarum/jest-config` — a dev-only package extensions already
+ * install to test their frontend — rather than in core's `tests/` directory,
+ * which is stripped from the Composer package and so is never present in a
+ * standalone extension's vendored core. They are self-contained (no core
+ * imports), so they ship cleanly here and are available to any extension.
+ */
+
+export function makeDiscussion(data: any = {}) {
+  return makeModel('discussions', data.id, {
+    attributes: {
+      title: 'Discussion 1',
+      slug: 'discussion-1',
+      lastPostedAt: new Date().toISOString(),
+      unreadCount: 0,
+      commentCount: 0,
+      ...(data.attributes || {}),
+    },
+    relationships: {
+      firstPost: {
+        data: { type: 'posts', id: '1' },
+      },
+      user: {
+        data: { type: 'users', id: '1' },
+      },
+      ...(data.relationships || {}),
+    },
+  });
+}
+
+export function makeUser(data: any = {}) {
+  return makeModel('users', data.id, {
+    attributes: {
+      id: data.id,
+      username: 'user' + data.id,
+      displayName: 'User ' + data.id,
+      email: `user${data.id}@machine.local`,
+      joinTime: '2021-01-01T00:00:00Z',
+      isEmailConfirmed: true,
+      preferences: {},
+      ...(data.attributes || {}),
+    },
+    relationships: {
+      groups: {
+        data: [],
+      },
+      ...(data.relationships || {}),
+    },
+  });
+}
+
+function makeModel(type: string | undefined | null, id: string | number | undefined | null, data: any) {
+  if (!id) {
+    throw new Error('You must provide an id when making a model');
+  }
+
+  if (!type) {
+    throw new Error('You must provide a type when making a model');
+  }
+
+  return {
+    type,
+    id,
+    ...data,
+  };
+}

--- a/js-packages/jest-config/index.cjs
+++ b/js-packages/jest-config/index.cjs
@@ -1,20 +1,82 @@
 const path = require('path');
+const fs = require('fs');
 
-module.exports = (options = {}) => ({
-  testEnvironment: 'jsdom',
-  extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  transform: {
-    '^.+\\.[tj]sx?$': ['babel-jest', require('flarum-webpack-config/babel.config.cjs')],
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      {
-        useESM: true,
-      },
-    ],
-  },
-  preset: 'ts-jest',
-  setupFiles: [path.resolve(__dirname, 'pollyfills.js')],
-  setupFilesAfterEnv: [path.resolve(__dirname, 'setup-env.js')],
-  moduleDirectories: ['node_modules', 'src'],
-  ...options,
-});
+/**
+ * Locate Flarum core's frontend source (its `js` directory).
+ *
+ * Inside the monorepo, `@flarum/core` resolves as a workspace package. A
+ * standalone, Composer-installed extension has no such package; instead core's
+ * source is vendored at `vendor/flarum/core/js`. Detect the monorepo case
+ * first (so core and the bundled extensions are unaffected) and fall back to
+ * the vendored path, so the same config works in both layouts with no setup.
+ */
+function resolveCoreDir(cwd) {
+  // A standalone, Composer-installed extension carries core's frontend source
+  // at `vendor/flarum/core/js`. Prefer it when present: the extension under
+  // test is the authority on where its own core lives, and this is checked
+  // relative to the extension (cwd), not to where this package happens to sit.
+  //
+  // `cwd` is the directory jest runs from — the extension's `js` dir for a
+  // typical layout — so look for the vendor path from there and from its
+  // parent (extensions keep `vendor/` beside `js/`, not inside it).
+  for (const base of [cwd, path.resolve(cwd, '..')]) {
+    const vendored = path.resolve(base, 'vendor/flarum/core/js');
+
+    if (fs.existsSync(vendored)) {
+      return vendored;
+    }
+  }
+
+  try {
+    // Monorepo (or any install where @flarum/core resolves as a package).
+    return path.dirname(require.resolve('@flarum/core/package.json', { paths: [cwd, __dirname] }));
+  } catch (e) {
+    throw new Error(
+      '@flarum/jest-config could not locate Flarum core. Expected a Composer-vendored copy at ' +
+        '`vendor/flarum/core/js`, or the `@flarum/core` package (inside the monorepo). Run ' +
+        '`composer install` so `flarum/core` is present, then try again.'
+    );
+  }
+}
+
+module.exports = (options = {}) => {
+  const cwd = process.cwd();
+  const coreDir = resolveCoreDir(cwd);
+
+  return {
+    testEnvironment: 'jsdom',
+    extensionsToTreatAsEsm: ['.ts', '.tsx'],
+    transform: {
+      '^.+\\.[tj]sx?$': ['babel-jest', require('flarum-webpack-config/babel.config.cjs')],
+      '^.+\\.tsx?$': [
+        'ts-jest',
+        {
+          useESM: true,
+        },
+      ],
+    },
+    preset: 'ts-jest',
+    setupFiles: [path.resolve(__dirname, 'pollyfills.js')],
+    setupFilesAfterEnv: [path.resolve(__dirname, 'setup-env.js')],
+    moduleDirectories: ['node_modules', 'src'],
+    // Transform the extension's own files and, when core is vendored outside
+    // it, core's source too — otherwise its TypeScript is loaded untransformed
+    // and fails on the first type annotation.
+    roots: ['<rootDir>', coreDir],
+    // Core's source imports its runtime deps by bare name (`mithril`, …). When
+    // core is vendored, those files resolve modules from core's own ancestry,
+    // not the extension's node_modules where a single `yarn install` puts them,
+    // so add the extension's node_modules as an explicit resolver search path.
+    modulePaths: [path.join(cwd, 'node_modules')],
+    // Resolve `@flarum/core/...` imports (used by setup-env and the bootstrap
+    // helpers, and available for tests) to wherever core actually lives.
+    moduleNameMapper: {
+      '^@flarum/core/(.*)$': path.join(coreDir, '$1'),
+    },
+    // Exposed so the bootstrap helpers can read core's bundled locale file.
+    globals: {
+      __FLARUM_CORE_DIR__: coreDir,
+    },
+    ...options,
+  };
+};

--- a/js-packages/jest-config/package.json
+++ b/js-packages/jest-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flarum/jest-config",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Jest config for Flarum.",
   "main": "index.cjs",
   "author": "Flarum Team",

--- a/js-packages/jest-config/package.json
+++ b/js-packages/jest-config/package.json
@@ -9,14 +9,31 @@
   "prettier": "@flarum/prettier-config",
   "dependencies": {
     "@types/jest": "^29.2.2",
+    "body-scroll-lock": "^4.0.0-beta.0",
+    "bootstrap": "^3.4.1",
+    "clsx": "^1.1.1",
+    "color-thief-browser": "^2.0.2",
+    "dayjs": "^1.10.7",
     "flarum-webpack-config": "^3.0.0",
     "flat": "^5.0.2",
+    "focus-trap": "^6.7.1",
+    "format-message": "^6.2.4",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
+    "jquery": "^3.6.0",
+    "jquery.hotkeys": "^0.1.0",
     "js-yaml": "^4.3.1",
     "jsdom": "^24.0.0",
+    "mithril": "^2.2",
     "mithril-query": "^4.0.1",
-    "ts-jest": "^29.0.3"
+    "nanoid": "^3.3.18",
+    "punycode": "^2.1.1",
+    "sortablejs": "^1.14.0",
+    "textarea-caret": "^3.1.0",
+    "throttle-debounce": "^3.0.1",
+    "ts-jest": "^29.0.3",
+    "web-haptics": "^0.0.6",
+    "xslt-polyfill": "^1.0.21"
   },
   "devDependencies": {
     "prettier": "^2.4.1"

--- a/js-packages/jest-config/src/bootstrap/common.js
+++ b/js-packages/jest-config/src/bootstrap/common.js
@@ -1,8 +1,9 @@
 import Drawer from '@flarum/core/src/common/utils/Drawer';
-import { makeUser } from '@flarum/core/tests/factory';
+import { makeUser } from '../../factory';
 import flatten from 'flat';
 import jsYaml from 'js-yaml';
 import fs from 'fs';
+import path from 'path';
 
 export default function bootstrap(Application, app, payload = {}) {
   Application.prototype.mount = () => {};
@@ -37,6 +38,9 @@ export default function bootstrap(Application, app, payload = {}) {
   });
 
   app.translator.setLocale('en');
-  app.translator.addTranslations(flatten(jsYaml.load(fs.readFileSync('../locale/core.yml', 'utf8'))));
+  // core's locale file lives at <core>/locale/core.yml. `__FLARUM_CORE_DIR__`
+  // points at core's `js` dir (set by the jest config), so step up one level.
+  const coreLocale = path.join(__FLARUM_CORE_DIR__, '..', 'locale', 'core.yml');
+  app.translator.addTranslations(flatten(jsYaml.load(fs.readFileSync(coreLocale, 'utf8'))));
   app.drawer = new Drawer();
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**

Fixes #4689 — the documented frontend test setup does not work in a standalone, Composer-installed extension.

The [frontend testing docs](https://docs.flarum.org/2.x/extend/testing/#frontend-tests) present a flow that only works inside the `flarum/framework` monorepo. Outside it, `@flarum/jest-config` imports from `@flarum/core`, which is **not** an npm package — so every `bootstrapForum()`/`bootstrapAdmin()` test fails at resolution. Even mapped to the Composer-vendored core, its TypeScript went untransformed and its runtime deps were absent.

This makes the same config work in both layouts, so an extension author gets working frontend tests from a single `yarn install` in their `js/` folder — exactly what the docs already promise.

**What changed (`@flarum/jest-config`):**

- **Resolve core wherever it lives.** `resolveCoreDir()` prefers the Composer-vendored core (`vendor/flarum/core/js`) when present and falls back to the monorepo `@flarum/core` package. `moduleNameMapper` then points `@flarum/core/*` at it. Core and the bundled extensions resolve exactly as before.
- **Transform the vendored core.** Its source sits outside the extension, so it's added to the transform `roots` — otherwise its TypeScript is loaded untransformed and dies on the first type annotation (`SyntaxError: Unexpected token ':'`).
- **Resolve core's own imports.** Core's source imports its runtime deps by bare name (`mithril`, `format-message`, …); the extension's `node_modules` is added to `modulePaths` so those resolve there, where a single install puts them.
- **Locale read** now derives from the resolved core dir, not a bare `../locale/core.yml`.
- **The frontend test factory moves here.** `makeUser`/`makeDiscussion` lived in core's `js/tests/`, which the Composer package strips (`**/tests export-ignore`) — so a standalone extension never has it. It now lives in `@flarum/jest-config` (a dev-only package extensions already install), so no test code ships to a production install. Core re-exports it so existing monorepo imports keep working.
- **Core's frontend runtime dependencies are declared here**, so the one `yarn install` in the extension's `js/` provides everything core's source needs at test time.

**Still to do (not in this PR):**

- Publish a new `@flarum/jest-config` carrying this.
- Update the frontend testing docs (the standalone flow, and the example test paths, which are currently monorepo-relative).

**Reviewers should focus on:**

- That the monorepo path is untouched behaviour — core, bundled extensions and their `bootstrapForum()` tests resolve core the same way as before.
- That the standalone path works from a single `yarn install` in `js/`, with no `install` inside `vendor/`.
- Whether declaring core's runtime deps here is the right call, versus another way to make the single install carry them (the constraint: one `yarn install` in `js/`, and `@flarum/core` is not on npm).

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — verified in the monorepo (core: 207 unit tests + factory integration; tags: 447) and standalone against a real Composer-installed extension (fof/links), where `bootstrapForum()` now boots the app and loads core translations.
- [x] Frontend changes: tests are green.
- [ ] Frontend changes: tests have been added — the fix is to the test tooling itself; verified against real suites in both layouts rather than a new unit test.
- [ ] Backend changes: n/a.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [x] Related documentation PR: flarum/docs#581

