### PR TITLE
fix: extraDocumentClasses never reached the document

### DIFF
--- a/framework/core/src/Extend/Frontend.php
+++ b/framework/core/src/Extend/Frontend.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Extend;
 
+use Closure;
 use Flarum\Extension\Event\Disabled;
 use Flarum\Extension\Event\Enabled;
 use Flarum\Extension\Extension;
@@ -365,9 +366,22 @@ class Frontend implements ExtenderInterface
             "flarum.frontend.$this->frontend",
             function (ActualFrontend $frontend, Container $container) {
                 $frontend->content(function (Document $document) use ($container) {
-                    foreach ($this->extraDocumentAttributes as $classes) {
-                        $classes = is_callable($classes) ? ContainerUtil::wrapCallback($classes, $container) : $classes;
-                        $document->extraAttributes[] = $classes;
+                    foreach ($this->extraDocumentAttributes as $attributes) {
+                        foreach ($attributes as $key => $value) {
+                            // Only a closure, never `is_callable`. An attribute
+                            // value is a value: `is_callable('value')` is true,
+                            // because Laravel defines a global `value()`, and
+                            // the document would call it with the request.
+                            $value = $value instanceof Closure ? ContainerUtil::wrapCallback($value, $container) : $value;
+
+                            // Classes accumulate; the document holds them as a
+                            // list so that several extensions can each add one.
+                            if ($key === 'class') {
+                                $document->extraAttributes['class'][] = $value;
+                            } else {
+                                $document->extraAttributes[$key] = $value;
+                            }
+                        }
                     }
                 }, 111);
             }

--- a/framework/core/src/Frontend/Document.php
+++ b/framework/core/src/Frontend/Document.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Frontend;
 
+use Closure;
 use Flarum\Formatter\XsltPolyfill;
 use Flarum\Foundation\Config;
 use Flarum\Frontend\Compiler\VersionerInterface;
@@ -244,7 +245,9 @@ class Document implements Renderable
         $extraClasses = $this->extraAttributes['class'] ?? [];
 
         foreach ($extraClasses as $class) {
-            if (is_callable($class)) {
+            // Only a closure. A class name is a string, and `is_callable` on a
+            // string is true whenever a global function happens to share it.
+            if ($class instanceof Closure) {
                 $class = $class($this->request);
             }
 
@@ -263,7 +266,7 @@ class Document implements Renderable
                 continue;
             }
 
-            if (is_callable($value)) {
+            if ($value instanceof Closure) {
                 $value = $value($this->request);
             }
 

--- a/framework/core/tests/integration/extenders/FrontendDocumentAttributesTest.php
+++ b/framework/core/tests/integration/extenders/FrontendDocumentAttributesTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend\Frontend;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FrontendDocumentAttributesTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private function html(): string
+    {
+        return $this->send($this->request('GET', '/'))->getBody()->getContents();
+    }
+
+    /**
+     * The opening `<html>` tag, which is where these end up.
+     */
+    private function htmlTag(): string
+    {
+        preg_match('/<html[^>]*>/', $this->html(), $matches);
+
+        return $matches[0] ?? '';
+    }
+
+    #[Test]
+    public function extra_document_classes_reach_the_html_tag()
+    {
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentClasses('some-class')
+        );
+
+        $this->assertStringContainsString('some-class', $this->htmlTag());
+    }
+
+    #[Test]
+    public function extra_document_classes_accept_an_array()
+    {
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentClasses(['first-class', 'second-class' => true, 'absent-class' => false])
+        );
+
+        $tag = $this->htmlTag();
+
+        $this->assertStringContainsString('first-class', $tag);
+        $this->assertStringContainsString('second-class', $tag);
+        $this->assertStringNotContainsString('absent-class', $tag);
+    }
+
+    #[Test]
+    public function extra_document_classes_accept_a_callable()
+    {
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentClasses(function (ServerRequestInterface $request) {
+                return 'from-callable';
+            })
+        );
+
+        $this->assertStringContainsString('from-callable', $this->htmlTag());
+    }
+
+    #[Test]
+    public function classes_from_several_extenders_all_arrive()
+    {
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentClasses('first-extender'),
+            (new Frontend('forum'))->extraDocumentClasses('second-extender')
+        );
+
+        $tag = $this->htmlTag();
+
+        $this->assertStringContainsString('first-extender', $tag);
+        $this->assertStringContainsString('second-extender', $tag);
+    }
+
+    #[Test]
+    public function extra_document_attributes_reach_the_html_tag()
+    {
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentAttributes(['data-test' => 'value'])
+        );
+
+        $this->assertStringContainsString('data-test="value"', $this->htmlTag());
+    }
+
+    #[Test]
+    public function extra_document_attributes_accept_a_callable()
+    {
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentAttributes([
+                'data-test' => function (ServerRequestInterface $request) {
+                    return 'from-callable';
+                },
+            ])
+        );
+
+        $this->assertStringContainsString('data-test="from-callable"', $this->htmlTag());
+    }
+
+    #[Test]
+    public function an_attribute_value_that_shares_a_name_with_a_global_function_is_not_called()
+    {
+        // `is_callable('value')` is true, because Laravel defines a global
+        // `value()` helper. Treating a string value as callable therefore
+        // called it with the request and tried to escape a ServerRequest.
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentAttributes(['data-test' => 'value'])
+        );
+
+        $this->assertStringContainsString('data-test="value"', $this->htmlTag());
+    }
+
+    #[Test]
+    public function a_class_that_shares_a_name_with_a_global_function_is_not_called()
+    {
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentClasses('value')
+        );
+
+        $this->assertStringContainsString('value', $this->htmlTag());
+    }
+
+    #[Test]
+    public function no_numerically_keyed_attribute_is_emitted()
+    {
+        // The shape of the bug this covers: attributes were appended to the
+        // document's map at a numeric index, so the class never reached
+        // `makeExtraClasses` and an attribute named `0` was written instead.
+        $this->extend(
+            (new Frontend('forum'))->extraDocumentClasses('some-class')
+        );
+
+        $this->assertDoesNotMatchRegularExpression('/<html[^>]*\s\d+=/', $this->htmlTag());
+    }
+}


### PR DESCRIPTION
### Fixes #

`Extend\Frontend::extraDocumentClasses()` has never worked.

### Changes proposed in this pull request:

`registerDocumentAttributes()` appends each attribute map to the document at a numeric index:

```php
$document->extraAttributes[] = $classes;
```

but `Document::makeExtraClasses()` reads `$extraAttributes['class']`, which is therefore never written, and `makeExtraAttributes()` iterates the map by key and emits the numeric one. So:

```php
(new Frontend('forum'))->extraDocumentClasses('some-class')
```

renders

```html
<html dir="ltr" lang="en" class="guest-user" data-theme="auto" 0="some-class">
```

— no class, and an invalid `0=""` attribute. Neither `extraDocumentClasses()` nor `extraDocumentAttributes()` had any test coverage, which is how it survived.

Merging by key rather than appending surfaced a second problem. The old code tested `is_callable()` on the outer array, which is never callable, so the branch was dead. Testing the *value* instead means a plain string is treated as callable whenever a global function happens to share its name — and Laravel defines `value()` — so:

```php
(new Frontend('forum'))->extraDocumentAttributes(['data-test' => 'value'])
```

called it with the request and then tried to `e()` a `ServerRequest`, returning a 500.

Both sides now check `instanceof Closure`. An attribute value is a value; only a closure is a callback. `ContainerUtil::wrapCallback` still handles the closure case, so invokable behaviour is unchanged.

### Reviewers should focus on:

Whether narrowing `is_callable` to `instanceof Closure` in `Document` is acceptable. It rules out passing an invokable class string as an attribute value — which cannot currently work anyway, since the extender is broken — in exchange for making a plain string value safe.

### Confirmed

- [x] Frontend changes: tested on a local Flarum installation with all frontend bundles recompiled.
- [x] Backend changes: tested on a local Flarum installation.
- [x] Backend changes: added or updated relevant tests.

### Required changes:

- [ ] Documentation PR (if necessary):