### PR TITLE
Increase vertical density in audit log by reducing block padding

### DIFF
--- a/extensions/audit/less/common.less
+++ b/extensions/audit/less/common.less
@@ -188,7 +188,7 @@
 }
 
 .AuditItem {
-    padding: 20px;
+    padding: 10px 20px;
     display: flex;
     border-top: 1px solid var(--control-bg);
 


### PR DESCRIPTION
Reduced block margins for Audit items to increase vertical density

**Changes proposed in this pull request:**
On my MacBook I currently see just three in the audit log:
<img width="2440" height="1404" alt="image" src="https://github.com/user-attachments/assets/df350836-0b3e-4bea-b670-bbd47ccf72b8" />
In this PR: With the block padding for Audit items reduced from 20px to 10px the vertical density is increased by a bit and I can already see 4 items:
<img width="2438" height="1406" alt="image" src="https://github.com/user-attachments/assets/94e669fe-66eb-4e57-94c0-aa1d301d3d88" />

**Reviewers should focus on:**
-

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Frontend changes: tests are green (run `yarn test` in `js/`).
- [X] Frontend changes: tests are not appropriate here.
- [X] Backend changes: tests are green (run `composer test`).
- [Y] Backend changes: tests are not appropriate here.
- [ ] Core developer confirmed locally this works as intended.
- [X] The description above is written by me and describes what this pull request actually does.