### PR TITLE
[2.x] fix: Stop a realtime update duplicating a discussion in the list

### DIFF
--- a/framework/core/js/src/forum/states/DiscussionListState.ts
+++ b/framework/core/js/src/forum/states/DiscussionListState.ts
@@ -86,8 +86,16 @@ export default class DiscussionListState<P extends DiscussionListParams = Discus
   }
 
   deleteDiscussion(discussion: Discussion): void {
+    // Match by id, not by object reference: realtime hands us a discussion
+    // resolved through the store, which is a fresh instance whenever the store
+    // no longer holds the one already on screen. A reference check would miss
+    // that copy and leave the discussion showing twice.
+    const id = discussion.id();
+
+    if (id == null) return;
+
     for (const page of this.pages) {
-      const index = page.items.indexOf(discussion);
+      const index = page.items.findIndex((d) => d.id() === id);
 
       if (index !== -1) {
         page.items.splice(index, 1);
@@ -95,10 +103,10 @@ export default class DiscussionListState<P extends DiscussionListParams = Discus
       }
     }
 
-    const index = this.extraDiscussions.indexOf(discussion);
+    const index = this.extraDiscussions.findIndex((d) => d.id() === id);
 
     if (index !== -1) {
-      this.extraDiscussions.splice(index);
+      this.extraDiscussions.splice(index, 1);
     }
 
     m.redraw();

--- a/framework/core/js/tests/unit/forum/states/DiscussionListState.dedup.test.ts
+++ b/framework/core/js/tests/unit/forum/states/DiscussionListState.dedup.test.ts
@@ -1,0 +1,113 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from 'flarum/forum/app';
+import DiscussionListState from '../../../../src/forum/states/DiscussionListState';
+import Discussion from '../../../../src/common/models/Discussion';
+import { makeDiscussion } from '../../../factory';
+
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+});
+
+beforeEach(() => {
+  app.store.data = {};
+});
+
+/**
+ * Adding and removing discussions from the list must identify a discussion by
+ * its id, not by object reference. Realtime hands the list a discussion it got
+ * from `app.store.pushPayload`, which returns a fresh model instance whenever
+ * the store no longer holds that discussion — so a reference-based check misses
+ * the copy already on screen and the discussion shows twice until a refresh.
+ * (Reported against rc.7.)
+ */
+describe('DiscussionListState de-duplicates by discussion id', () => {
+  function seedListWith(discussion: Discussion): DiscussionListState {
+    const state = new DiscussionListState({});
+    // Stand in for an initial page load holding this discussion.
+    (state as any).pages = [{ number: 0, items: [discussion] }];
+    return state;
+  }
+
+  function idsInList(state: DiscussionListState): string[] {
+    return state
+      .getPages()
+      .flatMap((page) => page.items as Discussion[])
+      .map((d) => d.id()!);
+  }
+
+  describe('with realtime (addDiscussion)', () => {
+    test('re-adding the same instance does not duplicate', () => {
+      const a = app.store.pushObject<Discussion>(makeDiscussion({ id: '1' }))!;
+      const state = seedListWith(a);
+
+      // The store still holds it, so realtime would hand back the same object.
+      state.addDiscussion(a);
+
+      expect(idsInList(state).filter((id) => id === '1')).toHaveLength(1);
+    });
+
+    test('re-adding a fresh instance of the same discussion does not duplicate', () => {
+      const a = app.store.pushObject<Discussion>(makeDiscussion({ id: '1' }))!;
+      const state = seedListWith(a);
+
+      // The store no longer holds it (evicted / scrolled out), so a realtime
+      // event builds a brand-new instance for the same id.
+      app.store.data = {};
+      const b = app.store.pushObject<Discussion>(makeDiscussion({ id: '1' }))!;
+
+      expect(b).not.toBe(a);
+
+      state.addDiscussion(b);
+
+      expect(idsInList(state).filter((id) => id === '1')).toHaveLength(1);
+    });
+
+    test('the re-added discussion moves to the top', () => {
+      const a = app.store.pushObject<Discussion>(makeDiscussion({ id: '1' }))!;
+      const other = app.store.pushObject<Discussion>(makeDiscussion({ id: '2' }))!;
+      const state = new DiscussionListState({});
+      (state as any).pages = [{ number: 0, items: [other, a] }];
+
+      app.store.data = {};
+      const fresh = app.store.pushObject<Discussion>(makeDiscussion({ id: '1' }))!;
+      state.addDiscussion(fresh);
+
+      // Once, and now first.
+      expect(idsInList(state).filter((id) => id === '1')).toHaveLength(1);
+      expect(idsInList(state)[0]).toBe('1');
+    });
+  });
+
+  describe('without realtime (deletion flows call removeDiscussion)', () => {
+    test('removing a discussion drops it from the page', () => {
+      const a = app.store.pushObject<Discussion>(makeDiscussion({ id: '1' }))!;
+      const b = app.store.pushObject<Discussion>(makeDiscussion({ id: '2' }))!;
+      const state = new DiscussionListState({});
+      (state as any).pages = [{ number: 0, items: [a, b] }];
+
+      // How PostControls / DiscussionControls remove a deleted discussion — the
+      // canonical list instance, no realtime involved.
+      state.removeDiscussion(a);
+
+      expect(idsInList(state)).toEqual(['2']);
+    });
+
+    test('removing one extra discussion leaves the others after it in place', () => {
+      // Guards the splice(index) -> splice(index, 1) fix: removing an item must
+      // not take everything after it in the list with it.
+      const a = app.store.pushObject<Discussion>(makeDiscussion({ id: '1' }))!;
+      const b = app.store.pushObject<Discussion>(makeDiscussion({ id: '2' }))!;
+      const c = app.store.pushObject<Discussion>(makeDiscussion({ id: '3' }))!;
+      const state = new DiscussionListState({});
+      // All three sitting in extraDiscussions, as realtime pushes accumulate.
+      state.addDiscussion(c);
+      state.addDiscussion(b);
+      state.addDiscussion(a); // order is now [1, 2, 3]
+
+      state.removeDiscussion(b);
+
+      expect(idsInList(state)).toEqual(['1', '3']);
+    });
+  });
+});


### PR DESCRIPTION
**Changes proposed in this pull request:**

`DiscussionListState` adds and removes discussions by matching on the model instance (`indexOf`). Realtime hands the list a discussion resolved through `app.store.pushPayload`, and the store returns a **fresh** instance whenever it no longer holds the one already on screen — a discussion that has scrolled out of the loaded pages, for instance. The reference match then fails to find the copy in the list, so `addDiscussion` adds the discussion a second time, and it shows twice until the page is refreshed. (Reported against rc.7: "left the tab idle, came back to a duplicate discussion; refreshing fixes it.")

- `deleteDiscussion` now matches by `discussion.id()` rather than object reference, so a fresh instance of a discussion already listed replaces it instead of duplicating it.
- It also fixes `this.extraDiscussions.splice(index)` — missing its length argument, it removed the matched item *and everything after it* — to `splice(index, 1)`.
- A `null` id is guarded, so an unsaved discussion (should one ever reach the list) can't match another by `null === null`.

**A note on forums without realtime:** `addDiscussion` has no caller in core or any bundled extension — only realtime adds discussions to the list this way — so a non-realtime forum never hits the duplicate path at all. Its only route through this code is discussion deletion (`PostControls`, `DiscussionControls`), which passes the canonical list instance; there the id match and the old reference match are equivalent, so behaviour is unchanged.

**Reviewers should focus on:**

- That matching by id is safe here — the list only ever holds saved discussions (pages come from the API; `extraDiscussions` only ever receives store-resolved discussions), so ids are present and unique.
- That the `splice(index)` → `splice(index, 1)` change is correct — the old form was removing a tail of the pending list.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — a realtime update can show a discussion twice until refresh.
- [x] If applicable, have various options for solving this problem been considered? — matching by id reuses the identity the store already keys on; tracking instances some other way would be heavier and no more correct.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the list state lives in core; realtime and other extensions build on it.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — reproduced the duplicate and its fix in a unit test (a fresh store instance of a listed discussion); the realtime path drives exactly this.
- [x] Frontend changes: tests are green.
- [x] Frontend changes: tests have been added. — covers, with realtime, re-adding the same and a fresh instance (no duplicate) and that the re-add moves to the top; and, without realtime, that removal drops the discussion and doesn't take the rest of the list with it.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added, or are not appropriate here — n/a.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
