### PR TITLE
[2.x] fix(akismet): allow the api key setting to be null

### DIFF
--- a/extensions/akismet/src/Akismet.php
+++ b/extensions/akismet/src/Akismet.php
@@ -35,7 +35,7 @@ class Akismet
     private ?ClientInterface $client;
 
     public function __construct(
-        private readonly string $apiKey,
+        private readonly ?string $apiKey,
         string $homeUrl,
         private readonly string $flarumVersion,
         private readonly string $extensionVersion,
@@ -43,7 +43,7 @@ class Akismet
         ?ClientInterface $client = null
     ) {
         $this->client = $client;
-        $this->params['api_key'] = $apiKey;
+        $this->params['api_key'] = $apiKey ?? '';
         $this->params['blog'] = $homeUrl;
 
         if ($inDebugMode) {

--- a/extensions/akismet/tests/integration/SaveKeyOnFreshInstallTest.php
+++ b/extensions/akismet/tests/integration/SaveKeyOnFreshInstallTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Akismet\Tests\integration;
+
+use Flarum\Akismet\Akismet;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * On a fresh install no api_key setting exists yet, so the container resolves
+ * Akismet with a null key. The service must tolerate that: the settings save
+ * that stores the very first key resolves Akismet *before* the key is written
+ * (ValidateApiKey takes it as a constructor dependency), so a non-nullable
+ * constructor made it impossible to ever save one (flarum/framework#5029).
+ *
+ * Deliberately uses the real provider rather than the Guzzle fake, because the
+ * failure is in construction, not in any request.
+ */
+class SaveKeyOnFreshInstallTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-flags', 'flarum-approval', 'flarum-akismet');
+
+        $this->prepareDatabase([
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    #[Test]
+    public function akismet_resolves_when_no_api_key_has_ever_been_saved()
+    {
+        $this->app();
+
+        // No flarum-akismet.api_key row exists at all.
+        $akismet = $this->app()->getContainer()->make(Akismet::class);
+
+        $this->assertFalse($akismet->isConfigured());
+    }
+
+    #[Test]
+    public function saving_the_first_api_key_does_not_error()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['flarum-akismet.api_key' => 'a-first-key'],
+            ])
+        );
+
+        $this->assertNotEquals(500, $response->getStatusCode(), (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
**Fixes #5029**

**Changes proposed in this pull request:**

`Akismet::__construct()` accepts a null API key.

`ValidateApiKey` takes `Akismet` as a constructor dependency, so the container has to build it before the listener body runs — at which point the submitted key exists only in the `Saving` event payload and `$settings->get('flarum-akismet.api_key')` is still `null`. The constructor declared `private readonly string $apiKey`, so the save threw:

```
TypeError: Flarum\Akismet\Akismet::__construct(): Argument #1 ($apiKey)
must be of type string, null given
```

That made it a catch-22: the only way to save a first key was to already have one saved. A fresh install could never configure Akismet, while a forum that already had a key stored was unaffected — which matches every detail of the report, including that `migrate` doesn't help, a direct DB insert does, and rc.5 works.

Introduced by #4884, which added the listener and the typed constructor.

`isConfigured()` already tests with `! empty()`, so a null key correctly reports as unconfigured; the `?? ''` keeps the outgoing request params well-typed.

**Reviewers should focus on:**

- Whether nullable is the right shape versus defaulting to `''` in `AkismetProvider`. Nullable keeps "never configured" distinguishable from "explicitly cleared" at the type level, and matches what the settings repository actually returns.
- Whether `ValidateApiKey` should resolve `Akismet` lazily instead. That would also fix this, and arguably belongs in a follow-up — but it leaves the constructor lying about what the settings repository can hand it, so this seemed the more honest fix.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — Akismet cannot be configured on a fresh install, per #5029.
- [x] If applicable, have various options for solving this problem been considered? — see above; a lazy resolve in the listener is the alternative.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the bundled akismet extension is where the constructor lives.
- [x] Are we willing to maintain this for years / potentially forever? — it removes a wrong type annotation.

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`). — akismet 13 unit / 16 integration, `analyse:phpstan` clean, core 446 unit.
- [x] Backend changes: tests have been added, or are not appropriate here. — `SaveKeyOnFreshInstallTest`.
- [ ] Frontend changes: n/a — no frontend changes.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**On the tests**

Written first, and both fail on `2.x` today: resolving `Akismet` from the container with no key ever saved, and `POST /api/settings` with the first key, which returns the reporter's 500 verbatim. 14 pre-existing akismet integration tests pass throughout, so the two reds were the new ones only.

The new test deliberately uses the real provider rather than `FakeAkismetProvider`. That is why the existing `VerifyKeySettingTest` never caught this: the fake rebinds `Akismet` onto a mocked Guzzle client, so the null never reaches the real constructor. The failure is in construction, not in any request.
