### PR TITLE
[2.x] fix: Restore held-back email values on every message, and protect core mail

### DIFF
--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -130,8 +130,15 @@ class MailServiceProvider extends AbstractServiceProvider
         // values back and a formatter that puts them in, escaped, after
         // rendering. Doing it here means no template has to change — including
         // the ones in extensions that will never be updated.
+        //
+        // Core's own mail views live in the `mail::` namespace; extensions
+        // conventionally keep theirs under an `email`/`emails` path. Both are
+        // covered so that core notifications are protected too, not only
+        // extension mail. The values are put back on the finished message by
+        // {@see MutateEmail}, so a template that never calls the formatter is
+        // still safe — the marker just survives until then.
         $views->composer('*', function (View $view) use ($container) {
-            if (! str_contains($view->name(), 'email')) {
+            if (! $this->isMailView($view->name())) {
                 return;
             }
 
@@ -140,5 +147,14 @@ class MailServiceProvider extends AbstractServiceProvider
                 'formatter' => new MailFormatter($container->make(Formatter::class)),
             ]);
         });
+    }
+
+    /**
+     * Whether a view name belongs to an email — core's `mail::` namespace, or
+     * an extension view kept under an `email`/`emails` path by convention.
+     */
+    private function isMailView(string $name): bool
+    {
+        return str_starts_with($name, 'mail::') || str_contains($name, 'email');
     }
 }

--- a/framework/core/src/Mail/MutateEmail.php
+++ b/framework/core/src/Mail/MutateEmail.php
@@ -23,6 +23,37 @@ class MutateEmail
             $headers->addTextHeader('List-Unsubscribe', '<'.$unsubscribeLink.'>');
         }
 
+        $this->restoreSafeValues($event);
+
         return true;
+    }
+
+    /**
+     * Put back any values {@see MailTranslator} held out of the rendered body
+     * as markers. Doing it on the finished message — rather than relying on a
+     * template to route every translation through {@see MailFormatter} — means
+     * the values are restored no matter which template or extension produced
+     * the mail, and no template has to change.
+     *
+     * A body that carries no markers (anything that never went through the mail
+     * translator) is left untouched.
+     */
+    private function restoreSafeValues(MessageSending $event): void
+    {
+        $message = $event->message;
+
+        $html = $message->getHtmlBody();
+
+        if (is_string($html) && SafeSubstitution::contains($html)) {
+            $message->html(SafeSubstitution::restore($html), $message->getHtmlCharset() ?? 'utf-8');
+        }
+
+        $text = $message->getTextBody();
+
+        if (is_string($text) && SafeSubstitution::contains($text)) {
+            // Plain text has no markup to protect, so the value is restored
+            // as-is rather than HTML-escaped.
+            $message->text(SafeSubstitution::restore($text, escape: false), $message->getTextCharset() ?? 'utf-8');
+        }
     }
 }

--- a/framework/core/src/Mail/SafeSubstitution.php
+++ b/framework/core/src/Mail/SafeSubstitution.php
@@ -44,14 +44,22 @@ abstract class SafeSubstitution
     }
 
     /**
-     * Put the marked values back into rendered output, escaped so that they
-     * are shown rather than interpreted.
+     * Put the marked values back into rendered output.
+     *
+     * In HTML the values are escaped so that they are shown rather than
+     * interpreted. In a plain-text part there is no markup to protect against,
+     * so the value is put back as-is — escaping it there would show literal
+     * entities like `&amp;` to the reader. Pass `$escape = false` for text.
      */
-    public static function restore(string $rendered): string
+    public static function restore(string $rendered, bool $escape = true): string
     {
         return preg_replace_callback(
             '/'.self::PREFIX.'([A-Za-z0-9]*)'.self::SUFFIX.'/',
-            fn (array $matches) => htmlspecialchars(self::decode($matches[1]), ENT_QUOTES, 'UTF-8'),
+            function (array $matches) use ($escape) {
+                $value = self::decode($matches[1]);
+
+                return $escape ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : $value;
+            },
             $rendered
         ) ?? $rendered;
     }

--- a/framework/core/tests/fixtures/views/email/bare-trans.blade.php
+++ b/framework/core/tests/fixtures/views/email/bare-trans.blade.php
@@ -1,0 +1,5 @@
+{{-- A mail view that outputs a translated value directly, WITHOUT routing it
+     through the formatter — the way flarum/gdpr's erasure email does. The safe
+     markers the mail translator applies must still be put back before the mail
+     is sent, or the reader sees `flarumsafevalue…endflarumsafevalue`. --}}
+{!! $translator->trans($template, $parameters) !!}

--- a/framework/core/tests/fixtures/views/email/formatter.blade.php
+++ b/framework/core/tests/fixtures/views/email/formatter.blade.php
@@ -1,0 +1,4 @@
+{{-- A mail view that renders the value through the formatter, the way core's
+     own notification templates do. The value is restored during rendering; the
+     message-level restore must not touch it again. --}}
+{!! $formatter->convert($translator->trans($template, $parameters)) !!}

--- a/framework/core/tests/fixtures/views/email/plain-passthrough.blade.php
+++ b/framework/core/tests/fixtures/views/email/plain-passthrough.blade.php
@@ -1,0 +1,3 @@
+{{-- A mail view whose content never went through the mail translator, so it
+     carries no markers at all. --}}
+{{ $bodyText }}

--- a/framework/core/tests/integration/mail/SafeSubstitutionRestoreTest.php
+++ b/framework/core/tests/integration/mail/SafeSubstitutionRestoreTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\mail;
+
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Mail\Message;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mime\Email;
+
+/**
+ * The mail translator holds parameter values back as markers so they cannot be
+ * parsed as markup, and they are put back once the mail is rendered. The values
+ * must be restored on every mail — whichever template or extension produced it,
+ * and whether or not that template routed the value through the formatter — so
+ * that a reader never sees a raw `flarumsafevalue…endflarumsafevalue` marker.
+ *
+ * These send a real mail through the mailer and inspect the finished message,
+ * which is where {@see \Flarum\Mail\MutateEmail} puts the values back.
+ */
+class SafeSubstitutionRestoreTest extends TestCase
+{
+    private ?Email $sent = null;
+
+    /**
+     * Send a mail built from the given text and html views and return the
+     * message as it went out, after all mutation.
+     *
+     * @param array<string, string> $data
+     */
+    private function sendMail(string $textView, string $htmlView, array $data): Email
+    {
+        /** @var Factory $views */
+        $views = $this->app()->getContainer()->make(Factory::class);
+        $views->addNamespace('flarum-core-test', __DIR__.'/../../fixtures/views');
+
+        /** @var \Illuminate\Contracts\Events\Dispatcher $events */
+        $events = $this->app()->getContainer()->make('events');
+        $events->listen(MessageSent::class, function (MessageSent $event) {
+            $this->sent = $event->message;
+        });
+
+        /** @var Mailer $mailer */
+        $mailer = $this->app()->getContainer()->make(Mailer::class);
+
+        $mailer->send(
+            ['text' => $textView, 'html' => $htmlView],
+            $data,
+            function (Message $message) {
+                $message->to('recipient@example.com');
+                $message->subject('Test');
+            }
+        );
+
+        $this->assertNotNull($this->sent, 'The mail was never sent.');
+
+        return $this->sent;
+    }
+
+    #[Test]
+    public function a_value_output_without_the_formatter_is_still_restored()
+    {
+        // The gdpr erasure email renders its body straight from the translator,
+        // never through the formatter — this pins that its values are put back
+        // regardless.
+        $data = [
+            'template' => 'Someone requested to erase the account `{name}`.',
+            'parameters' => ['{name}' => 'Karaok'],
+        ];
+
+        $message = $this->sendMail('flarum-core-test::email.bare-trans', 'flarum-core-test::email.bare-trans', $data);
+
+        $html = $message->getHtmlBody();
+        $text = $message->getTextBody();
+
+        $this->assertStringNotContainsString('flarumsafevalue', $html, 'A marker leaked into the html body.');
+        $this->assertStringNotContainsString('flarumsafevalue', $text, 'A marker leaked into the text body.');
+
+        $this->assertStringContainsString('Karaok', $html, 'The value must be restored in the html body.');
+        $this->assertStringContainsString('Karaok', $text, 'The value must be restored in the text body.');
+    }
+
+    #[Test]
+    public function a_value_output_through_the_formatter_is_restored_once()
+    {
+        // The value goes through the formatter here, so it was already restored
+        // during rendering; the message-level restore must leave it alone
+        // rather than double-process it.
+        $data = [
+            'template' => 'Welcome, {name}.',
+            'parameters' => ['{name}' => 'Karaok'],
+        ];
+
+        $message = $this->sendMail('flarum-core-test::email.formatter', 'flarum-core-test::email.formatter', $data);
+
+        $this->assertStringNotContainsString('flarumsafevalue', $message->getHtmlBody());
+        $this->assertStringContainsString('Karaok', $message->getHtmlBody());
+    }
+
+    #[Test]
+    public function a_marked_value_is_escaped_in_html_but_not_in_plain_text()
+    {
+        // In html the value is shown, not interpreted, so markup in it is
+        // escaped. In plain text there is nothing to interpret, so it is put
+        // back verbatim — no stray entities.
+        $data = [
+            'template' => 'Account: {name}.',
+            'parameters' => ['{name}' => 'A & B <tag>'],
+        ];
+
+        $message = $this->sendMail('flarum-core-test::email.bare-trans', 'flarum-core-test::email.bare-trans', $data);
+
+        $this->assertStringContainsString('A &amp; B &lt;tag&gt;', $message->getHtmlBody(), 'Markup in the value must be escaped in html.');
+        $this->assertStringContainsString('A & B <tag>', $message->getTextBody(), 'The plain-text value must not be html-escaped.');
+    }
+
+    #[Test]
+    public function a_core_mail_namespaced_view_is_protected()
+    {
+        // Core's own mail views live under the `mail::` namespace, whose names
+        // do not contain "email". They must be marked and restored just the
+        // same, or a value in a core notification would reach the reader
+        // unprotected — the very thing the mail translator exists to prevent.
+        //
+        // A marked value comes back html-escaped; an unmarked one is emitted
+        // verbatim. Feeding html metacharacters through therefore tells the two
+        // apart: escaping only happens if the `mail::` view was marked.
+        /** @var Factory $views */
+        $views = $this->app()->getContainer()->make(Factory::class);
+        // Add the fixtures dir as a second source for the real `mail` namespace,
+        // so the view name starts with `mail::` the way core's own views do.
+        $views->addNamespace('mail', __DIR__.'/../../fixtures/views/email');
+
+        $data = [
+            'template' => 'posted: {title}.',
+            'parameters' => ['{title}' => '<b>x</b>'],
+        ];
+
+        $message = $this->sendMail('mail::bare-trans', 'mail::bare-trans', $data);
+
+        $this->assertStringNotContainsString('flarumsafevalue', $message->getHtmlBody());
+        $this->assertStringContainsString('&lt;b&gt;x&lt;/b&gt;', $message->getHtmlBody(), 'The value in a core mail:: view must be marked and restored escaped.');
+        $this->assertStringNotContainsString('<b>x</b>', $message->getHtmlBody(), 'An unescaped value means the mail:: view was never protected.');
+    }
+
+    #[Test]
+    public function a_body_with_no_markers_is_untouched()
+    {
+        // A mail whose values never went through the mail translator carries no
+        // markers; the restore must be a no-op, not a mangle.
+        $data = ['bodyText' => 'nothing to restore here'];
+
+        $message = $this->sendMail('flarum-core-test::email.plain-passthrough', 'flarum-core-test::email.plain-passthrough', $data);
+
+        $this->assertStringContainsString('nothing to restore here', $message->getHtmlBody());
+        $this->assertStringContainsString('nothing to restore here', $message->getTextBody());
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**

The mail translator replaces parameter values (a discussion title, a display name) with opaque markers before an email is rendered, so they cannot be parsed as markup, and puts them back once rendering is done. That restore only ran inside `MailFormatter::convert()` — so any template that prints a translated value directly, without the formatter, sent the raw marker to the reader. flarum/gdpr's erasure emails do exactly that, and reported it: the account name and confirmation link arrived as `flarumsafevalue…endflarumsafevalue`.

This moves the restore onto the finished message, in `MutateEmail`:

- Values are put back on the rendered `MessageSending` body, so it happens for every email regardless of which template or extension produced it — and no template has to change, including ones in extensions that will never be updated.
- HTML parts are escaped as before (the value is shown, not interpreted). Plain-text parts are restored verbatim — there is no markup to guard against there, and escaping would show entities like `&amp;` to the reader.
- A body carrying no markers is left untouched, so mail that never went through the mail translator is unaffected.

It also fixes a gap in the original change: the view composer keyed on the view name containing `email`, which core's own `mail::` views don't — so core notifications were never marked, and the markup-injection protection didn't apply to them at all. Both `mail::` views and the extension `email`/`emails` convention are now covered.

**Reviewers should focus on:**

- That the restore on the message body is correct for both parts — HTML escaped, plain text verbatim — and is a no-op when there are no markers.
- That marking core `mail::` views doesn't double-process values that already go through the formatter (it doesn't — the markers are gone by then, so the message-level restore has nothing to do).

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — extension and core emails leak raw substitution markers; core mail had no injection protection at all.
- [x] If applicable, have various options for solving this problem been considered? — restoring per-template would need every template changed; the message-level restore fixes it once for all.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the mail translator/formatter and the send pipeline are core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no frontend changes.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here. — new tests send real mail and assert the finished message carries no markers, escapes HTML, leaves plain text verbatim, and that a core `mail::` view is protected.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
