### PR TITLE
[2.x] ci: bump flarum/action-build to v5.1.0

### DIFF
--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -170,7 +170,7 @@ jobs:
         working-directory: ${{ inputs.frontend_directory }}
 
       - name: JS Checks & Production Build
-        uses: flarum/action-build@4ef2245181c661e2978c9223f65fa865767aacde # v5.0.1
+        uses: flarum/action-build@bf667f571cd12ab6ec0e66e34de8624f18d7f031 # v5.1.0
         with:
           build_script: ${{ inputs.build_script }}
           build_typings_script: ${{ inputs.build_typings_script }}


### PR DESCRIPTION
**Fixes the red `Frontend Workflow` on `2.x`**

**Changes proposed in this pull request:**

Bumps `flarum/action-build` from `v5.0.1` to `v5.1.0` in `REUSABLE_frontend.yml` — one line, SHA-pinned as before.

`v5.1.0` carries [flarum/action-build#19](https://github.com/flarum/action-build/pull/19), which fixes two problems in the monorepo build path. Both came from running all 24 packages through a single unbounded `Promise.all`:

- **The post-build phase was getting the runner killed.** Six packages here have a `test` script, and each jest run starts its own worker pool sized to the host — so that phase ran roughly 6 × (cores − 1) node processes with jsdom heaps on one runner. The failures showed as `The runner has received a shutdown signal` / `SIGTERM` mid-jest with no test failure to point at. Post-build checks now run at a bounded concurrency (default 2), separate from the build concurrency (default 4). **This is the part that should turn the tick green.**
- **Packages were deleting the typings their siblings were reading.** Every tsconfig resolves `flarum/*` and `ext:flarum/*` to other packages' `dist-typings`, and `build-typings` clears its own output before emitting. That produced the `TS2307: Cannot find module 'ext:flarum/realtime/…'` and `TS6053: … dist-typings/@types/shims.d.ts not found` noise. Typings are now their own phase, and any package that fails is retried serially once the whole set has been emitted. These were warnings (`exitOnError: false`), so they weren't failing the job — but they meant the emitted typings were unreliable.

It also picks up [flarum/action-build#18](https://github.com/flarum/action-build/pull/18), which pins that repo's own external actions to immutable hashes — no effect on what runs here.

**Reviewers should focus on:**

- Whether the concurrency defaults are right for our runners. 4 and 2 are judgement, not measurement — this PR's own run is the first real test. If the frontend job still dies mid-jest, `max_parallel_test_packages` wants to be 1, and we can set it explicitly from `frontend.yml` without another action release.
- That nothing else references `action-build` — `grep` finds this single occurrence, so there's no second pin to keep in step.

**Screenshot**

Not applicable — CI configuration only.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — `2.x` frontend CI has failed on four consecutive runs across two branches, so no PR can get a green frontend tick.
- [x] If applicable, have various options for solving this problem been considered? — the alternative was changing `build-typings` in all 20 `package.json` files to stop deleting; that was rejected because it forks from the `flarum/cli` skeleton every extension carries, and it wouldn't have addressed the runner being killed, which is the actual cause of the red tick.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — it's this repo's reusable workflow.
- [x] Are we willing to maintain this for years / potentially forever? — it's a version bump on an existing pin.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — CI configuration; nothing forum-facing.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`). — unchanged by this PR. `action-build`'s own suite is green (11 tests), and the deterministic typings repro no longer reproduces under the new phase order.
- [ ] Frontend changes: tests have been added, or are not appropriate here. — not applicable to a workflow pin; the tests live in `flarum/action-build`.
- [ ] Backend changes: tests are green (run `composer test`). — no backend changes.
- [ ] Backend changes: tests have been added, or are not appropriate here. — n/a.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
