### PR TITLE
[2.x] fix: start a new account in the language its owner signed up in

### DIFF
--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -17,6 +17,7 @@ use Flarum\Bus\Dispatcher;
 use Flarum\Foundation\ValidationException;
 use Flarum\Group\Group;
 use Flarum\Http\SlugManager;
+use Flarum\Locale\LocaleManager;
 use Flarum\Locale\TranslatorInterface;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\AvatarUploader;
@@ -51,6 +52,7 @@ class UserResource extends AbstractDatabaseResource
         protected AvatarUploader $avatarUploader,
         protected AvatarValidator $imageValidator,
         protected Dispatcher $bus,
+        protected LocaleManager $locales,
     ) {
     }
 
@@ -77,6 +79,26 @@ class UserResource extends AbstractDatabaseResource
             $user = $this->slugManager->forResource(User::class)->fromSlug($id, $actor);
         } else {
             $user = $this->query($context)->findOrFail($id);
+        }
+
+        return $user;
+    }
+
+    public function newModel(\Tobyz\JsonApiServer\Context $context): object
+    {
+        $user = parent::newModel($context);
+
+        // Someone signing up has already chosen a language for the interface,
+        // so start their account in it: otherwise the activation email, which
+        // reads this preference, always goes out in the forum's default.
+        // An explicit `preferences.locale` in the request still wins, since
+        // fields are applied after this.
+        if ($context->getActor()->isGuest()) {
+            $locale = Arr::get($context->request->getCookieParams(), 'locale');
+
+            if ($locale && $this->locales->hasLocale($locale)) {
+                $user->setPreference('locale', $locale);
+            }
         }
 
         return $user;

--- a/framework/core/tests/integration/api/users/CreateTest.php
+++ b/framework/core/tests/integration/api/users/CreateTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tests\integration\api\users;
 
+use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -434,5 +435,55 @@ class CreateTest extends TestCase
             $this->assertEquals($regToken->user_attributes['username'], $user->username);
             $this->assertEquals($regToken->user_attributes['email'], $user->email);
         }
+    }
+
+    #[Test]
+    public function registering_records_the_locale_the_visitor_chose()
+    {
+        $this->app()->getContainer()->make(LocaleManager::class)->addLocale('de', 'Deutsch');
+
+        $response = $this->send(
+            $this->request('POST', '/api/users', [
+                'json' => ['data' => [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => 'wilhelm',
+                        'password' => 'too-obscure',
+                        'email' => 'wilhelm@machine.local',
+                    ],
+                ]],
+            ])->withCookieParams(['locale' => 'de'])
+                ->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), (string) $response->getBody());
+
+        $user = User::where('username', 'wilhelm')->firstOrFail();
+
+        $this->assertEquals('de', $user->getPreference('locale'));
+    }
+
+    #[Test]
+    public function registering_ignores_a_locale_the_forum_does_not_have()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users', [
+                'json' => ['data' => [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => 'ronald',
+                        'password' => 'too-obscure',
+                        'email' => 'ronald@machine.local',
+                    ],
+                ]],
+            ])->withCookieParams(['locale' => 'not-a-locale'])
+                ->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), (string) $response->getBody());
+
+        $user = User::where('username', 'ronald')->firstOrFail();
+
+        $this->assertNull($user->getPreference('locale'));
     }
 }


### PR DESCRIPTION
Fixes #5035.

Registration never records the locale the visitor was using, so `AccountActivationMailerTrait::sendConfirmationEmail()` finds no preference and falls back to the forum default:

```php
$locale = $user->getPreference('locale') ?? $this->settings->get('default_locale');
```

Someone who switches the interface to German and signs up therefore gets an English activation email.

A guest's language already lives in the `locale` cookie, which `Http\Middleware\SetLocale` reads for exactly this purpose. This carries it onto the new account when it names a locale the forum actually has.

- An explicit `preferences.locale` in the request still wins, because fields are applied after `newModel()`.
- Nothing changes for a visitor who never picked a language: no cookie, no preference, same behaviour as today.
- An unknown or invalid locale is ignored, guarded by `hasLocale()` the same way `SetLocale` guards it.
- Only self-registration is affected. The guest check means an admin creating an account through the API does not hand the new user their own interface language.

## Verified on a 2.x forum

A forum with a second language pack installed and the default left as English, registering as a guest carrying `locale=de`, reading the activation email out of the log mailer. Same forum and same pack for both runs, only the patch differs:

| | locale preference stored | activation email |
| --- | --- | --- |
| before | none | English, "Activate Your New Account" |
| after | `de` | German, from the pack |

## Tests

Two integration tests in `CreateTest`: registering with a `locale` cookie for a locale the forum has stores the preference, and registering with a locale it does not have stores nothing.

Worth noting for reviewers that `Extend\Locales` only registers translation files; the selectable list that `hasLocale()` consults comes from `Extend\LanguagePack` or `LocaleManager::addLocale()`. The test registers the locale on the booted app for that reason.