### PR TITLE
[2.x] fix: Key the notification email dedup lock on the notification, not its type

### DIFF
--- a/extensions/gdpr/tests/integration/api/ReRequestErasureTest.php
+++ b/extensions/gdpr/tests/integration/api/ReRequestErasureTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\tests\integration\api;
+
+use Flarum\Gdpr\Models\ErasureRequest;
+use Flarum\Notification\Notification;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\RawMessage;
+
+/**
+ * A user may request erasure, change their mind and cancel, then later request
+ * it again. Each request must send its own confirmation email — otherwise the
+ * second request leaves the user waiting for a link that never arrives, with no
+ * way to complete the erasure.
+ */
+class ReRequestErasureTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('flarum-gdpr');
+
+        $this->setting('mail_driver', 'log');
+        $this->setting('forum_title', 'Flarum Test');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Notification::query()->delete();
+        ErasureRequest::query()->delete();
+    }
+
+    /**
+     * Swap in a transport that records every sent message, so confirmation
+     * emails can be counted. Returns the array the captured messages land in.
+     *
+     * @return \ArrayObject<int, RawMessage>
+     */
+    private function captureSentMail(): \ArrayObject
+    {
+        $captured = new \ArrayObject();
+
+        $transport = new class($captured) implements TransportInterface {
+            public function __construct(private \ArrayObject $captured)
+            {
+            }
+
+            public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+            {
+                $this->captured[] = $message;
+
+                return new SentMessage($message, $envelope ?? Envelope::create($message));
+            }
+
+            public function __toString(): string
+            {
+                return 'capture';
+            }
+        };
+
+        $container = $this->app()->getContainer();
+        $container->instance('symfony.mailer.transport', $transport);
+        $container->forgetInstance('mailer');
+
+        return $captured;
+    }
+
+    private function requestErasure(): int
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/user-erasure-requests', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => ['attributes' => []],
+                    'meta' => ['password' => 'too-obscure'],
+                ],
+            ])->withAttribute('bypassCsrfToken', true)
+        );
+
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(201, $response->getStatusCode(), $body);
+
+        return (int) json_decode($body, true)['data']['id'];
+    }
+
+    private function cancelErasure(int $id): void
+    {
+        $response = $this->send(
+            $this->request('POST', "/api/user-erasure-requests/$id/cancel", [
+                'authenticatedAs' => 2,
+            ])->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(204, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    /**
+     * Count the confirmation emails among the captured messages, matched by
+     * their subject so cancellation emails are not counted. The test locale
+     * leaves translation keys untranslated, so the subject is the raw key.
+     */
+    private function confirmationEmailCount(\ArrayObject $captured): int
+    {
+        $count = 0;
+
+        foreach ($captured as $message) {
+            if ($message instanceof Email && $message->getSubject() === 'flarum-gdpr.email.confirm_erasure.subject') {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    #[Test]
+    public function requesting_erasure_sends_a_confirmation_email()
+    {
+        $captured = $this->captureSentMail();
+
+        $this->requestErasure();
+
+        $this->assertEquals(1, $this->confirmationEmailCount($captured), 'The first request must send a confirmation email.');
+    }
+
+    #[Test]
+    public function re_requesting_after_cancelling_sends_a_fresh_confirmation_email()
+    {
+        $captured = $this->captureSentMail();
+
+        $id = $this->requestErasure();
+        $this->assertEquals(1, $this->confirmationEmailCount($captured), 'The first request must send a confirmation email.');
+
+        $this->cancelErasure($id);
+
+        $this->requestErasure();
+
+        // The second request is a new decision by the user and must send its
+        // own confirmation email; a stale, cancelled request must not swallow
+        // it.
+        $this->assertEquals(2, $this->confirmationEmailCount($captured), 'Re-requesting after a cancel must send a second confirmation email.');
+    }
+}

--- a/framework/core/src/Notification/Job/SendEmailNotificationJob.php
+++ b/framework/core/src/Notification/Job/SendEmailNotificationJob.php
@@ -33,9 +33,9 @@ class SendEmailNotificationJob extends AbstractJob
         // fires twice in quick succession (e.g. Posted then Revised), two
         // identical jobs land in the queue for the same recipient, and
         // without a guard each runs and sends an email. Take a short-lived
-        // atomic lock keyed by blueprint+recipient; the first job to claim
-        // it sends the email, the rest no-op. The lock TTL just needs to
-        // outlive normal mail-send latency — minutes is plenty.
+        // atomic lock keyed by the notification's identity and recipient; the
+        // first job to claim it sends the email, the rest no-op. The lock TTL
+        // just needs to outlive normal mail-send latency — minutes is plenty.
         $store = $cache->getStore();
 
         if (! $store instanceof LockProvider) {
@@ -47,20 +47,46 @@ class SendEmailNotificationJob extends AbstractJob
             return;
         }
 
-        $lockKey = sprintf(
-            'flarum.notification.email-sent:%s:%d',
-            $this->blueprint::getType(),
-            $this->recipient->id
-        );
+        // Key the lock on the notification's identity — its subject and data,
+        // not just its type — so that only genuinely duplicate jobs are
+        // suppressed. Keying on type alone silently dropped a legitimate second
+        // notification of the same type to the same user within the TTL (e.g. a
+        // GDPR erasure request made, cancelled, then made again).
+        $lockKey = $this->lockKey();
 
         $lock = $store->lock($lockKey, 600);
 
         if (! $lock->get()) {
             // Another worker has already claimed responsibility for this
-            // (blueprint, recipient) email. Drop silently.
+            // (notification, recipient) email. Drop silently.
             return;
         }
 
         $mailer->send($this->blueprint, $this->recipient);
+    }
+
+    /**
+     * A lock key identifying this exact notification for this recipient. Two
+     * jobs share it only when they represent the same notification — same type,
+     * sender, subject and data — so a repeat of the same event is deduplicated
+     * while a distinct notification of the same type still sends.
+     */
+    private function lockKey(): string
+    {
+        $subject = $this->blueprint->getSubject();
+        $data = $this->blueprint->getData();
+
+        $identity = implode(':', [
+            $this->blueprint::getType(),
+            ($fromUser = $this->blueprint->getFromUser()) ? $fromUser->id : '',
+            $subject ? $subject->getKey() : '',
+            $data === null ? '' : md5(json_encode($data)),
+        ]);
+
+        return sprintf(
+            'flarum.notification.email-sent:%s:%d',
+            md5($identity),
+            $this->recipient->id
+        );
     }
 }

--- a/framework/core/tests/integration/notification/SyncerRaceTest.php
+++ b/framework/core/tests/integration/notification/SyncerRaceTest.php
@@ -129,6 +129,58 @@ class SyncerRaceTest extends TestCase
 
         $this->assertEquals(1, $mailer->sentCount, 'SendEmailNotificationJob is not idempotent — repeated runs sent duplicate emails.');
     }
+
+    #[Test]
+    public function separate_jobs_for_the_same_notification_still_email_once(): void
+    {
+        // The real #4622 race is two *different* blueprint instances of the
+        // same event — Posted builds one, an immediately-following Revised
+        // builds another, both wrapping the same subject with the same data.
+        // They are the same notification and must still be deduplicated to a
+        // single email, even though they are not the same object.
+        $this->app();
+
+        $recipient = User::find(3);
+
+        $mailer = new CountingNotificationMailer();
+        $this->app()->getContainer()->instance(NotificationMailer::class, $mailer);
+
+        $cache = $this->app()->getContainer()->make(\Illuminate\Contracts\Cache\Repository::class);
+
+        $posted = new TestBlueprintMailable(['post' => 1]);
+        $revised = new TestBlueprintMailable(['post' => 1]);
+
+        (new SendEmailNotificationJob($posted, $recipient))->handle($mailer, $cache);
+        (new SendEmailNotificationJob($revised, $recipient))->handle($mailer, $cache);
+
+        $this->assertEquals(1, $mailer->sentCount, 'Two jobs for the same notification sent duplicate emails.');
+    }
+
+    #[Test]
+    public function distinct_notifications_of_the_same_type_both_email_the_recipient(): void
+    {
+        // The idempotence guard must not swallow a genuinely different
+        // notification that happens to share a type and recipient with a recent
+        // one — e.g. a GDPR erasure request made, cancelled, then made again
+        // within the lock's lifetime. Each carries its own data, so each must
+        // send its own email.
+        $this->app();
+
+        $recipient = User::find(3);
+
+        $mailer = new CountingNotificationMailer();
+        $this->app()->getContainer()->instance(NotificationMailer::class, $mailer);
+
+        $cache = $this->app()->getContainer()->make(\Illuminate\Contracts\Cache\Repository::class);
+
+        $first = new TestBlueprintMailable(['request' => 1]);
+        $second = new TestBlueprintMailable(['request' => 2]);
+
+        (new SendEmailNotificationJob($first, $recipient))->handle($mailer, $cache);
+        (new SendEmailNotificationJob($second, $recipient))->handle($mailer, $cache);
+
+        $this->assertEquals(2, $mailer->sentCount, 'A distinct notification of the same type was suppressed.');
+    }
 }
 
 class TestBlueprint implements BlueprintInterface, AlertableInterface
@@ -161,6 +213,15 @@ class TestBlueprint implements BlueprintInterface, AlertableInterface
 
 class TestBlueprintMailable extends TestBlueprint implements MailableInterface
 {
+    public function __construct(private ?array $data = null)
+    {
+    }
+
+    public function getData(): ?array
+    {
+        return $this->data;
+    }
+
     public static function getType(): string
     {
         return 'syncerRaceTestMailable';


### PR DESCRIPTION
**Changes proposed in this pull request:**

`NotificationSyncer::sync()` queues a `SendEmailNotificationJob` per recipient on every call, so when `sync()` fires twice in quick succession for the same notification (Posted then Revised, say) two identical jobs land in the queue for the same recipient. `SendEmailNotificationJob` guards against that with a short-lived atomic lock — the first job sends, the rest no-op.

That lock was keyed on the notification's **type** and recipient alone. So a genuinely *different* notification of the same type to the same user, within the lock's 600s lifetime, was also dropped. The clearest case: a user requests account erasure, cancels it, then requests again — the second request reuses `gdpr_erasure_confirm` for the same user, hits the still-held lock, and its confirmation email is silently discarded. The user is left waiting for a link that never arrives, with no way to complete the request.

This keys the lock on the notification's **identity** — type, sender, subject and data, the same attributes `Notification::matchingBlueprint()` uses to decide whether two blueprints are the same notification:

- Two jobs for the *same* notification (the race the guard exists for) still share a key and still dedupe to one email.
- Two *distinct* notifications of the same type — a re-request, a second mention, anything carrying different subject/data — now get distinct keys and each sends.

This also brings the email guard into line with the notification-row guard: `SendNotificationsJob` already dedupes on `matchingBlueprint` identity, so the row and the email now agree on what counts as the same notification, rather than the email half being coarser.

**Reviewers should focus on:**

- That the identity key still collapses the original race — two jobs built from the same event (same subject, same data) send once. There's a test pinning exactly this with two separate blueprint instances.
- That the identity is derived the same way `matchingBlueprint` derives it, so the email guard and the row guard can't disagree.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — a legitimate second notification of the same type to a user was being silently dropped for 600s.
- [x] If applicable, have various options for solving this problem been considered? — the fix reuses the existing blueprint-identity notion rather than inventing a new discriminator.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the dedup lock lives in core's `SendEmailNotificationJob`.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no frontend changes.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here. — a core test that two distinct notifications of one type both email; one that two separate jobs for the same notification still email once; and a gdpr test covering request, cancel, re-request.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — the lock is a cache lock; no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
