### PR TITLE
[2.x] fix(tags): stop wrapping the tag link's contents in list items

### DIFF
--- a/extensions/tags/js/src/forum/components/TagLinkButton.tsx
+++ b/extensions/tags/js/src/forum/components/TagLinkButton.tsx
@@ -3,7 +3,6 @@ import Link from 'flarum/common/components/Link';
 import LinkButton from 'flarum/common/components/LinkButton';
 import classList from 'flarum/common/utils/classList';
 import ItemList from 'flarum/common/utils/ItemList';
-import listItems from 'flarum/common/helpers/listItems';
 import type Mithril from 'mithril';
 
 import tagIcon from '../../common/helpers/tagIcon';
@@ -17,7 +16,7 @@ export default class TagLinkButton extends LinkButton {
 
     return (
       <Link className={className} href={this.attrs.route} style={tag ? { '--color': tag.color() } : undefined} title={description || undefined}>
-        {listItems(this.linkItems(tag).toArray())}
+        {this.linkItems(tag).toArray()}
       </Link>
     );
   }


### PR DESCRIPTION
**Fixes #5031**

**Changes proposed in this pull request:**

`TagLinkButton` renders its contents without wrapping them in list items.

The component renders an `<a>`, but built its contents with `listItems()`, whose wrapper tag defaults to `'li'`. So each tag link contained:

```html
<a class="TagLinkButton hasIcon">
  <li class="item-icon"><i class="icon fa-regular fa-code Button-icon"></i></li>
  <li class="item-label"><span class="Button-label">Dev</span></li>
</a>
```

`<li>` is only valid inside a `ul`, `ol` or `menu`, so these have no valid parent in the chain. Assistive technology announces a list inside the link, and markup validators and a11y test suites flag it.

`ItemList.toArray()` already attaches `itemName` to each item, so rendering the array directly keeps `linkItems()` extensible — which is what #4755 added it for — while restoring the flat markup 1.x produced:

```html
<a class="TagLinkButton hasIcon">
  <i class="icon fa-regular fa-comments Button-icon"></i>
  <span class="Button-label">General</span>
</a>
```

**On the cause:** the issue suggests #5000, but that PR only changed how `ItemList.toArray()` handles null content and touches no markup. This came from #4755, which converted the component to TSX with an extensible `linkItems` list and reached for `listItems()` to render it. `listItems` is present in `TagLinkButton` at rc.4, rc.5, rc.6, rc.7 and rc.8, so the markup has been like this since rc.4 rather than being new in rc.8.

**Reviewers should focus on:**

- Whether anything downstream depends on the `item-icon` / `item-label` classes those wrappers carried. Nothing in this repo does — no selector in `extensions/tags/less` references them — but a theme could.
- Whether the outer `<li class="item-tag4">` is still correct. It is: that one comes from the *navigation* list rendering the links, and remains a direct child of the sidebar's `<ul>`.

**Screenshot**

Not applicable — no visual change; the icon and label render identically. The change is in the element names around them, as above.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained? — invalid `<li>` inside the tag link's `<a>`, per #5031.
- [x] If applicable, have various options for solving this problem been considered? — `listItems()` accepts a `customTag`, so passing e.g. `'span'` would also remove the `<li>`. That keeps a wrapper element per item for no benefit here; the button's contents are not a list and do not need one.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the component is in the bundled tags extension.
- [x] Are we willing to maintain this for years / potentially forever? — it removes a wrapper rather than adding anything.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation. — see below.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`). — tags 83 suites / 476 tests, core 82 suites / 467 tests; `check-typings` and `prettier --check` clean.
- [ ] Frontend changes: tests have been added, or are not appropriate here. — no test added; see below.
- [ ] Backend changes: tests are green (run `composer test`). — no backend changes.
- [ ] Backend changes: tests have been added, or are not appropriate here. — n/a.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [ ] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Verification**

Measured against a running forum rather than asserted, counting every `<li>` on the page whose immediate parent is not a `ul`, `ol` or `menu`:

| | invalid `<li>` | offending parent |
| --- | --- | --- |
| before | 36 | `a.TagLinkButton` |
| after | 0 | — |

Zero on the index, on the index with user-search results open, and on a discussion page. I rebuilt and re-checked with the change reverted to confirm the 36 came back, so the count tracks this change rather than something else on the page.

No test is added because the tags frontend suite cannot currently mount this component — its jest config stubs `TagHero` for the same reason, the ESM transform fails on the legacy `.js` helpers these components pull in. A markup assertion here would need that harness problem solved first, which is worth doing but is not this fix.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
