### PR TITLE
[2.x] fix: resolve translation references in implicitly-loaded fallback catalogues

### DIFF
--- a/framework/core/src/Locale/Translator.php
+++ b/framework/core/src/Locale/Translator.php
@@ -16,6 +16,17 @@ class Translator extends BaseTranslator implements TranslatorInterface
 {
     public const REFERENCE_REGEX = '/^=>\s*([a-z0-9_\-\.]+)$/i';
 
+    /**
+     * Catalogue objects whose `=> reference` values have already been resolved.
+     *
+     * Tracked per object rather than per locale: Symfony stores an original
+     * catalogue per locale but attaches fresh copies as fallbacks of other
+     * locales, so several objects can share one locale name.
+     *
+     * @var \WeakMap<MessageCatalogueInterface, bool>
+     */
+    private ?\WeakMap $parsedCatalogues = null;
+
     public function get($key, array $replace = [], $locale = null): string
     {
         return $this->trans($key, $replace, null, $locale);
@@ -35,16 +46,14 @@ class Translator extends BaseTranslator implements TranslatorInterface
             $this->assertValidLocale($locale);
         }
 
-        $parse = ! isset($this->catalogues[$locale]);
-
         $catalogue = parent::getCatalogue($locale);
 
-        if ($parse) {
-            $this->parseCatalogue($catalogue);
+        $this->parsedCatalogues ??= new \WeakMap();
 
-            $fallbackCatalogue = $catalogue;
-            while ($fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue()) {
-                $this->parseCatalogue($fallbackCatalogue);
+        for ($current = $catalogue; $current !== null; $current = $current->getFallbackCatalogue()) {
+            if (! isset($this->parsedCatalogues[$current])) {
+                $this->parseCatalogue($current);
+                $this->parsedCatalogues[$current] = true;
             }
         }
 

--- a/framework/core/tests/unit/Locale/TranslatorReferenceResolutionTest.php
+++ b/framework/core/tests/unit/Locale/TranslatorReferenceResolutionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Locale;
+
+use Flarum\Locale\PrefixedYamlFileLoader;
+use Flarum\Locale\Translator;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+class TranslatorReferenceResolutionTest extends TestCase
+{
+    private const DOMAIN = 'messages'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cacheDir = sys_get_temp_dir().'/flarum-translator-test-'.uniqid('', true);
+        mkdir($this->cacheDir);
+
+        file_put_contents($this->cacheDir.'/en.yml', "foo: '=> bar'\nbar: Resolved\n");
+        file_put_contents($this->cacheDir.'/de.yml', "baz: Beispiel\n");
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob($this->cacheDir.'/*') ?: []);
+        rmdir($this->cacheDir);
+
+        parent::tearDown();
+    }
+
+    private function translator(): Translator
+    {
+        // Wired like LocaleServiceProvider: non-debug, cache dir, 'en' fallback.
+        $translator = new Translator('de', null, $this->cacheDir, false);
+        $translator->setFallbackLocales(['en']);
+        $translator->addLoader('prefixed_yaml', new PrefixedYamlFileLoader());
+        $translator->addResource('prefixed_yaml', ['file' => $this->cacheDir.'/en.yml', 'prefix' => ''], 'en', self::DOMAIN);
+        $translator->addResource('prefixed_yaml', ['file' => $this->cacheDir.'/de.yml', 'prefix' => ''], 'de', self::DOMAIN);
+
+        return $translator;
+    }
+
+    #[Test]
+    public function references_are_resolved_when_locale_is_loaded_directly()
+    {
+        $translator = $this->translator();
+
+        $this->assertSame('Resolved', $translator->getCatalogue('en')->get('foo', 'messages'));
+    }
+
+    #[Test]
+    public function references_are_resolved_when_locale_was_first_loaded_as_a_fallback()
+    {
+        $translator = $this->translator();
+
+        // Loading 'de' makes Symfony implicitly load and store the 'en'
+        // catalogue as its fallback, before 'en' is ever requested directly.
+        $translator->getCatalogue('de');
+
+        $this->assertSame('Resolved', $translator->getCatalogue('en')->get('foo', 'messages'));
+    }
+
+    #[Test]
+    public function references_are_resolved_in_fallback_catalogues()
+    {
+        $translator = $this->translator();
+
+        $fallback = $translator->getCatalogue('de')->getFallbackCatalogue();
+
+        $this->assertSame('Resolved', $fallback->get('foo', 'messages'));
+        $this->assertSame('Resolved', $translator->trans('foo', [], null, 'de'));
+    }
+}


### PR DESCRIPTION
**Fixes** unresolved translation references leaking into compiled locale JS assets.

## Symptom

Compiled locale assets (e.g. `admin-en.js`) sometimes contain **unresolved translation references** — literal values like:

```json
"core.admin.nav.dashboard_button":"=> core.admin.dashboard.title"
```

The admin UI then displays raw `=> core.admin.…` strings. Observed in production on Flarum 1.8.19 (community.sbb.ch); the affected logic is identical on `2.x` and `1.x`. Characteristics:

- Only ever affects the **fallback locale** (`en`, hardcoded via `setFallbackLocales(['en'])`).
- Plain (non-reference) entries in the same file are correct.
- Intermittent: only manifests when a locale asset is (re)compiled by an "unlucky" request — the poisoned asset then **persists** (its revision exists, so it is never recompiled) until a cache flush.

## Root cause

`Flarum\Locale\Translator::getCatalogue()` decided whether to run `=>`-reference resolution (`parseCatalogue()`) with a **locale-keyed** flag:

```php
$parse = ! isset($this->catalogues[$locale]);
```

But Symfony's `Translator::loadFallbackCatalogues()` (same pattern verified on symfony/translation v5.4 and v7.4), when loading any *other* locale, pre-stores the **original** fallback catalogue in `$this->catalogues['en']` while attaching only a **fresh copy** to the requesting catalogue:

```php
if (!isset($this->catalogues[$fallback])) {
    $this->initializeCatalogue($fallback);          // stores the ORIGINAL — raw
}
$fallbackCatalogue = new MessageCatalogue($fallback, $this->getAllMessages($this->catalogues[$fallback]));
$current->addFallbackCatalogue($fallbackCatalogue); // attaches a COPY
```

So loading `de` first stores a raw, never-parsed `en` original. Flarum's parse-walk resolves `de` and the *copy* — the stored original stays raw. A later `getCatalogue('en')` finds the locale already set, skips parsing, and returns the raw original. Any consumer that snapshots the catalogue — most damagingly `Flarum\Frontend\AddTranslations`, which compiles the locale JS assets — emits the literal `=> …` strings.

Trigger shape in production: any request that touches a non-`en` catalogue before compiling an `en` asset (forums whose default locale is not `en`, or cross-locale rendering such as notification emails).

## Reproduction

Deterministic 12-line script (run from the monorepo root after `composer install`), mirroring `LocaleServiceProvider`'s wiring — full script in the test file added by this PR; essence:

```php
$t = makeTranslator();          // locale 'de', fallback ['en'], non-debug, cache dir
$t->getCatalogue('en');
$t->getCatalogue('en')->get('core.admin.nav.dashboard_button');
// => "Dashboard"                                       ✔

$t = makeTranslator();          // fresh translator, fresh cache
$t->getCatalogue('de');         // implicit fallback load of 'en'
$t->getCatalogue('en')->get('core.admin.nav.dashboard_button');
// => "=> core.admin.dashboard.title"                   ✘
```

Also confirmed end-to-end on a live Flarum 1.8.19 install: a script that calls `getCatalogue('de')` before force-recompiling the English admin locale asset produces literal `=> …` strings in the real admin UI; the identical script minus that one line produces a clean asset.

## Fix

Track parsed state per catalogue **object** (`WeakMap`) instead of per locale name, and walk the fallback chain on every `getCatalogue()` call. The raw stored original and its parsed copy share a locale name, so a locale-keyed flag cannot distinguish them; per-object tracking parses each catalogue object exactly once. Already-parsed objects cost one `WeakMap` lookup per call. `parseCatalogue()` is unchanged (and idempotent, so even a double parse would be harmless).

Note: reference resolution remains in-memory only, by design — the on-disk catalogue cache files always contain raw references. The fix guarantees the in-memory parse for every object handed out.

## Tests

New `TranslatorReferenceResolutionTest`, wired like `LocaleServiceProvider` (non-debug, cache dir, `en` fallback):

- `en` loaded **directly** → references resolved (regression guard, passed before).
- `en` first loaded **implicitly as a fallback** of `de`, then requested directly → references resolved (**failed before this fix** with exactly `'=> bar'` vs `'Resolved'`).
- The fallback copy attached to `de` is resolved, both via `getFallbackCatalogue()` and via `trans()` fallthrough (regression guard).

Full unit suite and PHPStan pass.

## Context

Surfaced while working on FriendsOfFlarum/redis#34 — multi-instance cache invalidation increases recompile frequency, raising exposure — but the bug is reproducible on a bare single-instance install. A `1.x` backport PR (PHP 7.3-compatible, `SplObjectStorage` instead of `WeakMap`) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
