### PR TITLE
[2.x] feat: stop auth extensions having to fork core internals

### DIFF
--- a/framework/core/src/Extend/Middleware.php
+++ b/framework/core/src/Extend/Middleware.php
@@ -119,7 +119,7 @@ class Middleware implements ExtenderInterface
             foreach ($this->insertBeforeMiddlewares as $originalMiddleware => $newMiddleware) {
                 array_splice(
                     $existingMiddleware,
-                    array_search($originalMiddleware, $existingMiddleware),
+                    $this->offsetOf($originalMiddleware, $newMiddleware, $existingMiddleware),
                     0,
                     $newMiddleware
                 );
@@ -128,7 +128,7 @@ class Middleware implements ExtenderInterface
             foreach ($this->insertAfterMiddlewares as $originalMiddleware => $newMiddleware) {
                 array_splice(
                     $existingMiddleware,
-                    array_search($originalMiddleware, $existingMiddleware) + 1,
+                    $this->offsetOf($originalMiddleware, $newMiddleware, $existingMiddleware) + 1,
                     0,
                     $newMiddleware
                 );
@@ -136,5 +136,29 @@ class Middleware implements ExtenderInterface
 
             return array_diff($existingMiddleware, $this->removeMiddlewares);
         });
+    }
+
+    /**
+     * Locate the anchor an insertion is relative to.
+     *
+     * Extenders run in extension order, so another extension may already have
+     * replaced or removed the anchor. Throwing beats defaulting to an offset: the
+     * front of the stack sits ahead of the error handler.
+     *
+     * @param array<string> $existingMiddleware
+     */
+    private function offsetOf(string $originalMiddleware, string $newMiddleware, array $existingMiddleware): int
+    {
+        $offset = array_search($originalMiddleware, $existingMiddleware, true);
+
+        if ($offset === false) {
+            throw new \InvalidArgumentException(
+                "Cannot insert middleware [$newMiddleware] relative to [$originalMiddleware]:"
+                ." it is not present in the [$this->frontend] middleware stack."
+                .' Another extension may have replaced or removed it, or it was never registered.'
+            );
+        }
+
+        return $offset;
     }
 }

--- a/framework/core/src/Forum/Auth/ResponseFactory.php
+++ b/framework/core/src/Forum/Auth/ResponseFactory.php
@@ -33,8 +33,11 @@ class ResponseFactory
      * @param string   $identifier            The provider's unique identifier for this user.
      * @param callable $configureRegistration Callback that populates a {@see Registration} instance
      *                                        with data from the provider (email, username, avatar, etc.).
-     * @param string   $returnTo              Validated same-origin URL to redirect to after login.
-     *                                        Must be validated by the caller before being passed here.
+     * @param string   $returnTo              Validated same-origin path to redirect to after login.
+     *                                        Must be validated by the caller — see
+     *                                        {@see \Flarum\Http\ReturnUrlValidator::validatePath()}, or
+     *                                        {@see \Flarum\Http\ReturnUrlValidator::validate()} for an
+     *                                        absolute URL on a host listed under `redirectDomains`.
      */
     public function make(
         string $provider,

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -9,9 +9,9 @@
 
 namespace Flarum\Forum\Controller;
 
-use Flarum\Foundation\Config;
 use Flarum\Http\Rememberer;
 use Flarum\Http\RequestUtil;
+use Flarum\Http\ReturnUrlValidator;
 use Flarum\Http\SessionAuthenticator;
 use Flarum\Http\UrlGenerator;
 use Flarum\User\Event\LoggedOut;
@@ -30,7 +30,7 @@ class LogOutController implements RequestHandlerInterface
         protected SessionAuthenticator $authenticator,
         protected Rememberer $rememberer,
         protected UrlGenerator $url,
-        protected Config $config
+        protected ReturnUrlValidator $returnUrl
     ) {
     }
 
@@ -61,30 +61,11 @@ class LogOutController implements RequestHandlerInterface
 
     protected function sanitizeReturnUrl(string $url, string $base): Uri
     {
-        if (empty($url)) {
-            return new Uri($base);
-        }
-
-        try {
-            $parsedUrl = new Uri($url);
-        } catch (\InvalidArgumentException) {
-            return new Uri($base);
-        }
-
-        if (in_array($parsedUrl->getHost(), $this->getAllowedRedirectDomains())) {
-            return $parsedUrl;
-        }
-
-        return new Uri($base);
+        return $this->returnUrl->sanitize($url, $base);
     }
 
     protected function getAllowedRedirectDomains(): array
     {
-        $forumUri = $this->config->url();
-
-        return array_merge(
-            [$forumUri->getHost()],
-            $this->config->offsetGet('redirectDomains') ?? []
-        );
+        return $this->returnUrl->allowedHosts();
     }
 }

--- a/framework/core/src/Forum/Controller/LogOutViewController.php
+++ b/framework/core/src/Forum/Controller/LogOutViewController.php
@@ -9,8 +9,8 @@
 
 namespace Flarum\Forum\Controller;
 
-use Flarum\Foundation\Config;
 use Flarum\Http\RequestUtil;
+use Flarum\Http\ReturnUrlValidator;
 use Flarum\Http\UrlGenerator;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
@@ -26,7 +26,7 @@ class LogOutViewController implements RequestHandlerInterface
     public function __construct(
         protected Factory $view,
         protected UrlGenerator $url,
-        protected Config $config
+        protected ReturnUrlValidator $returnUrl
     ) {
     }
 
@@ -55,30 +55,11 @@ class LogOutViewController implements RequestHandlerInterface
 
     protected function sanitizeReturnUrl(string $url, string $base): Uri
     {
-        if (empty($url)) {
-            return new Uri($base);
-        }
-
-        try {
-            $parsedUrl = new Uri($url);
-        } catch (\InvalidArgumentException) {
-            return new Uri($base);
-        }
-
-        if (in_array($parsedUrl->getHost(), $this->getAllowedRedirectDomains())) {
-            return $parsedUrl;
-        }
-
-        return new Uri($base);
+        return $this->returnUrl->sanitize($url, $base);
     }
 
     protected function getAllowedRedirectDomains(): array
     {
-        $forumUri = $this->config->url();
-
-        return array_merge(
-            [$forumUri->getHost()],
-            $this->config->offsetGet('redirectDomains') ?? []
-        );
+        return $this->returnUrl->allowedHosts();
     }
 }

--- a/framework/core/src/Http/Middleware/AuthenticateWithSession.php
+++ b/framework/core/src/Http/Middleware/AuthenticateWithSession.php
@@ -32,7 +32,16 @@ class AuthenticateWithSession implements Middleware
         return $handler->handle($request);
     }
 
-    private function getActor(Session $session, Request $request): Guest|User
+    /**
+     * Resolve the actor this session belongs to.
+     *
+     * Extensions that need to validate a resolved actor against an external
+     * authority — an identity provider that may have revoked the upstream session
+     * since it was established — should override this, call `parent::getActor()`,
+     * and act on the result, rather than replacing the whole middleware and
+     * reimplementing the session-invalidation semantics below.
+     */
+    protected function getActor(Session $session, Request $request): Guest|User
     {
         if ($session->has('access_token')) {
             $token = AccessToken::findValid($session->get('access_token'));

--- a/framework/core/src/Http/RememberAccessToken.php
+++ b/framework/core/src/Http/RememberAccessToken.php
@@ -19,9 +19,11 @@ class RememberAccessToken extends AccessToken
 
     /**
      * Just a helper method so we can re-use the lifetime value which is protected.
+     *
+     * Resolved late so subclasses declaring their own `$lifetime` are honoured.
      */
     public static function rememberCookieLifeTime(): int
     {
-        return self::$lifetime;
+        return static::$lifetime;
     }
 }

--- a/framework/core/src/Http/Rememberer.php
+++ b/framework/core/src/Http/Rememberer.php
@@ -23,12 +23,16 @@ class Rememberer
 
     /**
      * Sets the remember cookie on a response.
+     *
+     * The lifetime comes off the token's own class, so a subclass declaring a
+     * different `$lifetime` gets a cookie that expires with the token instead of
+     * one outliving it.
      */
     public function remember(ResponseInterface $response, #[\SensitiveParameter] RememberAccessToken $token): ResponseInterface
     {
         return FigResponseCookies::set(
             $response,
-            $this->cookie->make(self::COOKIE_NAME, $token->token, RememberAccessToken::rememberCookieLifeTime())
+            $this->cookie->make(self::COOKIE_NAME, $token->token, $token::rememberCookieLifeTime())
         );
     }
 

--- a/framework/core/src/Http/ReturnUrlValidator.php
+++ b/framework/core/src/Http/ReturnUrlValidator.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Http;
+
+use Flarum\Foundation\Config;
+use Laminas\Diactoros\Uri;
+
+/**
+ * Validates caller-supplied URLs before Flarum redirects a browser to them.
+ *
+ * Two contracts, because the two places core accepts one differ in shape: an
+ * absolute URL checked against `redirectDomains` ({@see validate()}), and a
+ * same-origin relative path ({@see validatePath()}).
+ */
+class ReturnUrlValidator
+{
+    public function __construct(
+        protected Config $config
+    ) {
+    }
+
+    /**
+     * Hosts an absolute return URL is permitted to point at.
+     *
+     * @return list<string>
+     */
+    public function allowedHosts(): array
+    {
+        return array_values(array_merge(
+            [$this->config->url()->getHost()],
+            $this->config->offsetGet('redirectDomains') ?? []
+        ));
+    }
+
+    /**
+     * Validate an absolute return URL, or null if it is unusable.
+     *
+     * Relative paths are rejected here: they have no host to check, so they are
+     * indistinguishable from a protocol-relative URL pointing off-site once a
+     * browser resolves them. Use {@see validatePath()} for those.
+     */
+    public function validate(?string $url): ?Uri
+    {
+        if (empty($url)) {
+            return null;
+        }
+
+        try {
+            $uri = new Uri($url);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        if (! in_array($uri->getHost(), $this->allowedHosts(), true)) {
+            return null;
+        }
+
+        return $uri;
+    }
+
+    /**
+     * Validate an absolute return URL, falling back to the forum's base URL.
+     */
+    public function sanitize(?string $url, ?string $fallback = null): Uri
+    {
+        return $this->validate($url)
+            ?? new Uri($fallback ?? (string) $this->config->url());
+    }
+
+    /**
+     * Validate a same-origin relative path, falling back to `/`.
+     *
+     * Control characters are rejected alongside off-origin references, since the
+     * path reaches the browser inside a `Location` header.
+     */
+    public function validatePath(?string $path, string $fallback = '/'): string
+    {
+        if (empty($path)) {
+            return $fallback;
+        }
+
+        if (! str_starts_with($path, '/')
+            || str_starts_with($path, '//')
+            || str_contains($path, '://')
+            || preg_match('/[\x00-\x1F\x7F]/', $path) === 1
+        ) {
+            return $fallback;
+        }
+
+        return $path;
+    }
+}

--- a/framework/core/tests/unit/Extend/MiddlewareTest.php
+++ b/framework/core/tests/unit/Extend/MiddlewareTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Extend;
+
+use Flarum\Extend;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\Attributes\Test;
+
+class MiddlewareTest extends TestCase
+{
+    protected function stack(array $middleware, Extend\Middleware $extender): array
+    {
+        $container = new Container();
+        $container->instance('flarum.forum.middleware', $middleware);
+
+        $extender->extend($container);
+
+        return array_values($container->make('flarum.forum.middleware'));
+    }
+
+    #[Test]
+    public function insert_before_places_the_middleware_ahead_of_its_anchor()
+    {
+        $this->assertEquals(['a', 'new', 'b'], $this->stack(
+            ['a', 'b'],
+            (new Extend\Middleware('forum'))->insertBefore('b', 'new')
+        ));
+    }
+
+    #[Test]
+    public function insert_after_places_the_middleware_behind_its_anchor()
+    {
+        $this->assertEquals(['a', 'new', 'b'], $this->stack(
+            ['a', 'b'],
+            (new Extend\Middleware('forum'))->insertAfter('a', 'new')
+        ));
+    }
+
+    #[Test]
+    public function insert_before_a_missing_anchor_throws()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot insert middleware [new] relative to [gone]');
+
+        $this->stack(['a', 'b'], (new Extend\Middleware('forum'))->insertBefore('gone', 'new'));
+    }
+
+    #[Test]
+    public function insert_after_a_missing_anchor_throws()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('[forum] middleware stack');
+
+        $this->stack(['a', 'b'], (new Extend\Middleware('forum'))->insertAfter('gone', 'new'));
+    }
+
+    #[Test]
+    public function inserting_relative_to_an_anchor_another_extender_replaced_throws()
+    {
+        // The realistic case: two extensions touching the same region of the stack,
+        // applied in extension order.
+        $this->expectException(\InvalidArgumentException::class);
+
+        $container = new Container();
+        $container->instance('flarum.forum.middleware', ['a', 'b']);
+
+        (new Extend\Middleware('forum'))->replace('b', 'replacement')->extend($container);
+        (new Extend\Middleware('forum'))->insertAfter('b', 'new')->extend($container);
+
+        $container->make('flarum.forum.middleware');
+    }
+
+    #[Test]
+    public function removing_a_missing_middleware_is_still_a_no_op()
+    {
+        $this->assertEquals(['a', 'b'], $this->stack(
+            ['a', 'b'],
+            (new Extend\Middleware('forum'))->remove('gone')
+        ));
+    }
+}

--- a/framework/core/tests/unit/Http/RemembererTest.php
+++ b/framework/core/tests/unit/Http/RemembererTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Http;
+
+use Dflydev\FigCookies\FigResponseCookies;
+use Flarum\Foundation\Config;
+use Flarum\Http\CookieFactory;
+use Flarum\Http\RememberAccessToken;
+use Flarum\Http\Rememberer;
+use Flarum\Testing\unit\TestCase;
+use Laminas\Diactoros\Response\EmptyResponse;
+use PHPUnit\Framework\Attributes\Test;
+
+class RemembererTest extends TestCase
+{
+    protected function rememberer(): Rememberer
+    {
+        return new Rememberer(new CookieFactory(new Config(['url' => 'http://flarum.test'])));
+    }
+
+    protected function token(string $class): RememberAccessToken
+    {
+        $token = new $class;
+        $token->token = 'a-remember-token';
+
+        return $token;
+    }
+
+    #[Test]
+    public function remember_cookie_uses_the_default_token_lifetime()
+    {
+        $response = $this->rememberer()->remember(
+            new EmptyResponse(),
+            $this->token(RememberAccessToken::class)
+        );
+
+        $cookie = FigResponseCookies::get($response, 'flarum_remember');
+
+        $this->assertEquals('a-remember-token', $cookie->getValue());
+        $this->assertEquals(5 * 365 * 24 * 60 * 60, $cookie->getMaxAge());
+    }
+
+    #[Test]
+    public function remember_cookie_uses_a_subclass_lifetime()
+    {
+        $response = $this->rememberer()->remember(
+            new EmptyResponse(),
+            $this->token(ShortLivedRememberAccessToken::class)
+        );
+
+        $this->assertEquals(
+            7 * 24 * 60 * 60,
+            FigResponseCookies::get($response, 'flarum_remember')->getMaxAge()
+        );
+    }
+}
+
+class ShortLivedRememberAccessToken extends RememberAccessToken
+{
+    public static string $type = 'session_remember_short';
+
+    protected static int $lifetime = 7 * 24 * 60 * 60;
+}

--- a/framework/core/tests/unit/Http/ReturnUrlValidatorTest.php
+++ b/framework/core/tests/unit/Http/ReturnUrlValidatorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Http;
+
+use Flarum\Foundation\Config;
+use Flarum\Http\ReturnUrlValidator;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ReturnUrlValidatorTest extends TestCase
+{
+    protected function validator(?array $config = null): ReturnUrlValidator
+    {
+        return new ReturnUrlValidator(new Config(array_merge([
+            'url' => 'http://flarum.test'
+        ], $config ?? [])));
+    }
+
+    #[Test]
+    public function allowed_hosts_default_to_the_forum_host()
+    {
+        $this->assertEquals(['flarum.test'], $this->validator()->allowedHosts());
+    }
+
+    #[Test]
+    public function allowed_hosts_include_configured_redirect_domains()
+    {
+        $hosts = $this->validator(['redirectDomains' => ['idp.example', 'app.example']])->allowedHosts();
+
+        $this->assertEquals(['flarum.test', 'idp.example', 'app.example'], $hosts);
+    }
+
+    #[Test]
+    public function urls_on_the_forum_host_are_accepted()
+    {
+        $uri = $this->validator()->validate('http://flarum.test/d/1-hello');
+
+        $this->assertNotNull($uri);
+        $this->assertEquals('http://flarum.test/d/1-hello', (string) $uri);
+    }
+
+    #[Test]
+    public function urls_on_a_configured_redirect_domain_are_accepted()
+    {
+        $uri = $this->validator(['redirectDomains' => ['idp.example']])
+            ->validate('https://idp.example/logout?next=1');
+
+        $this->assertNotNull($uri);
+        $this->assertEquals('https://idp.example/logout?next=1', (string) $uri);
+    }
+
+    #[Test]
+    public function urls_on_any_other_host_are_rejected()
+    {
+        $this->assertNull($this->validator()->validate('https://evil.example/steal'));
+    }
+
+    #[Test]
+    public function relative_paths_are_rejected_by_validate()
+    {
+        // They carry no host to check against the allow list, so they belong to
+        // validatePath() instead.
+        $this->assertNull($this->validator()->validate('/d/1-hello'));
+    }
+
+    #[Test]
+    public function unparseable_and_empty_urls_are_rejected()
+    {
+        $this->assertNull($this->validator()->validate('http://'));
+        $this->assertNull($this->validator()->validate(''));
+        $this->assertNull($this->validator()->validate(null));
+    }
+
+    #[Test]
+    public function sanitize_falls_back_to_the_forum_url()
+    {
+        $this->assertEquals(
+            'http://flarum.test',
+            (string) $this->validator()->sanitize('https://evil.example')
+        );
+    }
+
+    #[Test]
+    public function sanitize_honours_an_explicit_fallback()
+    {
+        $this->assertEquals(
+            'http://flarum.test/base',
+            (string) $this->validator()->sanitize('https://evil.example', 'http://flarum.test/base')
+        );
+    }
+
+    #[Test]
+    public function same_origin_paths_are_accepted_by_validate_path()
+    {
+        $validator = $this->validator();
+
+        $this->assertEquals('/', $validator->validatePath('/'));
+        $this->assertEquals('/d/1-hello', $validator->validatePath('/d/1-hello'));
+        $this->assertEquals('/d/1?page=2', $validator->validatePath('/d/1?page=2'));
+    }
+
+    #[Test]
+    public function off_origin_paths_are_rejected_by_validate_path()
+    {
+        $validator = $this->validator();
+
+        $this->assertEquals('/', $validator->validatePath('//evil.example'));
+        $this->assertEquals('/', $validator->validatePath('https://evil.example'));
+        $this->assertEquals('/', $validator->validatePath('d/1-hello'));
+        $this->assertEquals('/', $validator->validatePath("/d/1\r\nLocation: https://evil.example"));
+        $this->assertEquals('/', $validator->validatePath(''));
+        $this->assertEquals('/', $validator->validatePath(null));
+    }
+
+    #[Test]
+    public function validate_path_honours_an_explicit_fallback()
+    {
+        $this->assertEquals('/all', $this->validator()->validatePath('https://evil.example', '/all'));
+    }
+}


### PR DESCRIPTION
**Fixes** four places where an extension that authenticates against an external identity provider has to copy or replace core internals to do so. 

**Changes proposed in this pull request:**

One commit per gap; they're independent and can be dropped individually.

**1. `Extend\Middleware` silently mis-inserts when its anchor is gone** (`fix`)

```php
array_splice($existingMiddleware, array_search($originalMiddleware, $existingMiddleware), 0, $newMiddleware);
```

`array_search()` returns `false` when the anchor was already replaced or removed by an earlier extender, and `array_splice()` reads `false` as offset 0. So `insertAfter(AuthenticateWithSession::class, …)` lands the middleware at the very front of the stack — ahead of `HandleErrors`, where nothing it throws can be reported — and nothing says so.

This is reachable with two ordinary extensions: one `replace()`s a middleware, the other `insertAfter()`s the same class, and whichever loads second gets moved to position 0. Insertions now throw with the frontend, the anchor and the middleware named. `remove()` keeps its no-op semantics for an absent entry; only insertions need an anchor to exist. Comparison is also now strict.

**2. No return-URL validator, in three different flavours** (`feat`)

`ResponseFactory::make()` documents `$returnTo` as "must be validated by the caller before being passed here" and ships nothing to validate it with, while `LogOutController` and `LogOutViewController` each carry an identical private copy of a host allow-list check. Third-party OAuth controllers have filled the gap independently — one accepts relative paths only, another compares against a hard-coded host list — so there are currently three unrelated security models for the same parameter.

`Flarum\Http\ReturnUrlValidator` covers both shapes core accepts: `validate()`/`sanitize()` for an absolute URL checked against the forum host plus `redirectDomains`, which is what `?return=` on the logout endpoints takes, and `validatePath()` for the same-origin relative path `ResponseFactory` expects. Both logout controllers delegate to it and keep `sanitizeReturnUrl()`/`getAllowedRedirectDomains()` as protected shims.

Behaviour is deliberately unchanged: `validate()` still rejects relative paths, because they carry no host to check and a browser resolves `//host` off-site.

**3. The remember cookie ignores its token's lifetime** (`fix`)

`Rememberer::remember()` hardcoded `RememberAccessToken::rememberCookieLifeTime()` regardless of the token it was handed, and that method resolved `self::$lifetime` rather than `static::$lifetime`. A subclass declaring its own `$lifetime` therefore changed when the token stopped being valid but not when the cookie expired, so the browser kept presenting a dead token for up to the five-year default. Two bugs pointing the same way, and between them a documented-looking seam that silently does nothing.

The lifetime now comes off the token instance's class and resolves late. Relevant to any login that inherits `session_remember` from an external authority whose own session is nowhere near five years long — which is every OAuth login today, since `ResponseFactory` mints a `RememberAccessToken` for all of them.

**4. `AuthenticateWithSession::getActor()` is private** (`feat`)

An extension that needs to check a resolved actor against an external authority — an identity provider that may have revoked the upstream session since this one was established — has to `replace()` the whole middleware and reimplement the body, including the `$session->invalidate()` / `regenerateToken()` path taken when a token is no longer valid. That copy then diverges from core silently on every change to it. Now `protected`, so such an extension overrides it, calls `parent::getActor()`, and acts on the result.

**Reviewers should focus on:**

- **The throw in (1) is a behaviour change on upgrade.** An extension that mis-inserts today does so silently; after this it fails at boot. That is the point, but it converts a quiet misordering into a hard failure for a forum that currently "works". The alternatives are logging and appending, or logging and skipping — both leave the extension's middleware somewhere it didn't ask for. Happy to switch if you'd rather not break a boot during RC.
- **Two of the four commits are additive**, and I'm aware `2.x` is bug-fix-only until GA. (1) and (3) are fixes; (2) and (4) add surface. Say the word and I'll pull the additive pair onto a separate PR for 2.1 and leave the two fixes here.
- **`LogOutController` and `LogOutViewController` constructor signatures change** — `Config` out, `ReturnUrlValidator` in, since `Config` was only there for the allow-list. Both are container-resolved and nothing in the monorepo instantiates them directly, and the protected methods still work for subclasses, but it is a signature change.
- **Whether `ResponseFactory::make()` should validate `$returnTo` itself** rather than documenting that its caller must. I left the contract as-is because existing OAuth extensions already validate before calling and double-validation would silently narrow what they accept, but "core hands you a documented obligation and no tool" is arguably the wrong default and this PR only fixes the missing tool.
- **Whether the logout endpoints should accept a relative `?return=`.** They reject one today — `validate()` preserves that — but a same-origin path is the obvious common case and is strictly safer than the absolute URLs they do accept. Out of scope here; flagging it because the new `validatePath()` makes it a two-line change if you want it.

**Screenshot**

Not applicable — no user-facing or visual change.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — four cases where core's own extension points either misbehave silently, don't exist, or exist and don't work. (1) and (3) are defects on their own terms, independent of who is extending what.
- [x] If applicable, have various options for solving this problem been considered? — for (2) the alternative was leaving the duplicated private helpers alone and documenting the expected shape, which is what produced three incompatible implementations downstream. For (4) the alternative was a `flarum.http.session_actor_resolvers` tagged list; `protected` is the smaller change and can grow into one later if a second use case turns up. For (1) see the first bullet above.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — all four are in core classes: an extender, a middleware, `Rememberer`, and two controllers. None is reachable from an extension without replacing or copying the class.
- [x] Are we willing to maintain this for years / potentially forever? — (1), (3) and (4) remove special cases rather than adding any. (2) adds one small class whose behaviour is already implemented twice in the same repo, so the maintenance surface is going down, not up.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation. — no frontend changes.
- [ ] Frontend changes: tests are green (run `yarn test` in `js/`). — no frontend changes.
- [ ] Frontend changes: tests have been added, or are not appropriate here. — no frontend changes.
- [ ] Backend changes: tests are green (run `composer test`). — **partially**: I ran the unit suite only (`phpunit -c tests/phpunit.unit.xml`), not the integration suite, which needs a database I don't have provisioned. 
- [x] Backend changes: tests have been added, or are not appropriate here. — 20 unit tests across three new files, listed below.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no schema, no migration, no queries touched.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**On the tests**

Three new unit files, 20 tests:

- `tests/unit/Extend/MiddlewareTest.php` (6) — `insertBefore`/`insertAfter` placement, the throw for a missing anchor in both directions, the two-extender case where one `replace()`s the anchor the other inserts against, and that `remove()` is still a no-op for an absent entry. Core had no unit coverage of this extender; the integration `extenders/MiddlewareTest` covers placement through a real request but not the missing-anchor path.
- `tests/unit/Http/ReturnUrlValidatorTest.php` (12) — the allow list, acceptance and rejection for both contracts, unparseable and empty input, the explicit fallbacks, and a CRLF payload against `validatePath()`.
- `tests/unit/Http/RemembererTest.php` (2) — the default lifetime and a subclass lifetime, which is the one that fails before this change.

**Required changes:**

- [ ] Related documentation PR: `ReturnUrlValidator` should be mentioned wherever `$returnTo` is documented for OAuth authors — the 2.0 upgrade guide currently tells them to validate it without saying with what. Happy to open that once the shape here is settled. While checking, I also noticed `redirectDomains` isn't documented in `config.md` at all, and it's the allow list this validator reads.
