### PR TITLE
[2.x] fix: Detect the web memory limit from Debian/Ubuntu's FPM conf.d

### DIFF
--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -225,15 +225,15 @@ class InfoCommand extends AbstractCommand
     }
 
     /**
-     * Try to detect the web server's PHP memory limit.
-     * This is a best-effort attempt and may not work in all environments.
+     * Files that may declare the web SAPI's `memory_limit`, in priority order.
+     *
+     * @return string[]
      */
-    private function detectWebServerMemoryLimit(): ?string
+    protected function webServerMemoryLimitFiles(): array
     {
-        // Try to detect PHP-FPM pool configuration
         $phpVersion = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
 
-        $possiblePaths = [
+        return [
             // Docker PHP paths (most common for containerized setups)
             '/usr/local/etc/php/php.ini',
             '/usr/local/etc/php/conf.d/memory.ini',
@@ -247,8 +247,32 @@ class InfoCommand extends AbstractCommand
             "/etc/php{$phpVersion}/fpm/php.ini",
             '/etc/php.ini',
         ];
+    }
 
-        foreach ($possiblePaths as $path) {
+    /**
+     * conf.d directories whose INI files may override the web SAPI's
+     * `memory_limit`.
+     *
+     * @return string[]
+     */
+    protected function webServerMemoryLimitConfDirs(): array
+    {
+        $phpVersion = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
+
+        return [
+            '/usr/local/etc/php/conf.d',
+            "/etc/php/{$phpVersion}/fpm/conf.d",
+            "/etc/php{$phpVersion}/fpm/conf.d",
+        ];
+    }
+
+    /**
+     * Try to detect the web server's PHP memory limit.
+     * This is a best-effort attempt and may not work in all environments.
+     */
+    protected function detectWebServerMemoryLimit(): ?string
+    {
+        foreach ($this->webServerMemoryLimitFiles() as $path) {
             if (file_exists($path) && is_readable($path)) {
                 $content = file_get_contents($path);
 
@@ -264,19 +288,37 @@ class InfoCommand extends AbstractCommand
             }
         }
 
-        // Also scan /usr/local/etc/php/conf.d/ directory for any INI files with memory_limit
-        $confDir = '/usr/local/etc/php/conf.d';
-        if (is_dir($confDir) && is_readable($confDir)) {
+        // Also scan the conf.d directories for any INI file that sets
+        // memory_limit. Debian and Ubuntu put per-SAPI overrides under
+        // /etc/php/{version}/fpm/conf.d/, which none of the paths above cover —
+        // so without this the base php.ini value is reported and every override
+        // there is missed.
+        foreach ($this->webServerMemoryLimitConfDirs() as $confDir) {
+            if (! is_dir($confDir) || ! is_readable($confDir)) {
+                continue;
+            }
+
             $iniFiles = glob($confDir.'/*.ini');
-            if ($iniFiles) {
-                foreach ($iniFiles as $iniFile) {
-                    if (is_readable($iniFile)) {
-                        $content = file_get_contents($iniFile);
-                        if (preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
-                            return trim($matches[1]);
-                        }
+
+            if (! $iniFiles) {
+                continue;
+            }
+
+            // Later files win, mirroring how PHP loads conf.d in name order, so
+            // keep the last match rather than returning the first.
+            $found = null;
+
+            foreach ($iniFiles as $iniFile) {
+                if (is_readable($iniFile)) {
+                    $content = file_get_contents($iniFile);
+                    if (preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
+                        $found = trim($matches[1]);
                     }
                 }
+            }
+
+            if ($found !== null) {
+                return $found;
             }
         }
 

--- a/framework/core/tests/integration/console/InfoCommandMemoryLimitTest.php
+++ b/framework/core/tests/integration/console/InfoCommandMemoryLimitTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\console;
+
+use Flarum\Foundation\Console\InfoCommand;
+use Flarum\Testing\integration\ConsoleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class InfoCommandMemoryLimitTest extends ConsoleTestCase
+{
+    private string $confDir;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->confDir = sys_get_temp_dir().'/flarum-info-confd-'.uniqid();
+        mkdir($this->confDir, 0777, true);
+    }
+
+    public function tearDown(): void
+    {
+        array_map('unlink', glob($this->confDir.'/*'));
+        @rmdir($this->confDir);
+
+        parent::tearDown();
+    }
+
+    /**
+     * A command that detects its memory limit from the given fixture
+     * directories rather than the real system paths.
+     */
+    private function commandReading(array $files, array $confDirs): InfoCommand
+    {
+        $container = $this->app()->getContainer();
+
+        return new class($container, $files, $confDirs) extends InfoCommand {
+            public function __construct($container, private array $files, private array $confDirs)
+            {
+                parent::__construct(
+                    $container->make(\Flarum\Extension\ExtensionManager::class),
+                    $container->make(\Flarum\Foundation\Config::class),
+                    $container->make(\Flarum\Settings\SettingsRepositoryInterface::class),
+                    $container->make(\Illuminate\Database\ConnectionInterface::class),
+                    $container->make(\Flarum\Foundation\ApplicationInfoProvider::class),
+                );
+            }
+
+            protected function webServerMemoryLimitFiles(): array
+            {
+                return $this->files;
+            }
+
+            protected function webServerMemoryLimitConfDirs(): array
+            {
+                return $this->confDirs;
+            }
+
+            public function detect(): ?string
+            {
+                return $this->detectWebServerMemoryLimit();
+            }
+        };
+    }
+
+    #[Test]
+    public function it_reads_a_memory_limit_from_a_confd_override()
+    {
+        // The case this fixes: distros keep the base php.ini limit low and set
+        // the real one in a conf.d file, which the fixed-path list never covers.
+        file_put_contents($this->confDir.'/99-overrides.ini', "memory_limit = 512M\n");
+
+        $command = $this->commandReading([], [$this->confDir]);
+
+        $this->assertEquals('512M', $command->detect());
+    }
+
+    #[Test]
+    public function a_later_confd_file_overrides_an_earlier_one()
+    {
+        // conf.d files load in name order, so a later file's value wins.
+        file_put_contents($this->confDir.'/10-base.ini', "memory_limit = 256M\n");
+        file_put_contents($this->confDir.'/99-overrides.ini', "memory_limit = 512M\n");
+
+        $command = $this->commandReading([], [$this->confDir]);
+
+        $this->assertEquals('512M', $command->detect());
+    }
+
+    #[Test]
+    public function a_direct_file_is_preferred_over_confd()
+    {
+        // A memory_limit found in the file list is returned before the conf.d
+        // scan runs at all.
+        $file = $this->confDir.'/php.ini';
+        file_put_contents($file, "memory_limit = 1G\n");
+        file_put_contents($this->confDir.'/99-overrides.ini', "memory_limit = 512M\n");
+
+        $command = $this->commandReading([$file], [$this->confDir]);
+
+        $this->assertEquals('1G', $command->detect());
+    }
+
+    #[Test]
+    public function it_returns_null_when_nothing_declares_a_limit()
+    {
+        $command = $this->commandReading([], [$this->confDir]);
+
+        $this->assertNull($command->detect());
+    }
+
+    #[Test]
+    public function the_default_confd_list_covers_the_debian_ubuntu_fpm_path()
+    {
+        // The bug this fixes: Debian and Ubuntu put memory_limit overrides in
+        // /etc/php/{version}/fpm/conf.d/, which the detection never scanned, so
+        // it reported the base php.ini value. Pin that this path is covered.
+        $phpVersion = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
+
+        $container = $this->app()->getContainer();
+        $command = new class($container) extends InfoCommand {
+            public function __construct($container)
+            {
+                parent::__construct(
+                    $container->make(\Flarum\Extension\ExtensionManager::class),
+                    $container->make(\Flarum\Foundation\Config::class),
+                    $container->make(\Flarum\Settings\SettingsRepositoryInterface::class),
+                    $container->make(\Illuminate\Database\ConnectionInterface::class),
+                    $container->make(\Flarum\Foundation\ApplicationInfoProvider::class),
+                );
+            }
+
+            public function confDirs(): array
+            {
+                return $this->webServerMemoryLimitConfDirs();
+            }
+        };
+
+        $this->assertContains("/etc/php/{$phpVersion}/fpm/conf.d", $command->confDirs());
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**

`flarum info` reports the web SAPI's `memory_limit` by scanning a fixed list of config files and one hard-coded conf.d directory (`/usr/local/etc/php/conf.d`, the Docker layout). On Debian and Ubuntu the effective value is usually set in `/etc/php/{version}/fpm/conf.d/` — which nothing in the list covered — so the detection fell through to the base `php.ini` value and reported a figure well below the real one (a report in the wild: "Web: 128M" shown against a real 512M).

That output is exactly what people paste into support threads, so a wrong figure actively misleads diagnosis.

- The conf.d scan now covers the Debian/Ubuntu FPM directories (`/etc/php/{version}/fpm/conf.d` and the `/etc/php{version}/...` variant) alongside the Docker one.
- Within a conf.d directory the last matching file wins, mirroring how PHP loads conf.d in name order (a later `99-*.ini` overrides an earlier `10-*.ini`), rather than returning the first match found.
- The file list and the conf.d list are now their own `protected` methods, so the detection can be tested against fixture directories instead of the real system paths.

This is a display-only diagnostic; it changes nothing about how Flarum runs.

**Reviewers should focus on:**

- That the default conf.d list includes the Debian/Ubuntu FPM path — there's a test pinning exactly that, since it's the bug.
- That "last match wins" within a directory is the right ordering for conf.d.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — `flarum info` misreports the web memory limit on the most common distro layout.
- [x] If applicable, have various options for solving this problem been considered? — scanning the distro conf.d is the direct fix; parsing `php-fpm -i` output would be heavier and not always available.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — `flarum info` is a core command.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no frontend changes.
- [ ] Frontend changes: tests are green — n/a.
- [ ] Frontend changes: tests have been added — n/a.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here. — tests cover reading a limit from a conf.d override, later-file precedence, direct-file precedence over conf.d, the empty case, and that the default list covers the Debian/Ubuntu FPM path.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
