### PR TITLE
[2.x] fix: Build the text formatter during cache:clear, not on the next request

### DIFF
--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -140,6 +140,23 @@ class Formatter
         $this->cache->forget('flarum.formatter');
     }
 
+    /**
+     * Build and cache the formatter now, rather than leaving it to the first
+     * post that needs rendering.
+     *
+     * Compiling the renderer can be expensive on a forum with many extensions,
+     * and it happens lazily inside whichever request first renders a post after
+     * the cache was cleared. On a tight web memory limit that request can hit a
+     * fatal and fail silently. Warming here — from `cache:clear`, where the
+     * limit is usually higher — keeps that cost out of the render path.
+     */
+    public function warm(): void
+    {
+        // Resolving any component finalizes the configurator, which compiles
+        // and caches every component at once.
+        $this->getComponent('renderer');
+    }
+
     protected function getConfigurator(): Configurator
     {
         $configurator = new Configurator;

--- a/framework/core/src/Foundation/Console/CacheClearCommand.php
+++ b/framework/core/src/Foundation/Console/CacheClearCommand.php
@@ -12,6 +12,7 @@ namespace Flarum\Foundation\Console;
 use Flarum\Console\AbstractCommand;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
+use Flarum\Formatter\Formatter;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Console\Command\Command;
@@ -21,7 +22,8 @@ class CacheClearCommand extends AbstractCommand
     public function __construct(
         protected Store $cache,
         protected Dispatcher $events,
-        protected Paths $paths
+        protected Paths $paths,
+        protected Formatter $formatter
     ) {
         parent::__construct();
     }
@@ -51,6 +53,17 @@ class CacheClearCommand extends AbstractCommand
         array_map('unlink', glob($storagePath.'/views/*'));
 
         $this->events->dispatch(new ClearingCache);
+
+        // Rebuild the formatter now, while we're here and the memory limit is
+        // usually generous, rather than leaving the (sometimes heavy) compile
+        // to whichever request next renders a post. Best-effort: a failure to
+        // warm must not fail the clear itself — the cache is already cleared,
+        // and the render path will rebuild lazily as before.
+        try {
+            $this->formatter->warm();
+        } catch (\Throwable $e) {
+            $this->error('Cache cleared, but the formatter could not be pre-built: '.$e->getMessage());
+        }
 
         return Command::SUCCESS;
     }

--- a/framework/core/src/Foundation/Console/CacheClearCommand.php
+++ b/framework/core/src/Foundation/Console/CacheClearCommand.php
@@ -10,9 +10,9 @@
 namespace Flarum\Foundation\Console;
 
 use Flarum\Console\AbstractCommand;
+use Flarum\Formatter\Formatter;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
-use Flarum\Formatter\Formatter;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Console\Command\Command;

--- a/framework/core/tests/integration/console/CacheClearCommandTest.php
+++ b/framework/core/tests/integration/console/CacheClearCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\console;
+
+use Flarum\Formatter\Formatter;
+use Flarum\Testing\integration\ConsoleTestCase;
+use Illuminate\Contracts\Cache\Repository;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CacheClearCommandTest extends ConsoleTestCase
+{
+    /**
+     * @return array{output: string, status: int}
+     */
+    private function runCacheClear(): array
+    {
+        $output = new BufferedOutput();
+        $status = $this->console()->run(new ArrayInput(['command' => 'cache:clear']), $output);
+
+        return ['output' => trim($output->fetch()), 'status' => $status];
+    }
+
+    #[Test]
+    public function it_succeeds()
+    {
+        $result = $this->runCacheClear();
+
+        $this->assertEquals(Command::SUCCESS, $result['status'], $result['output']);
+    }
+
+    #[Test]
+    public function it_leaves_the_formatter_warm()
+    {
+        /** @var Repository $cache */
+        $cache = $this->app()->getContainer()->make(Repository::class);
+
+        // Force the formatter cache cold, the state a clear would otherwise
+        // leave the render path in.
+        $this->app()->getContainer()->make(Formatter::class)->flush();
+        $this->assertFalse($cache->has('flarum.formatter'), 'Precondition: the formatter cache should be cold.');
+
+        $this->runCacheClear();
+
+        // The command rebuilds the formatter itself, so the next render doesn't
+        // have to — keeping the compile off the (memory-tight) web request that
+        // would otherwise trigger it.
+        $this->assertTrue($cache->has('flarum.formatter'), 'cache:clear should leave the formatter cache warm.');
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**

`cache:clear` deletes the compiled text formatter, so the next request that renders a post rebuilds it. `Formatter::getComponent()` compiles the renderer lazily inside `rememberForever('flarum.formatter', …)`, which only runs when the cache is cold — i.e. inside whichever request first renders after the clear.

On a forum with many extensions that compiled renderer is large (a real report: ~174 KB, with the cold build peaking over a 256 MB web `memory_limit` and taking ~30s). When it runs in a web request whose SAPI memory limit is tighter than the CLI's, it can hit a PHP memory fatal — which is not an exception (Flarum's error handler never sees it) and not a kernel OOM (nothing in `dmesg`), so the visitor gets a blank HTTP 500 and nothing is logged. Clearing the cache from the admin panel is the common trigger, and the failure lands on the *next* visitor, not the admin who cleared it.

This rebuilds the formatter at the end of `cache:clear`, where the memory limit is usually generous, so the render path finds it already cached:

- New `Formatter::warm()` compiles and caches the formatter on demand.
- `CacheClearCommand` calls it after clearing, best-effort: wrapped in `try`/`catch` so a warm-build failure never fails the clear itself — the cache is already cleared and the render path rebuilds lazily as before. This only ever removes a failure mode, never adds one.
- The admin-panel clear runs the same command; it warms in the admin's own request, so if a build is going to fail on tight memory it fails there (visible to the admin) rather than silently on the next visitor. Large forums that clear via the CLI get the build entirely off the web SAPI.

**Reviewers should focus on:**

- That `warm()` failing can't fail the clear — `cache:clear` still returns success and the formatter still rebuilds lazily.
- That warming is a plain rebuild of the same cache the render path reads, not a second/parallel cache.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — a cache clear can silently 500 a forum when the cold formatter build outgrows the web memory limit.
- [x] If applicable, have various options for solving this problem been considered? — building off the web request removes the failure mode regardless of extension count or memory tuning; a docs-only note would leave the silent failure in place.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the formatter and `cache:clear` are core.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no frontend changes.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here. — a test asserting `cache:clear` leaves the formatter cache warm, and that it still succeeds.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
