### PR TITLE
[2.x] fix: Stop the reconnect catch-up duplicating a discussion in the list

### DIFF
--- a/framework/core/js/src/forum/states/DiscussionListState.ts
+++ b/framework/core/js/src/forum/states/DiscussionListState.ts
@@ -122,8 +122,36 @@ export default class DiscussionListState<P extends DiscussionListParams = Discus
     m.redraw();
   }
 
+  /**
+   * Reconcile the realtime additions after a background revalidation.
+   *
+   * `refresh()` empties `extraDiscussions`, because it routes through
+   * `clear()`. `revalidate()` deliberately does not clear anything before it
+   * asks the API, so it rebuilds `pages` and leaves `extraDiscussions` alone —
+   * and the first page it gets back contains exactly the discussions realtime
+   * put there, since a new post is what moved them to the top. Left unhandled
+   * they render from both places at once, which is what a reader coming back
+   * to an idle tab sees as a duplicate.
+   *
+   * Only the ids the new pages actually contain are dropped. A revalidation
+   * that failed resolves rather than rejecting and leaves `pages` untouched,
+   * so clearing unconditionally would take realtime's additions off a list
+   * that was never reloaded.
+   */
+  public revalidate(): Promise<void> {
+    return super.revalidate().then(() => {
+      // `super.getPages()`, not `this.getPages()`: the override below prepends
+      // `extraDiscussions`, which would match every one of them against itself.
+      const listed = new Set(super.getPages().flatMap((page) => page.items.map((discussion) => discussion.id())));
+
+      this.extraDiscussions = this.extraDiscussions.filter((discussion) => !listed.has(discussion.id()));
+    });
+  }
+
   protected getAllItems(): Discussion[] {
-    return this.extraDiscussions.concat(super.getAllItems());
+    // `getPages()` already prepends `extraDiscussions`, and `super` flattens
+    // that — concatenating them again here would count them twice.
+    return super.getAllItems();
   }
 
   public getPages(): Page<Discussion>[] {

--- a/framework/core/js/tests/unit/forum/states/DiscussionListState.revalidate.test.ts
+++ b/framework/core/js/tests/unit/forum/states/DiscussionListState.revalidate.test.ts
@@ -1,0 +1,126 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from 'flarum/forum/app';
+import DiscussionListState from '../../../../src/forum/states/DiscussionListState';
+import Discussion from '../../../../src/common/models/Discussion';
+import { makeDiscussion } from '../../../factory';
+
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+});
+
+beforeEach(() => {
+  app.store.data = {};
+});
+
+/**
+ * `revalidate()` is the shape the realtime reconnect catch-up uses: it reloads
+ * the first page without taking the current results off screen, so unlike
+ * `refresh()` it never routes through `clear()` and never empties
+ * `extraDiscussions`.
+ *
+ * That leaves the two halves of the list to reconcile. Realtime moves a
+ * discussion into `extraDiscussions`, and the page the catch-up fetches
+ * contains that same discussion — a new post is what put it at the top in the
+ * first place — so without reconciliation it renders from both halves at once.
+ * A reader returning to an idle tab sees it listed twice until they refresh.
+ */
+class TestState extends DiscussionListState {
+  /** What the next page load resolves with. */
+  public nextPage: Discussion[] = [];
+
+  /** When set, the next page load rejects instead. */
+  public failNextLoad = false;
+
+  protected loadPage(): Promise<any> {
+    if (this.failNextLoad) return Promise.reject(new Error('network'));
+
+    return Promise.resolve(Object.assign(this.nextPage.slice(), { payload: { links: {}, meta: {} } }));
+  }
+
+  /** Stand in for an initial page load holding these discussions. */
+  public seed(items: Discussion[]): void {
+    (this as any).pages = [{ number: 1, items, hasNext: false, hasPrev: false }];
+    (this as any).initialLoading = false;
+  }
+
+  /** The ids the list actually renders, in order. */
+  public ids(): string[] {
+    return this.getPages()
+      .flatMap((page) => page.items as Discussion[])
+      .map((discussion) => discussion.id()!);
+  }
+}
+
+function push(id: string): Discussion {
+  return app.store.pushObject<Discussion>(makeDiscussion({ id }))!;
+}
+
+describe('DiscussionListState reconciles realtime additions on revalidate', () => {
+  test('a discussion realtime added is not duplicated when the catch-up refetches it', async () => {
+    const a = push('1');
+    const b = push('2');
+
+    const state = new TestState({});
+    state.seed([b, a]);
+
+    // Realtime releases its pending updates: `a` leaves `pages` for
+    // `extraDiscussions` and renders at the top.
+    state.addDiscussion(a);
+    expect(state.ids()).toEqual(['1', '2']);
+
+    // The tab was idle, the socket died, the reader came back. The catch-up
+    // revalidates, and the server sorts `a` first because of the post that
+    // triggered the realtime event in the first place.
+    state.nextPage = [a, b];
+    await state.revalidate();
+
+    expect(state.ids()).toEqual(['1', '2']);
+  });
+
+  test('a realtime addition the refetch did not return stays on the list', async () => {
+    const a = push('1');
+    const b = push('2');
+
+    const state = new TestState({});
+    state.seed([b]);
+    state.addDiscussion(a);
+
+    // The reloaded page does not carry `a` — it is filtered out of this list,
+    // say. Reconciling must not be a blanket clear.
+    state.nextPage = [b];
+    await state.revalidate();
+
+    expect(state.ids()).toEqual(['1', '2']);
+  });
+
+  test('a failed revalidation leaves the list, realtime additions included, untouched', async () => {
+    const a = push('1');
+    const b = push('2');
+
+    const state = new TestState({});
+    state.seed([b]);
+    state.addDiscussion(a);
+
+    // `revalidate()` swallows the failure and keeps what is on screen; the
+    // pages were never replaced, so nothing may be dropped from either half.
+    state.failNextLoad = true;
+    await state.revalidate();
+
+    expect(state.ids()).toEqual(['1', '2']);
+  });
+
+  test('refresh still empties extraDiscussions, as it always has', async () => {
+    const a = push('1');
+    const b = push('2');
+
+    const state = new TestState({});
+    state.seed([b, a]);
+    state.addDiscussion(a);
+
+    state.nextPage = [a, b];
+    await state.refresh();
+
+    expect(state.ids()).toEqual(['1', '2']);
+  });
+});


### PR DESCRIPTION
Fixes #5002.

**Changes proposed in this pull request:**

Returning to a tab that had been idle long enough for the websocket to die shows a discussion listed twice, until the reader refreshes.

`refresh()` empties `extraDiscussions`, because it routes through `clear()` and `DiscussionListState.clear()` resets it. `revalidate()` (#4889) deliberately clears nothing before it asks the API — that is the point of it, the list stays on screen and keeps its scroll position — so it rebuilds `pages` and leaves `extraDiscussions` alone. The first page it gets back contains exactly the discussions realtime had put there, because a new post is what moved them to the top in the first place, and `getPages()` prepends `extraDiscussions` as a synthetic page. The discussion then renders from both halves at once.

- `revalidate()` now reconciles once the results have landed, dropping from `extraDiscussions` only the ids the new pages actually contain. Deliberately **not** a blanket clear: `revalidate()` swallows a failure and resolves rather than rejecting, leaving `pages` untouched, and clearing there would take realtime's additions off a list that was never reloaded.
- `getAllItems()` no longer counts `extraDiscussions` twice. It concatenated them onto `super.getAllItems()`, which flattens the `getPages()` this class had already overridden to prepend them. Harmless where it is read today (`isEmpty()`), wrong for anything that counts. Adjacent enough to the reconciliation that I'd rather not leave it in place underneath it, but happy to split it out if you'd prefer.

**A note on #4993:** that PR was filed against this same report, so I want to be explicit rather than look like I'm re-fixing it. #4993 matches by `id()` instead of by object reference on the reasoning that "the store returns a fresh instance whenever it no longer holds the one already on screen". `Store.data` is keyed `[type][id]`, `pushObject` returns the existing model when there is one, and the only eviction is `Store.remove()` from `Model.delete()` — so `pushPayload` hands back the same instance and the two matches are equivalent. And nothing on the failing path calls `deleteDiscussion` at all. Its `splice(index)` → `splice(index, 1)` half is a real fix and this PR keeps it; the duplicate simply comes from somewhere else. I have a test in this PR that fails on `2.x` today with #4993 in place.

**A note on forums without realtime:** `addDiscussion` has no caller in core or any bundled extension, so `extraDiscussions` is only ever non-empty with realtime enabled, and `revalidate()` only has a caller in realtime's reconnect catch-up. On a forum without realtime both changes are no-ops.

**Reviewers should focus on:**

- That reconciling against `super.getPages()` rather than `this.getPages()` is the right call — the override prepends `extraDiscussions`, so `this.getPages()` would match every one of them against itself and the filter would never drop anything.
- That filtering by "id present in the new pages" is the right predicate, rather than clearing outright. The failure case is the reason: a swallowed network error leaves the list exactly as it was, and realtime's additions have to survive that.
- Whether the `getAllItems()` change belongs here or in its own PR.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — a discussion renders twice after a reconnect catch-up; reported in #5002.
- [x] If applicable, have various options for solving this problem been considered? — clearing `extraDiscussions` in `revalidate()` outright is simpler but loses realtime additions when the revalidation fails; reconciling by id keeps the invisible-refetch contract intact.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the list state and `revalidate()` both live in core; realtime only calls them.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — reproduced on a full prod-mirror install (realtime enabled, auto-release at the default 10s) and then narrowed to a unit test.
- [x] Frontend changes: tests are green. — 230/230 in `framework/core/js/tests/unit`, including #4993's `DiscussionListState.dedup` suite and #4889's `PaginatedListState` revalidate suite. `check-typings` and `prettier --check` clean.
- [x] Frontend changes: tests have been added. — `DiscussionListState.revalidate.test.ts`: the duplicate itself (fails pre-fix, passes post-fix), that a realtime addition the refetch did not return stays on the list, that a failed revalidation leaves both halves untouched, and that `refresh()` still empties `extraDiscussions` as it always has.
- [ ] Backend changes: tests are green — no backend changes.
- [ ] Backend changes: tests have been added, or are not appropriate here — n/a.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
