### PR TITLE
feat: add Footer.items

### DIFF
--- a/framework/core/js/src/forum/components/Footer.tsx
+++ b/framework/core/js/src/forum/components/Footer.tsx
@@ -1,7 +1,19 @@
 import Component from '../../common/Component';
+import ItemList from '../../common/utils/ItemList';
+import type Mithril from 'mithril';
 
 export default class Footer extends Component {
   view() {
-    return null;
+    const items = this.items().toArray();
+
+    // Nothing has been added, so nothing is rendered -- an empty container
+    // would still take up its own padding at the bottom of every page.
+    if (!items.length) return null;
+
+    return <div className="Footer-container container">{items}</div>;
+  }
+
+  items(): ItemList<Mithril.Children> {
+    return new ItemList();
   }
 }

--- a/framework/core/js/tests/integration/forum/components/Footer.test.ts
+++ b/framework/core/js/tests/integration/forum/components/Footer.test.ts
@@ -1,0 +1,58 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import Footer from '../../../../src/forum/components/Footer';
+import ItemList from '../../../../src/common/utils/ItemList';
+import { extend } from '../../../../src/common/extend';
+import m from 'mithril';
+import mq from 'mithril-query';
+
+beforeAll(() => bootstrapForum());
+
+describe('Footer', () => {
+  const original = Footer.prototype.items;
+
+  afterEach(() => {
+    Footer.prototype.items = original;
+  });
+
+  it('renders nothing when no extension has added an item', () => {
+    const rendered = mq(m(Footer));
+
+    expect(rendered).not.toHaveElement('.Footer-container');
+    // The mount point sits on every page, so an empty footer must not
+    // contribute a container of its own.
+    expect(rendered).not.toHaveElement('.container');
+  });
+
+  it('returns an empty ItemList by default', () => {
+    const items = Footer.prototype.items.call(null);
+
+    expect(items).toBeInstanceOf(ItemList);
+    expect(items.toArray()).toHaveLength(0);
+  });
+
+  it('renders the items an extension adds, inside a container', () => {
+    extend(Footer.prototype, 'items', function (items: ItemList<any>) {
+      items.add('legal', m('a', { className: 'TestFooterLink', href: '/legal' }, 'Terms'));
+    });
+
+    const rendered = mq(m(Footer));
+
+    expect(rendered).toHaveElement('.Footer-container.container');
+    expect(rendered).toHaveElement('.Footer-container .TestFooterLink');
+    expect(rendered).toContainRaw('Terms');
+  });
+
+  it('renders several items in priority order', () => {
+    extend(Footer.prototype, 'items', function (items: ItemList<any>) {
+      items.add('second', m('span', { className: 'TestFooterItem' }, 'Second'), 10);
+      items.add('first', m('span', { className: 'TestFooterItem' }, 'First'), 20);
+    });
+
+    const rendered = mq(m(Footer));
+
+    expect(rendered.find('.TestFooterItem')).toHaveLength(2);
+    // Read off the rendered DOM rather than the ItemList, so that a view
+    // which rendered the items in some other order would be caught.
+    expect(Array.from(rendered.rootEl.querySelectorAll('.TestFooterItem')).map((el: any) => el.textContent)).toEqual(['First', 'Second']);
+  });
+});


### PR DESCRIPTION
### Fixes #

`Footer` is mounted on every forum page and renders `null`:

```tsx
export default class Footer extends Component {
  view() {
    return null;
  }
}
```

`extend` works by mutating a method's return value, and there is nothing to mutate, so the only way an extension can put anything in the footer is to `override` `view()` and return its own markup. The second extension to do that silently replaces the first, and neither has a way to detect it.

### Changes proposed in this pull request:

```tsx
extend(Footer.prototype, 'items', function (items) {
  items.add('legal', <Link href={app.route('legal')}>{app.translator.trans('acme.forum.legal')}</Link>, 10);
});
```

`items()` gives `Footer` the same `ItemList` every other container component has, so several extensions can each contribute and order themselves by priority.

When nothing has been added, `view()` still returns `null`. A forum with no extension in its footer renders exactly what it renders today, down to the absence of the container element — an empty `.container` would otherwise add its own padding to the bottom of every page.

### Reviewers should focus on:

The wrapper's class. `<footer class="App-footer" id="footer">` is the mount point in `forum.blade.php` and has no styles of its own, so the items need a `.container` to line up with the rest of the page; I've paired it with `Footer-container` for extensions to hook onto. Happy to drop the second class if that's redundant.

### Confirmed

- [x] Frontend changes: tested on a local Flarum installation with all frontend bundles recompiled.
- [x] Frontend changes: added or updated relevant tests.

Four tests in `tests/integration/forum/components/Footer.test.ts`: nothing rendered by default, an empty `ItemList` by default, extension items rendered inside the container, and priority order read off the rendered DOM. Each was checked against a deliberately broken implementation to confirm it fails.

### Required changes:

- [ ] Documentation PR (if necessary):