### PR TITLE
fix: return a validation error when an image upload arrives without a file

### DIFF
--- a/framework/core/js/src/forum/components/AvatarEditor.js
+++ b/framework/core/js/src/forum/components/AvatarEditor.js
@@ -157,7 +157,7 @@ export default class AvatarEditor extends Component {
       .appendTo('body')
       .hide()
       .click()
-      .on('input', (e) => {
+      .on('input change', (e) => {
         this.upload($(e.target)[0].files[0]);
       });
   }
@@ -168,7 +168,7 @@ export default class AvatarEditor extends Component {
    * @param {File} file
    */
   upload(file) {
-    if (this.loading) return;
+    if (this.loading || !(file instanceof Blob)) return;
 
     const user = this.attrs.user;
     const data = new FormData();

--- a/framework/core/js/tests/unit/forum/components/AvatarEditor.test.ts
+++ b/framework/core/js/tests/unit/forum/components/AvatarEditor.test.ts
@@ -1,0 +1,41 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import AvatarEditor from '../../../../src/forum/components/AvatarEditor';
+
+beforeAll(() => bootstrapForum());
+
+describe('AvatarEditor upload body', () => {
+  function capture(file: any): FormData {
+    let captured: FormData | undefined;
+
+    // @ts-ignore - minimal stub of the pieces upload() touches
+    global.app.forum = { attribute: () => 'https://example.com/api' };
+    // @ts-ignore
+    global.app.request = (options: any) => {
+      captured = options.body;
+      return new Promise(() => {}); // never settles: we only care about the outgoing body
+    };
+
+    const editor = Object.create(AvatarEditor.prototype);
+    editor.attrs = { user: { id: () => 2 } };
+    editor.loading = false;
+
+    editor.upload(file);
+
+    return captured!;
+  }
+
+  test('a real File produces a file part', () => {
+    const file = new File(['x'], 'avatar.png', { type: 'image/png' });
+
+    const entry = capture(file).get('avatar');
+
+    expect(entry).toBeInstanceOf(File);
+  });
+
+  test('undefined produces a text field, not a file part', () => {
+    const entry = capture(undefined).get('avatar');
+
+    expect(entry).not.toBeInstanceOf(File);
+    expect(entry).toBe('undefined');
+  });
+});

--- a/framework/core/js/tests/unit/forum/components/AvatarEditor.test.ts
+++ b/framework/core/js/tests/unit/forum/components/AvatarEditor.test.ts
@@ -4,7 +4,7 @@ import AvatarEditor from '../../../../src/forum/components/AvatarEditor';
 beforeAll(() => bootstrapForum());
 
 describe('AvatarEditor upload body', () => {
-  function capture(file: any): FormData {
+  function capture(file: any): FormData | undefined {
     let captured: FormData | undefined;
 
     // @ts-ignore - minimal stub of the pieces upload() touches
@@ -21,7 +21,7 @@ describe('AvatarEditor upload body', () => {
 
     editor.upload(file);
 
-    return captured!;
+    return captured;
   }
 
   test('a real File produces a file part', () => {
@@ -32,10 +32,10 @@ describe('AvatarEditor upload body', () => {
     expect(entry).toBeInstanceOf(File);
   });
 
-  test('undefined produces a text field, not a file part', () => {
-    const entry = capture(undefined).get('avatar');
-
-    expect(entry).not.toBeInstanceOf(File);
-    expect(entry).toBe('undefined');
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+  ])('%s sends no request at all', (_label, value) => {
+    expect(capture(value)).toBeUndefined();
   });
 });

--- a/framework/core/src/Api/Controller/UploadImageController.php
+++ b/framework/core/src/Api/Controller/UploadImageController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Api\JsonApi;
+use Flarum\Foundation\ValidationException;
 use Flarum\Http\RequestUtil;
 use Flarum\Locale\TranslatorInterface;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -53,6 +54,12 @@ abstract class UploadImageController extends ShowForumController
         $filenamePrefix = $this->filenamePrefix($request);
 
         $file = Arr::get($request->getUploadedFiles(), $filenamePrefix);
+
+        if (! $file instanceof UploadedFileInterface) {
+            throw new ValidationException([
+                $filenamePrefix => str_replace(':attribute', $filenamePrefix, $this->translator->trans('validation.required')),
+            ]);
+        }
 
         if ($this->validator) {
             $this->container->make($this->validator)->assertImageValid(

--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -36,6 +36,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Intervention\Image\ImageManager;
 use InvalidArgumentException;
+use Psr\Http\Message\UploadedFileInterface;
 
 /**
  * @extends AbstractDatabaseResource<User>
@@ -129,6 +130,12 @@ class UserResource extends AbstractDatabaseResource
                 ->route('POST', '/{id}/avatar')
                 ->action(function (Context $context) {
                     $file = Arr::get($context->request->getUploadedFiles(), 'avatar');
+
+                    if (! $file instanceof UploadedFileInterface) {
+                        throw new ValidationException([
+                            'avatar' => str_replace(':attribute', 'avatar', $this->translator->trans('validation.required')),
+                        ]);
+                    }
 
                     return $this->bus->dispatch(
                         new UploadAvatar((int) $context->modelId, $file, $context->getActor())

--- a/framework/core/tests/integration/api/AdminImageUploadMissingFileTest.php
+++ b/framework/core/tests/integration/api/AdminImageUploadMissingFileTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class AdminImageUploadMissingFileTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    public static function endpoints(): array
+    {
+        return [
+            ['/api/logo', 'logo'],
+            ['/api/favicon', 'favicon'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('endpoints')]
+    public function text_field_instead_of_file_part(string $path, string $prefix): void
+    {
+        $request = $this->request('POST', $path, ['authenticatedAs' => 1])
+            ->withUploadedFiles([])
+            ->withParsedBody([$prefix => 'undefined'])
+            ->withHeader('content-type', 'multipart/form-data; boundary=----WebKitFormBoundaryTEST');
+
+        $response = $this->send($request);
+
+        $this->assertEquals(422, $response->getStatusCode(), (string) $response->getBody());
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertEquals('validation_error', $body['errors'][0]['code'] ?? null);
+        $this->assertNotEmpty($body['errors'][0]['detail'] ?? null);
+    }
+}

--- a/framework/core/tests/integration/api/users/AvatarUploadMissingFileTest.php
+++ b/framework/core/tests/integration/api/users/AvatarUploadMissingFileTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class AvatarUploadMissingFileTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * Reproduces the production condition: the client posted a well-formed
+     * multipart body in which "avatar" is a plain text field rather than a file
+     * part, so PHP populates $_POST but leaves $_FILES empty.
+     */
+    #[Test]
+    public function text_field_instead_of_file_part(): void
+    {
+        $request = $this->request('POST', '/api/users/2/avatar', ['authenticatedAs' => 2])
+            ->withUploadedFiles([])
+            ->withParsedBody(['avatar' => 'undefined'])
+            ->withHeader('content-type', 'multipart/form-data; boundary=----WebKitFormBoundaryTEST');
+
+        $response = $this->send($request);
+
+        $this->assertEquals(422, $response->getStatusCode(), (string) $response->getBody());
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertEquals('/data/attributes/avatar', $body['errors'][0]['source']['pointer'] ?? null);
+        $this->assertEquals('validation_error', $body['errors'][0]['code'] ?? null);
+        $this->assertNotEmpty($body['errors'][0]['detail'] ?? null);
+    }
+}


### PR DESCRIPTION
Guards the avatar and admin image upload endpoints against a request carrying no file part, so the user sees "The <attribute> field is required." instead of the request failing with an unhandled TypeError, and stops the avatar picker posting a non-file in the first place.