### PR TITLE
[2.x] fix: Open the discussion controls in one tap on touch tablets

### DIFF
--- a/framework/core/less/forum/DiscussionListItem.less
+++ b/framework/core/less/forum/DiscussionListItem.less
@@ -161,6 +161,22 @@
   .DiscussionListItem-controls > .Dropdown-toggle {
     display: none;
   }
+
+  // On a touch device wide enough to get the tablet-up layout (an iPad, say),
+  // the controls are otherwise revealed only on `:hover` — which a touch
+  // screen has no real equivalent for. Safari fakes it with a "priming tap"
+  // that reveals the controls and swallows the tap, so the ⋮ menu needs two
+  // taps to open. Keep the controls and their toggle shown here, so one tap
+  // opens the dropdown.
+  @media @tablet-up {
+    .DiscussionListItem-controls {
+      opacity: 1;
+
+      > .Dropdown-toggle {
+        display: block;
+      }
+    }
+  }
 }
 
 @media @phone {


### PR DESCRIPTION
**Changes proposed in this pull request:**

On a touch device wide enough to get the tablet-up layout — an iPad — the per-discussion controls (the `⋮` dropdown) are hidden with `opacity: 0` and revealed only on `:hover`. A touch screen has no real hover, so iOS Safari fakes one with a "priming tap": the first tap on the control applies the hover state (revealing it) and is swallowed, and only the second tap actually opens the dropdown. The result is that the `⋮` menu needs two taps on iPad, but only when logged in (guests have no controls to reveal). It reproduces on discuss.flarum.org.

This shows the controls and their toggle for touch devices at tablet-up widths, inside the existing `@media (any-hover: none)` block, so a single tap opens the dropdown. Pointer devices keep the hover-to-reveal behaviour exactly as before — the change is scoped to `(any-hover: none) and (min-width: <tablet>)`.

Fixes #39568.

**Reviewers should focus on:**

- That pointer/desktop behaviour is untouched — the reveal-on-hover still applies there, and the new rule only takes effect under `any-hover: none`.
- That showing the controls always on touch tablets reads acceptably (they sit top-right of each row, as they do on hover elsewhere).

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — the discussion `⋮` menu needs two taps on iPad because it's gated behind `:hover`.
- [x] If applicable, have various options for solving this problem been considered? — gating on `any-hover: none` is the standard way to separate touch from hover; a JS tap handler would be heavier for a purely presentational issue.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — it's core's discussion-list styling.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — LESS compiles cleanly to `@media (any-hover: none) and (min-width: …)` via the runtime compiler; behavioural confirmation on a physical iPad is still worth a look (see below).
- [ ] Frontend changes: tests are green — n/a (CSS-only).
- [ ] Frontend changes: tests have been added — not applicable to a presentational media-query change.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added, or are not appropriate here — n/a.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
