### PR TITLE
[1.x] fix: resolve translation references in implicitly-loaded fallback catalogues

### DIFF
--- a/framework/core/src/Locale/Translator.php
+++ b/framework/core/src/Locale/Translator.php
@@ -17,6 +17,17 @@ class Translator extends BaseTranslator implements TranslatorContract
 {
     const REFERENCE_REGEX = '/^=>\s*([a-z0-9_\-\.]+)$/i';
 
+    /**
+     * Catalogue objects whose `=> reference` values have already been resolved.
+     *
+     * Tracked per object rather than per locale: Symfony stores an original
+     * catalogue per locale but attaches fresh copies as fallbacks of other
+     * locales, so several objects can share one locale name.
+     *
+     * @var \SplObjectStorage|null
+     */
+    private $parsedCatalogues;
+
     public function get($key, array $replace = [], $locale = null)
     {
         return $this->trans($key, $replace, null, $locale);
@@ -39,16 +50,16 @@ class Translator extends BaseTranslator implements TranslatorContract
             $this->assertValidLocale($locale);
         }
 
-        $parse = ! isset($this->catalogues[$locale]);
-
         $catalogue = parent::getCatalogue($locale);
 
-        if ($parse) {
-            $this->parseCatalogue($catalogue);
+        if ($this->parsedCatalogues === null) {
+            $this->parsedCatalogues = new \SplObjectStorage();
+        }
 
-            $fallbackCatalogue = $catalogue;
-            while ($fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue()) {
-                $this->parseCatalogue($fallbackCatalogue);
+        for ($current = $catalogue; $current !== null; $current = $current->getFallbackCatalogue()) {
+            if (! $this->parsedCatalogues->contains($current)) {
+                $this->parseCatalogue($current);
+                $this->parsedCatalogues->attach($current);
             }
         }
 

--- a/framework/core/tests/unit/Locale/TranslatorReferenceResolutionTest.php
+++ b/framework/core/tests/unit/Locale/TranslatorReferenceResolutionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Locale;
+
+use Flarum\Locale\PrefixedYamlFileLoader;
+use Flarum\Locale\Translator;
+use Flarum\Testing\unit\TestCase;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+class TranslatorReferenceResolutionTest extends TestCase
+{
+    private const DOMAIN = 'messages'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cacheDir = sys_get_temp_dir().'/flarum-translator-test-'.uniqid('', true);
+        mkdir($this->cacheDir);
+
+        file_put_contents($this->cacheDir.'/en.yml', "foo: '=> bar'\nbar: Resolved\n");
+        file_put_contents($this->cacheDir.'/de.yml', "baz: Beispiel\n");
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob($this->cacheDir.'/*') ?: []);
+        rmdir($this->cacheDir);
+
+        parent::tearDown();
+    }
+
+    private function translator(): Translator
+    {
+        // Wired like LocaleServiceProvider: non-debug, cache dir, 'en' fallback.
+        $translator = new Translator('de', null, $this->cacheDir, false);
+        $translator->setFallbackLocales(['en']);
+        $translator->addLoader('prefixed_yaml', new PrefixedYamlFileLoader());
+        $translator->addResource('prefixed_yaml', ['file' => $this->cacheDir.'/en.yml', 'prefix' => ''], 'en', self::DOMAIN);
+        $translator->addResource('prefixed_yaml', ['file' => $this->cacheDir.'/de.yml', 'prefix' => ''], 'de', self::DOMAIN);
+
+        return $translator;
+    }
+
+    public function test_references_are_resolved_when_locale_is_loaded_directly()
+    {
+        $translator = $this->translator();
+
+        $this->assertSame('Resolved', $translator->getCatalogue('en')->get('foo', 'messages'));
+    }
+
+    public function test_references_are_resolved_when_locale_was_first_loaded_as_a_fallback()
+    {
+        $translator = $this->translator();
+
+        // Loading 'de' makes Symfony implicitly load and store the 'en'
+        // catalogue as its fallback, before 'en' is ever requested directly.
+        $translator->getCatalogue('de');
+
+        $this->assertSame('Resolved', $translator->getCatalogue('en')->get('foo', 'messages'));
+    }
+
+    public function test_references_are_resolved_in_fallback_catalogues()
+    {
+        $translator = $this->translator();
+
+        $fallback = $translator->getCatalogue('de')->getFallbackCatalogue();
+
+        $this->assertSame('Resolved', $fallback->get('foo', 'messages'));
+        $this->assertSame('Resolved', $translator->trans('foo', [], null, 'de'));
+    }
+}


### PR DESCRIPTION
Backport of #5023 to `1.x`. See that PR for the full write-up; summary below.

## Symptom

Compiled locale JS assets (e.g. `admin-en.js`) sometimes contain **unresolved translation references** — literal values like:

```json
"core.admin.nav.dashboard_button":"=> core.admin.dashboard.title"
```

so the admin UI displays raw `=> core.admin.…` strings. Only the **fallback locale** (`en`) is affected; the poisoned compiled asset persists until a cache flush (its revision exists, so it is never recompiled). Found in production on Flarum 1.8.19 (community.sbb.ch) and confirmed end-to-end there: touching `getCatalogue('de')` before recompiling the English admin locale asset deterministically produces the broken asset; removing that single line produces a clean one.

## Root cause

`Translator::getCatalogue()` gated `=>`-reference resolution on a **locale-keyed** flag (`! isset($this->catalogues[$locale])`). But Symfony's `Translator::loadFallbackCatalogues()` (symfony/translation v5.4), when loading any other locale, pre-stores the **original** `en` catalogue in `$this->catalogues['en']` while attaching only a **copy** to the requesting catalogue. Loading `de` first therefore stores a raw, never-parsed `en` original; a later `getCatalogue('en')` finds the locale already set, skips parsing, and returns it raw. `Flarum\Frontend\AddTranslations` then compiles the literal `=> …` strings into the locale JS asset.

Deterministic repro (locale `de`, fallback `['en']`, non-debug, cache dir — mirroring `LocaleServiceProvider`):

```php
$t->getCatalogue('en');
$t->getCatalogue('en')->get('core.admin.nav.dashboard_button'); // "Dashboard"            ✔

// fresh translator, fresh cache:
$t->getCatalogue('de');   // implicit fallback load of 'en'
$t->getCatalogue('en')->get('core.admin.nav.dashboard_button'); // "=> core.admin.dashboard.title"  ✘
```

## Fix

Track parsed state per catalogue **object** instead of per locale name, and walk the fallback chain on every `getCatalogue()` call — the raw stored original and its parsed copy share a locale name, so a locale-keyed flag cannot distinguish them. Per-object tracking parses each catalogue object exactly once; `parseCatalogue()` is unchanged.

Differences from the 2.x fix, for PHP 7.3 compatibility: `SplObjectStorage` (`contains()`/`attach()`) instead of `WeakMap`, untyped private property.

## Tests

New `TranslatorReferenceResolutionTest` (PHPUnit 9 style), wired like `LocaleServiceProvider`:

- `en` loaded directly → resolved (regression guard).
- `en` first loaded implicitly as `de`'s fallback, then requested directly → resolved (**failed before this fix** with `'=> bar'` vs `'Resolved'`).
- `de`'s attached fallback copy resolved, via `getFallbackCatalogue()` and `trans()` fallthrough (regression guard).

Full unit suite and PHPStan pass on `1.x`.

## Context

Surfaced while working on FriendsOfFlarum/redis#34 — multi-instance cache invalidation increases recompile frequency, raising exposure — but reproducible on a bare single-instance install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
