### PR TITLE
[2.x] fix(jest-config): resolve the 'flarum/...' import alias in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - (subscriptions) delete the reply notification job when its post is gone by @karl-bullock [#4975]
 - (audit) break the audit/geoip circular dependency that aborts the upgrade by @imorland [#4978]
 - (tags) align an icon-less tag's square with its label by @imorland [#4979]
-- (jest-config) make frontend testing work in standalone, Composer-installed extensions by @imorland [#4983], [#4984]
+- (jest-config) make frontend testing work in standalone, Composer-installed extensions by @imorland [#4983], [#4984], [#4985]
 
 ## [v2.0.0-rc.6](https://github.com/flarum/framework/compare/v2.0.0-rc.5...v2.0.0-rc.6)
 

--- a/js-packages/jest-config/index.cjs
+++ b/js-packages/jest-config/index.cjs
@@ -103,10 +103,15 @@ module.exports = (options = {}) => {
     // not the extension's node_modules where a single `yarn install` puts them,
     // so add the extension's node_modules as an explicit resolver search path.
     modulePaths: [path.join(cwd, 'node_modules')],
-    // Resolve `@flarum/core/...` imports (used by setup-env and the bootstrap
-    // helpers, and available for tests) to wherever core actually lives.
+    // Resolve core imports to wherever core actually lives. `@flarum/core/...`
+    // is used by this package's own setup and bootstrap helpers; `flarum/...`
+    // is the alias extensions import core through at runtime (webpack turns it
+    // into a `flarum.reg` lookup), so map it to core's source for tests too —
+    // otherwise an extension's own components, which import via `flarum/...`,
+    // cannot be tested.
     moduleNameMapper: {
       '^@flarum/core/(.*)$': path.join(coreDir, '$1'),
+      '^flarum/(.*)$': path.join(coreDir, 'src', '$1'),
     },
     // Exposed so the bootstrap helpers can read core's bundled locale file.
     globals: {

--- a/js-packages/jest-config/package.json
+++ b/js-packages/jest-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flarum/jest-config",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Jest config for Flarum.",
   "main": "index.cjs",
   "author": "Flarum Team",


### PR DESCRIPTION
**Changes proposed in this pull request:**

Follow-up to #4983 / #4984. Those made a standalone extension able to run frontend tests that import core via `@flarum/core/...`. But **extensions import core through the `flarum/...` alias** — webpack rewrites `flarum/forum/app` etc. into a `flarum.reg` lookup at build time — so an extension's *own* components, which use `flarum/...`, still could not be tested: only test code written against `@flarum/core/...` resolved.

This maps `flarum/(.*)` to core's `src` alongside the existing `@flarum/core/...` mapping, pointing at whichever core is installed (Composer-vendored, or the monorepo). Now an extension can test its own component and util code with the same imports it ships.

Bundled extensions that already declare their own `flarum/*` moduleNameMapper are unaffected — theirs is merged on top and still wins.

**Scope note:** the `ext:<vendor>/<ext>/...` alias — used to import *another* extension — is deliberately not mapped here. Testing an extension's own code (which imports core via `flarum/...`) is the common case and what this enables; cross-extension test imports are a larger, separate problem.

`@flarum/jest-config` bumps to `2.0.2`.

**Reviewers should focus on:**

- That the monorepo path is unchanged — the full frontend suite stays green, and extensions with their own `flarum/*` mapper (e.g. tags) keep theirs.
- That `flarum/...` correctly resolves to core's `src` (not core's root), matching how the alias is used.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — full monorepo frontend suite green (core 438, embed 453, mentions 441, realtime 6, statistics 442, tags 447), and real tests in a standalone extension (fof/links) that import core via `flarum/...` now run.
- [x] Frontend changes: tests are green.
- [ ] Frontend changes: tests have been added — the fix is to the test tooling; verified against real suites in both layouts.
- [ ] Backend changes: n/a.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: flarum/docs#581 (the standalone frontend-testing guide).
