### PR TITLE
[2.x] fix(jest-config): transform core's source in standalone extension tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - (subscriptions) delete the reply notification job when its post is gone by @karl-bullock [#4975]
 - (audit) break the audit/geoip circular dependency that aborts the upgrade by @imorland [#4978]
 - (tags) align an icon-less tag's square with its label by @imorland [#4979]
-- (jest-config) make frontend testing work in standalone, Composer-installed extensions by @imorland [#4983]
+- (jest-config) make frontend testing work in standalone, Composer-installed extensions by @imorland [#4983], [#4984]
 
 ## [v2.0.0-rc.6](https://github.com/flarum/framework/compare/v2.0.0-rc.5...v2.0.0-rc.6)
 

--- a/js-packages/jest-config/index.cjs
+++ b/js-packages/jest-config/index.cjs
@@ -2,6 +2,32 @@ const path = require('path');
 const fs = require('fs');
 
 /**
+ * The shared Flarum babel config, with `@babel/preset-env` forced to emit ES
+ * modules. Under Jest that preset otherwise defaults to CommonJS (`modules:
+ * 'auto'`), which does not match `extensionsToTreatAsEsm` and breaks module
+ * loading. Everything else (the Mithril JSX pragma, TypeScript, the plugins)
+ * is kept as-is.
+ */
+function esmBabelConfig() {
+  const config = require('flarum-webpack-config/babel.config.cjs');
+
+  return {
+    ...config,
+    presets: (config.presets || []).map((preset) => {
+      const name = Array.isArray(preset) ? preset[0] : preset;
+
+      if (typeof name === 'string' && name.includes('preset-env')) {
+        const options = Array.isArray(preset) ? preset[1] || {} : {};
+
+        return [name, { ...options, modules: false }];
+      }
+
+      return preset;
+    }),
+  };
+}
+
+/**
  * Locate Flarum core's frontend source (its `js` directory).
  *
  * Inside the monorepo, `@flarum/core` resolves as a workspace package. A
@@ -46,19 +72,28 @@ module.exports = (options = {}) => {
   return {
     testEnvironment: 'jsdom',
     extensionsToTreatAsEsm: ['.ts', '.tsx'],
+    // Everything is transformed by babel-jest, which understands Flarum's
+    // Mithril-flavoured JSX (pragma `m`). We force `@babel/preset-env` to emit
+    // ES modules (`modules: false`) so the output matches
+    // `extensionsToTreatAsEsm` — the shared babel config defaults to `auto`,
+    // which is CommonJS under Jest and clashes with ESM loading (it surfaces as
+    // "Unexpected token" or a broken `class extends` once core's TypeScript is
+    // pulled in from outside the extension).
     transform: {
-      '^.+\\.[tj]sx?$': ['babel-jest', require('flarum-webpack-config/babel.config.cjs')],
-      '^.+\\.tsx?$': [
-        'ts-jest',
-        {
-          useESM: true,
-        },
-      ],
+      '^.+\\.[tj]sx?$': ['babel-jest', esmBabelConfig()],
     },
-    preset: 'ts-jest',
     setupFiles: [path.resolve(__dirname, 'pollyfills.js')],
     setupFilesAfterEnv: [path.resolve(__dirname, 'setup-env.js')],
     moduleDirectories: ['node_modules', 'src'],
+    // This package's setup and bootstrap files live in the extension's
+    // node_modules and import core's TypeScript. Jest ignores node_modules for
+    // transformation by default, and that ignore extends to the core source
+    // pulled in through them — so it reaches Jest untransformed and dies on its
+    // first type annotation. Un-ignore this package (and only this one) so its
+    // helpers, and the core code they import, are transformed; everything else
+    // under node_modules stays ignored, as some ships non-strict JS Jest can't
+    // parse.
+    transformIgnorePatterns: ['/node_modules/(?!@flarum/jest-config/)', '\\.pnp\\.[^\\/]+$'],
     // Transform the extension's own files and, when core is vendored outside
     // it, core's source too — otherwise its TypeScript is loaded untransformed
     // and fails on the first type annotation.

--- a/js-packages/jest-config/package.json
+++ b/js-packages/jest-config/package.json
@@ -9,6 +9,7 @@
   "prettier": "@flarum/prettier-config",
   "dependencies": {
     "@types/jest": "^29.2.2",
+    "babel-jest": "^29.3.1",
     "body-scroll-lock": "^4.0.0-beta.0",
     "bootstrap": "^3.4.1",
     "clsx": "^1.1.1",


### PR DESCRIPTION
**Changes proposed in this pull request:**

Follow-up to #4983. That PR made a standalone, Composer-installed extension able to *resolve* core for its frontend tests — but the tests still couldn't *run*. Verified against a real standalone extension (installed from the packaged tarball, not the monorepo), every test failed before executing. This completes the fix so they actually run.

Three things were wrong once core is resolved from outside the monorepo:

- **CommonJS vs ESM.** The shared babel config runs `@babel/preset-env` with `modules: 'auto'`, which is CommonJS under Jest — clashing with `extensionsToTreatAsEsm` and surfacing as `Unexpected token` / a broken `class extends`. `esmBabelConfig()` forces `modules: false` so babel-jest's output matches how Jest loads it.
- **Missing `babel-jest`.** It was assumed present (hoisted in the monorepo) but never declared as a dependency, so a standalone install had no transformer at all. Now declared.
- **Transform ignore reaching core.** This package's setup and bootstrap helpers live in the extension's `node_modules` and import core's TypeScript. Jest's default `transformIgnorePatterns: /node_modules/` extends to that core source, so it reached Jest untransformed and died on its first type annotation. Un-ignore this package (and only this one) so its helpers, and the core code they import, are transformed; everything else under `node_modules` stays ignored (some ships non-strict JS Jest can't parse).

`@flarum/jest-config` stays at `2.0.1` (the version bumped in #4983 was never published, so this corrects its contents before release).

**Reviewers should focus on:**

- That the monorepo path is unchanged in behaviour — the full frontend suite stays green.
- The `transformIgnorePatterns` negative-lookahead: it un-ignores exactly `@flarum/jest-config` and nothing else.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — full monorepo frontend suite green (core 438, embed 453, mentions 441, realtime 6, statistics 442, tags 447), and the documented unit + `bootstrapForum()` tests run in a real standalone extension installed from the packaged tarball.
- [x] Frontend changes: tests are green.
- [ ] Frontend changes: tests have been added — the fix is to the test tooling; verified against real suites in both layouts.
- [ ] Backend changes: n/a.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: flarum/docs#581 (already covers the standalone flow and the `^2.0.1` requirement).
