### PR TITLE
Remove FormControl-alt from Extension Manager search bar DiscoverSection

### DIFF
--- a/extensions/package-manager/js/src/admin/components/DiscoverSection.tsx
+++ b/extensions/package-manager/js/src/admin/components/DiscoverSection.tsx
@@ -158,7 +158,6 @@ export default class DiscoverSection<CustomAttrs extends IDiscoverSectionAttrs =
           this.search(value);
           this.applySearch(value);
         }}
-        inputAttrs={{ className: 'FormControl-alt' }}
         clearable={true}
         placeholder={app.translator.trans('flarum-extension-manager.admin.sections.discover.search')}
         prefixIcon="fas fa-search"


### PR DESCRIPTION
This ensures the search bar is actually visible as an interactive input field

**Changes proposed in this pull request:**
As a first time user to Flarum exploring the Extension Manager in admin I missed many times that there is actually a search field at the top. This is because the current styling does not convey that this is an interactive input field:
<img width="2380" height="1010" alt="image" src="https://github.com/user-attachments/assets/6c51f39f-fb47-4eb7-ab5b-40948a90499b" />
I would recommend to remove the .FormControl-alt styling class that adds the white background to this search bar and style it like search fields everywhere else in admin:
<img width="2402" height="1018" alt="image" src="https://github.com/user-attachments/assets/b877dbd4-2d41-42de-a1aa-27a6be881f46" />

**Reviewers should focus on:**
-

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Frontend changes: tests are green (run `yarn test` in `js/`).
- [X] Frontend changes: tests are not appropriate here.
- [X] Backend changes: tests are green (run `composer test`).
- [X] Backend changes: tests are not appropriate here.
- [ ] Core developer confirmed locally this works as intended.
- [X] The description above is written by me and describes what this pull request actually does.