### PR TITLE
[2.x] fix: use a dedicated tooltip for post search results

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -150,10 +150,7 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
 
     items.add(
       'avatar',
-      <Tooltip
-        text={app.translator.trans('core.forum.discussion_list.started_text', { user, ago: humanTime(discussion.createdAt()) })}
-        position="right"
-      >
+      <Tooltip text={this.authorTooltipText(user)} position="right">
         {user ? (
           <Link className="DiscussionListItem-author-avatar" href={app.route.user(user)}>
             <Avatar user={user} title="" />
@@ -170,6 +167,13 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
     items.add('badges', this.badgesView(), 90);
 
     return items;
+  }
+
+  authorTooltipText(user: User | null | false): Mithril.Children {
+    return app.translator.trans('core.forum.discussion_list.started_text', {
+      user,
+      ago: humanTime(this.attrs.discussion.createdAt()),
+    });
   }
 
   badgesView(): Mithril.Children {

--- a/framework/core/js/src/forum/components/MinimalDiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/MinimalDiscussionListItem.tsx
@@ -6,6 +6,8 @@ import app from '../app';
 import highlight from '../../common/helpers/highlight';
 import listItems from '../../common/helpers/listItems';
 import classList from '../../common/utils/classList';
+import humanTime from '../../common/utils/humanTime';
+import type User from '../../common/models/User';
 
 export default class MinimalDiscussionListItem extends DiscussionListItem<IDiscussionListItemAttrs> {
   elementAttrs() {
@@ -26,6 +28,19 @@ export default class MinimalDiscussionListItem extends DiscussionListItem<IDiscu
 
   authorItems(): ItemList<Mithril.Children> {
     return super.authorItems().remove('badges');
+  }
+
+  authorTooltipText(user: User | null | false): Mithril.Children {
+    const post = this.attrs.post;
+
+    if (!post) {
+      return super.authorTooltipText(user);
+    }
+
+    return app.translator.trans('core.forum.discussion_list.replied_text', {
+      user,
+      ago: humanTime(post.createdAt()),
+    });
   }
 
   mainView(): Mithril.Children {

--- a/framework/core/js/tests/unit/forum/components/MinimalDiscussionListItem.test.ts
+++ b/framework/core/js/tests/unit/forum/components/MinimalDiscussionListItem.test.ts
@@ -1,0 +1,60 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import DiscussionListItem from '../../../../src/forum/components/DiscussionListItem';
+import MinimalDiscussionListItem from '../../../../src/forum/components/MinimalDiscussionListItem';
+import ItemList from '../../../../src/common/utils/ItemList';
+import humanTime from '../../../../src/common/utils/humanTime';
+
+beforeAll(() => bootstrapForum());
+
+describe('author tooltip', () => {
+  const discussionCreatedAt = new Date('2020-01-01T00:00:00Z');
+  const postCreatedAt = new Date('2024-06-01T00:00:00Z');
+
+  const author = { id: () => '2', username: () => 'alice', displayName: () => 'Alice', slug: () => 'alice' };
+
+  const discussion: any = {
+    createdAt: () => discussionCreatedAt,
+    user: () => author,
+    badges: () => new ItemList(),
+  };
+
+  function tooltipCall(Klass: any, attrs: any) {
+    const calls: Array<[string, any]> = [];
+    const original = app.translator.trans;
+    // @ts-ignore
+    app.translator.trans = (key: string, params: any) => {
+      calls.push([key, params]);
+      return key;
+    };
+
+    try {
+      const item = Object.create(Klass.prototype);
+      item.attrs = attrs;
+      item.authorItems();
+    } finally {
+      app.translator.trans = original;
+    }
+
+    const call = calls.find(([key]) => key.includes('_text'));
+
+    return { key: call?.[0], params: call?.[1] };
+  }
+
+  test('a discussion result says "started" with the discussion time', () => {
+    const { key, params } = tooltipCall(DiscussionListItem, { discussion });
+
+    expect(key).toBe('core.forum.discussion_list.started_text');
+    expect(params.ago).toBe(humanTime(discussionCreatedAt));
+  });
+
+  test('a post result says "replied" with the post time', () => {
+    const { key, params } = tooltipCall(MinimalDiscussionListItem, {
+      discussion,
+      author,
+      post: { createdAt: () => postCreatedAt },
+    });
+
+    expect(key).toBe('core.forum.discussion_list.replied_text');
+    expect(params.ago).toBe(humanTime(postCreatedAt));
+  });
+});


### PR DESCRIPTION
Fixes #4994 — post search results now use the existing `replied_text` translation with the post's own timestamp, instead of reusing the discussion author tooltip.