### PR TITLE
fix: a route resolver that narrows its component is not assignable

### DIFF
--- a/framework/core/js/src/common/extenders/Routes.ts
+++ b/framework/core/js/src/common/extenders/Routes.ts
@@ -16,8 +16,21 @@ export default class Routes implements IExtender {
    * @param path The path of the route.
    * @param component must extend `Page` component.
    * @param resolverClass An optional custom route resolver class.
+   *
+   * `resolverClass` is spelled as a construct signature rather than as
+   * `typeof DefaultResolver`, and has to be. A resolver that narrows the
+   * component it accepts -- which is the only reason to write one, and what
+   * both of core's own do -- is not assignable to `typeof DefaultResolver`,
+   * because constructor parameters are contravariant and `DefaultResolver`'s
+   * are open. This matches the `resolverClass` field on `RouteItem`, which is
+   * where the value is being put.
    */
-  add(name: string, path: `/${string}`, component: NewComponent<any> | AsyncNewComponent<any>, resolverClass?: typeof DefaultResolver): Routes {
+  add(
+    name: string,
+    path: `/${string}`,
+    component: NewComponent<any> | AsyncNewComponent<any>,
+    resolverClass?: new (component: NewComponent<any> | AsyncNewComponent<any>, routeName: string) => DefaultResolver<any, any, any>
+  ): Routes {
     const route: FlarumGenericRoute = { path, component };
 
     if (resolverClass) {

--- a/framework/core/js/tests/integration/common/extenders/Routes.test.ts
+++ b/framework/core/js/tests/integration/common/extenders/Routes.test.ts
@@ -1,5 +1,7 @@
 import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
 import Routes from '../../../../src/common/extenders/Routes';
+import UserPageResolver from '../../../../src/forum/resolvers/UserPageResolver';
+import DiscussionPageResolver from '../../../../src/forum/resolvers/DiscussionPageResolver';
 import app from '@flarum/core/src/forum/app';
 
 beforeAll(() => bootstrapForum());
@@ -22,6 +24,42 @@ describe('Routes extender', () => {
 
     expect(() => app.route('nonexistent')).not.toThrow();
     expect(app.route('nonexistent')).toBe('/nonexistent');
+  });
+
+  /**
+   * Both of core's own resolvers narrow the component they accept, which is
+   * the only reason to write one. They have to be usable here.
+   *
+   * Note what this cannot check: the transform under Jest is Babel, which
+   * strips types without reading them, so a signature that rejects these at
+   * compile time still passes this test. The regression it guards is the
+   * runtime wiring; the typing is guarded by `yarn check-typings`.
+   */
+  test.each([
+    ['UserPageResolver', UserPageResolver],
+    ['DiscussionPageResolver', DiscussionPageResolver],
+  ])('a resolver that narrows its component is carried through (%s)', (_name, resolverClass) => {
+    app.bootExtensions({
+      test: {
+        extend: [new Routes().add('nonexistent', '/nonexistent', null, resolverClass)],
+      },
+    });
+
+    app.boot();
+
+    expect(app.routes.nonexistent).toHaveProperty('resolverClass', resolverClass);
+  });
+
+  test('a route added without a resolver has none', () => {
+    app.bootExtensions({
+      test: {
+        extend: [new Routes().add('nonexistent', '/nonexistent', null)],
+      },
+    });
+
+    app.boot();
+
+    expect(app.routes.nonexistent).not.toHaveProperty('resolverClass');
   });
 
   test('added route helper works', () => {


### PR DESCRIPTION
### Fixes #

`Routes.add()` types its optional resolver as `typeof DefaultResolver`, whose constructor accepts a component of any type:

```ts
add(name: string, path: `/${string}`, component: NewComponent<any> | AsyncNewComponent<any>, resolverClass?: typeof DefaultResolver): Routes
```

Every resolver worth writing narrows that — narrowing is the reason to write one — and constructor parameters are contravariant, so a narrower resolver is not assignable to it. Both of core's own resolvers narrow, so both are rejected.

This is `extensions/likes/js/src/forum/extend.ts:14` as it stands on `2.x`:

```ts
new Extend.Routes() //
  .add('user.likes', '/u/:username/likes', LikesUserPage, UserPageResolver),
```

```
error TS2345: Argument of type 'typeof UserPageResolver' is not assignable to parameter
of type 'typeof DefaultResolver'.
  Types of construct signatures are incompatible.
    ...
      Types of parameters 'component' and 'component' are incompatible.
```

Every extension that adds a profile tab or a discussion route hits it. The workaround people reach for is `as unknown as typeof DefaultResolver`, which is a cast around a correct call.

It has gone unnoticed because `check-typings` is run from the monorepo root, where there is no such script, so the bundled extensions are never typechecked. `tsc` inside `extensions/likes/js` shows it immediately.

### Changes proposed in this pull request:

`resolverClass` is now spelled as a construct signature rather than as `typeof DefaultResolver`.

This is not a new shape. The `resolverClass` field on `RouteItem` — which is where the value is being assigned, two lines later — is already declared this way and already accepts both resolvers:

```ts
resolverClass?: new (component: NewComponent<Comp> | AsyncNewComponent<Comp>, routeName: string) => DefaultResolver<Attrs, Comp, RouteArgs>;
```

The extender now says the same thing as the field it writes to.

### Reviewers should focus on:

Whether `DefaultResolver<any, any, any>` is the right return type here, or whether it should be `RouteResolver<any, any, any>`. I used `DefaultResolver` to match `RouteItem` exactly, since that is the type the assignment has to satisfy, but the extender itself only ever stores the value.

Also worth a decision, and deliberately not in this PR: `check-typings` currently typechecks nothing under `extensions/`, which is why this survived. Widening it would surface this class of problem on its own — and would surface one other pre-existing error in `likes` (`LikesUserPage.params` narrows its return type incompatibly with `PostsUserPage.params`), which I have left alone.

### Confirmed

- [x] Frontend changes: tested on a local Flarum installation with all frontend bundles recompiled.
- [x] Frontend changes: added or updated relevant tests.

`tsc` in `extensions/likes/js` before this change reports two errors, and after it reports one — the one removed is exactly the resolver error, and the one remaining is the unrelated `params` narrowing above. I also confirmed on a real extension of my own that the `as unknown as typeof DefaultResolver` cast becomes unnecessary.

Three tests added to `tests/integration/common/extenders/Routes.test.ts`: both core resolvers reach `app.routes`, and a route added without one has no `resolverClass`. Each was checked against a deliberately broken extender to confirm it fails.

Worth being explicit about what those tests do not cover: Jest transforms them with Babel, which strips types without reading them, so a signature that rejects both resolvers still passes them. `yarn check-typings` is what covers the signature.

### Required changes:

- [ ] Documentation PR (if necessary):