### PR TITLE
[2.x] fix: look up frontends by name in AssetManager::frontend()

### DIFF
--- a/framework/core/src/Frontend/AssetManager.php
+++ b/framework/core/src/Frontend/AssetManager.php
@@ -29,7 +29,12 @@ class AssetManager
 
     public function frontend(string $frontend): Assets
     {
-        if (! in_array($frontend, $this->assets)) {
+        // Keyed by frontend name ('forum'), the value being the container
+        // abstract ('flarum.assets.forum') — so the guard must look at the
+        // keys. Checking the values instead rejected every registered
+        // frontend, while an abstract passed the guard and then resolved an
+        // undefined key.
+        if (! array_key_exists($frontend, $this->assets)) {
             throw new InvalidArgumentException("Unknown frontend: $frontend");
         }
 

--- a/framework/core/tests/unit/Frontend/AssetManagerTest.php
+++ b/framework/core/tests/unit/Frontend/AssetManagerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend;
+
+use Flarum\Frontend\AssetManager;
+use Flarum\Frontend\Assets;
+use Flarum\Locale\LocaleManager;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+class AssetManagerTest extends TestCase
+{
+    #[Test]
+    public function it_resolves_each_registered_frontend_by_name()
+    {
+        $forum = m::mock(Assets::class);
+        $admin = m::mock(Assets::class);
+        $common = m::mock(Assets::class);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('flarum.assets.forum')->andReturn($forum);
+        $container->shouldReceive('make')->with('flarum.assets.admin')->andReturn($admin);
+        $container->shouldReceive('make')->with('flarum.assets.common')->andReturn($common);
+
+        $manager = new AssetManager($container, m::mock(LocaleManager::class));
+
+        // Exactly what core registers: Forum/Admin/FrontendServiceProvider each
+        // map a frontend NAME to a container ABSTRACT.
+        $manager->register('forum', 'flarum.assets.forum');
+        $manager->register('admin', 'flarum.assets.admin');
+        $manager->register('common', 'flarum.assets.common');
+
+        $this->assertSame($forum, $manager->frontend('forum'));
+        $this->assertSame($admin, $manager->frontend('admin'));
+        $this->assertSame($common, $manager->frontend('common'));
+    }
+
+    #[Test]
+    public function it_resolves_a_frontend_registered_by_an_extension()
+    {
+        $assets = m::mock(Assets::class);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('flarum.assets.support')->andReturn($assets);
+
+        $manager = new AssetManager($container, m::mock(LocaleManager::class));
+        $manager->register('support', 'flarum.assets.support');
+
+        $this->assertSame($assets, $manager->frontend('support'));
+    }
+
+    #[Test]
+    public function it_rejects_an_unregistered_frontend()
+    {
+        $container = m::mock(Container::class);
+        $container->shouldNotReceive('make');
+
+        $manager = new AssetManager($container, m::mock(LocaleManager::class));
+        $manager->register('forum', 'flarum.assets.forum');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown frontend: nope');
+
+        $manager->frontend('nope');
+    }
+
+    #[Test]
+    public function it_does_not_mistake_a_container_abstract_for_a_frontend_name()
+    {
+        // The registry is keyed by frontend name, and the abstract is the VALUE.
+        // Looking a name up against the values would both reject every real
+        // frontend and accept an abstract as though it were one.
+        $container = m::mock(Container::class);
+        $container->shouldNotReceive('make');
+
+        $manager = new AssetManager($container, m::mock(LocaleManager::class));
+        $manager->register('forum', 'flarum.assets.forum');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown frontend: flarum.assets.forum');
+
+        $manager->frontend('flarum.assets.forum');
+    }
+
+    #[Test]
+    public function all_returns_every_registered_frontend_keyed_by_name()
+    {
+        $forum = m::mock(Assets::class);
+        $admin = m::mock(Assets::class);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('flarum.assets.forum')->andReturn($forum);
+        $container->shouldReceive('make')->with('flarum.assets.admin')->andReturn($admin);
+
+        $manager = new AssetManager($container, m::mock(LocaleManager::class));
+        $manager->register('forum', 'flarum.assets.forum');
+        $manager->register('admin', 'flarum.assets.admin');
+
+        $this->assertSame(['forum' => $forum, 'admin' => $admin], $manager->all());
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

`AssetManager::frontend()` has never worked. The registry is keyed by name — `register('forum', 'flarum.assets.forum')` — but the guard searched the values, so `frontend('forum')` throws "Unknown frontend: forum" for every registered frontend.

Pass an abstract instead and it's worse: the guard passes, the lookup misses, and you get a `TypeError` for returning null.

`array_key_exists` fixes both. Added a test — there wasn't one, hence the bug.

From b8e1718 (#3977). Nothing calls it, which is why nobody noticed.

Found by @gianniguida in FriendsOfFlarum/redis#41.

**Reviewers should focus on:**

Whether it should throw or return null. Nothing depends on it yet, so still free to change.

**Screenshot**

n/a, backend.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`) — 451/451, PHP 8.5.
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
