### PR TITLE
Fix statistics custom date range sum showing 0

### DIFF
--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -186,9 +186,11 @@ export default class StatisticsWidget extends DashboardWidget {
       : this.periods![this.selectedPeriod!];
 
     if (this.selectedPeriod === 'custom') {
-      if (!this.customPeriodData[this.selectedEntity] && this.loadingCustom[this.selectedEntity] === 'unloaded') {
-        this.loadCustomRangeData(this.selectedEntity);
-      }
+      this.entities.forEach((entity) => {
+        if (!this.customPeriodData[entity] && this.loadingCustom[entity] === 'unloaded') {
+          this.loadCustomRangeData(entity);
+        }
+      });
     } else {
       if (!this.timedData[this.selectedEntity] && this.loadingTimed[this.selectedEntity] === 'unloaded') {
         this.loadTimedData(this.selectedEntity);
@@ -446,6 +448,11 @@ export default class StatisticsWidget extends DashboardWidget {
 
   getPeriodCount(entity: string, period: { start: number; end: number }) {
     const timed: Record<string, number> = (this.selectedPeriod === 'custom' ? this.customPeriodData : this.timedData)[entity];
+
+    if (!timed) {
+      return 0;
+    }
+
     let count = 0;
 
     for (const t in timed) {


### PR DESCRIPTION
Fix statistics custom date range sum showing 0

When selecting a custom date range in the admin Statistics widget,
the "New during range" cells showed 0 for all entity types except
the currently selected one.

Root cause: The content() method only loaded timed counts for the
currently selected entity. However, the entity loop renders all
entities and calls getPeriodCount() for each. When data wasn't
loaded for an entity, this.timedCounts[entity] was undefined,
causing a TypeError when iterating "for (const t in undefined)".

Fix:
1. Added null check in getPeriodCount() to return 0 early if
   timed data is not loaded
2. Modified content() to load timed counts for ALL entities when
   a custom period is selected, not just the selected entity

Fixes #4986