### PR TITLE
fix(testing): register extenders before enabling test extensions (#4600)

### DIFF
--- a/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -34,13 +34,17 @@ class OverrideExtensionManagerForTests implements ExtenderInterface
             $container->singleton(ExtensionManager::class, ExtensionManagerIncludeCurrent::class);
             $extensionManager = $container->make(ExtensionManager::class);
 
+            $extensionManager->booted = true;
+            $extensionManager->extend($container);
+
+            // Let enable() run instead of treating the test-selected extensions as already enabled.
+            $extensionManager->booted = false;
+
             foreach ($this->extensions as $extension) {
                 $extensionManager->enable($extension);
             }
 
             $extensionManager->booted = true;
-
-            $extensionManager->extend($container);
         }
     }
 }

--- a/php-packages/testing/tests/extend.php
+++ b/php-packages/testing/tests/extend.php
@@ -12,6 +12,7 @@ namespace Flarum\Testing;
 use Flarum\Extend;
 
 return [
+    new Extend\Locales(__DIR__.'/locale'),
     (new Extend\Settings)->serializeToForum('notARealSetting', 'not.a.real.setting'),
     (new Extend\Frontend('forum'))->route('/added-by-extension', 'added-by-extension')
 ];

--- a/php-packages/testing/tests/locale/en.yml
+++ b/php-packages/testing/tests/locale/en.yml
@@ -1,0 +1,2 @@
+flarum-testing-tests:
+  test: Translation from extension

--- a/php-packages/testing/tests/tests/integration/TestCaseTest.php
+++ b/php-packages/testing/tests/tests/integration/TestCaseTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Testing\Tests\integration;
 use Flarum\Extend;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Config;
+use Flarum\Locale\Translator;
 use Flarum\Settings\DefaultSettingsRepository;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\integration\TestCase;
@@ -119,6 +120,16 @@ class TestCaseTest extends TestCase
 
         $enabled = $this->app()->getContainer()->make('flarum.extensions')->isEnabled('flarum-testing-tests');
         $this->assertTrue($enabled);
+    }
+
+    #[Test]
+    public function current_extension_locales_applied_if_specified()
+    {
+        $this->extension('flarum-testing-tests');
+
+        $translator = $this->app()->getContainer()->make(Translator::class);
+
+        $this->assertEquals('Translation from extension', $translator->trans('flarum-testing-tests.test'));
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #4600.

`OverrideExtensionManagerForTests` was calling `enable()` on each test extension before calling `extend()`. Any extender that registers a `resolving()` callback during `extend()` — `Extend\Locales` does this for `LocaleManager` — never gets to fire, because `enable()` had already resolved that singleton via its `onEnable()` hook. A singleton only resolves once, so the callback registered afterward is too late. In practice this meant an extension's own locale files never loaded into the translator during integration tests; `$translator->trans('my-ext.some.key')` just echoed the key back instead of resolving it.

The obvious fix is to just swap the two calls, but that alone breaks something else: `ExtensionManagerIncludeCurrent::isEnabled()` returns `false` unconditionally while `booted` is `false`, specifically so that `enable()`'s early-return guard (`if ($this->isEnabled($name)) return;`) doesn't skip its own body — migrations, asset publishing, the `Enabling`/`Enabled` events, `onEnable()`. Flip `booted` to `true` before the `enable()` loop (which you'd need to do to call `extend()` first, since `extend()` only pulls extenders for already-enabled extensions) and `enable()` starts short-circuiting immediately, silently skipping all of that for every test extension.

So this toggles `booted` off again specifically around the `enable()` loop: `booted = true` → `extend()` (registers extenders, including `Locales`' `resolving()` callback) → `booted = false` → the `enable()` loop (now behaves exactly as it did before this change) → `booted = true` again.

Added a regression test: a fake extension in the testing package's own fixtures that ships a locale file via `Extend\Locales`, asserting its translation key resolves to the real string rather than being echoed back.

Verified with a disposable `php:8.3-cli` container (no persistent PHP/Composer in my normal setup): the new test fails against the old code exactly as described (`flarum-testing-tests.test` returned literally), and passes after the fix — ran the full `TestCaseTest` suite (15 tests, 24 assertions), including the existing migration and enabled-state tests, to make sure the `booted` toggling doesn't regress anything else in that file. Four unrelated tests in the same container failed on missing the `GD` PHP extension, unrelated to this change. Didn't touch 1.x — this worktree only has the 2.x version of the file, and the fix needs verifying separately there if you want it backported.
