### PR TITLE
[2.x] pref(subscriptions): Separate subscription button and dropdown option labels

### DIFF
--- a/extensions/subscriptions/js/src/forum/components/SubscriptionMenu.tsx
+++ b/extensions/subscriptions/js/src/forum/components/SubscriptionMenu.tsx
@@ -16,19 +16,19 @@ export default class SubscriptionMenu<CustomAttrs extends ISubscriptionMenuAttrs
     {
       subscription: null,
       icon: <Icon name="fa-regular fa-star" className="Button-icon" noStyleOverride />,
-      label: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_button'),
+      label: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_option'),
       description: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_text'),
     },
     {
       subscription: 'follow',
       icon: <Icon name="fa-solid fa-star" className="Button-icon" noStyleOverride />,
-      label: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_button'),
+      label: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_option'),
       description: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_text'),
     },
     {
       subscription: 'ignore',
       icon: 'far fa-eye-slash',
-      label: app.translator.trans('flarum-subscriptions.forum.sub_controls.ignoring_button'),
+      label: app.translator.trans('flarum-subscriptions.forum.sub_controls.ignoring_option'),
       description: app.translator.trans('flarum-subscriptions.forum.sub_controls.ignoring_text'),
     },
   ];

--- a/extensions/subscriptions/locale/en.yml
+++ b/extensions/subscriptions/locale/en.yml
@@ -39,11 +39,13 @@ flarum-subscriptions:
     sub_controls:
       follow_button: => flarum-subscriptions.ref.follow
       following_button: => flarum-subscriptions.ref.following
-      following_text: Be notified of all replies.
       ignoring_button: => flarum-subscriptions.ref.ignoring
-      ignoring_text: Never be notified. Hide from the discussion list.
-      not_following_button: Not Following
+      not_following_option: Not Following
+      following_option: => flarum-subscriptions.ref.following
+      ignoring_option: => flarum-subscriptions.ref.ignoring
       not_following_text: "Be notified only when @mentioned."
+      following_text: Be notified of all replies.
+      ignoring_text: Never be notified. Hide from the discussion list.
       notify_alert_tooltip: Get a forum notification when there are new posts
       notify_email_tooltip: Get an email when there are new posts
 


### PR DESCRIPTION
Affected versions: based on 2.x at f194386 (Application::VERSION = 2.0.0-rc.8). 

**Pref**

**Changes proposed in this pull request:**

The main subscription button represent states (Not Following, Following, or Ignoring), and a default action to Unfollow, while the dropdown options  performs an action (Follow, Unfollow, or Unignore). Currently the same labels are also used for the main action button, which is difficult to i18n naturally in Chinese. So it is better to separate them.

I didn't change the labels of the dropdown options, in case the original wording is already appropriate in English.

**Screenshot**
<img width="470" height="377" alt="image" src="https://github.com/user-attachments/assets/1b4a2c69-4f41-4f99-8217-f8b860667882" />

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.