### PR TITLE
[2.x] fix: write settings in a single upsert

### DIFF
--- a/framework/core/src/Settings/DatabaseSettingsRepository.php
+++ b/framework/core/src/Settings/DatabaseSettingsRepository.php
@@ -34,11 +34,17 @@ class DatabaseSettingsRepository implements SettingsRepositoryInterface
 
     public function set(string $key, mixed $value): void
     {
-        $query = $this->database->table('settings')->where('key', $key);
-
-        $method = $query->exists() ? 'update' : 'insert';
-
-        $query->$method(compact('key', 'value'));
+        // A single statement, resolved against `key` — the table's primary key.
+        // Reading first and then choosing insert or update lets two concurrent
+        // writers both find the row missing and both insert it: one wins, the
+        // other fails on the primary key. That is reachable whenever several
+        // processes write the same setting for the first time at once, such as
+        // on a fresh deploy or in the requests following a cache clear.
+        $this->database->table('settings')->upsert(
+            compact('key', 'value'),
+            ['key'],
+            ['value']
+        );
     }
 
     public function delete(string $keyLike): void

--- a/framework/core/tests/unit/Settings/DatabaseSettingsRepositoryTest.php
+++ b/framework/core/tests/unit/Settings/DatabaseSettingsRepositoryTest.php
@@ -41,4 +41,51 @@ class DatabaseSettingsRepositoryTest extends TestCase
 
         $this->assertEquals('default', $this->repository->get('key', 'default'));
     }
+
+    public function test_setting_a_value_writes_it_in_a_single_statement()
+    {
+        // One upsert, keyed on the table's primary key. A read-then-write pair
+        // lets two writers both decide the row is missing and both insert it,
+        // and the loser gets a duplicate-key error rather than a stored value.
+        $table = m::mock();
+        $table->shouldReceive('upsert')
+            ->once()
+            ->with(['key' => 'foo', 'value' => 'bar'], ['key'], ['value'])
+            ->andReturn(1);
+
+        $table->shouldNotReceive('exists');
+        $table->shouldNotReceive('insert');
+        $table->shouldNotReceive('update');
+        $table->shouldNotReceive('where');
+
+        $this->connection->shouldReceive('table')->with('settings')->once()->andReturn($table);
+
+        $this->repository->set('foo', 'bar');
+    }
+
+    public function test_setting_a_null_value_is_stored_rather_than_skipped()
+    {
+        // `value` is nullable, and a null is a real stored setting — distinct
+        // from an absent row, which is what makes get() fall back to a default.
+        $table = m::mock();
+        $table->shouldReceive('upsert')
+            ->once()
+            ->with(['key' => 'foo', 'value' => null], ['key'], ['value'])
+            ->andReturn(1);
+
+        $this->connection->shouldReceive('table')->with('settings')->once()->andReturn($table);
+
+        $this->repository->set('foo', null);
+    }
+
+    public function test_deleting_matches_on_the_key()
+    {
+        $table = m::mock();
+        $table->shouldReceive('where')->once()->with('key', 'foo')->andReturnSelf();
+        $table->shouldReceive('delete')->once()->andReturn(1);
+
+        $this->connection->shouldReceive('table')->with('settings')->once()->andReturn($table);
+
+        $this->repository->delete('foo');
+    }
 }


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

`DatabaseSettingsRepository::set()` read the row, then chose insert or update:

```php
$query = $this->database->table('settings')->where('key', $key);

$method = $query->exists() ? 'update' : 'insert';

$query->$method(compact('key', 'value'));
```

Two processes writing the same absent key both see it missing, both insert, and all but one get a fatal:

```
UniqueConstraintViolationException: SQLSTATE[23000]: Integrity constraint
violation: 1062 Duplicate entry 'contended' for key 'settings.PRIMARY'
```

`key` is the primary key, so one `upsert()` on it does the whole thing in one statement. Six processes writing the same new key at once: 5 of 6 died before, 0 of 6 now.

This turns a crash into last-write-wins. It does not make concurrent settings writes *correct* — five values are still discarded, same as before, just without the 500. Worth having anyway: the realistic trigger is several pods writing the same default at once on a fresh deploy or after a cache clear, where every writer has the same value and nothing is lost.

**Reviewers should focus on:**

- `upsert()` writes only `value`, so nothing can rewrite `key`. Verified the compiled SQL on all four drivers — MySQL/MariaDB `on duplicate key update`, Postgres/SQLite `on conflict ("key") do update set`.
- `delete()` still uses `where('key', $keyLike)` with no `like`, despite the parameter name. Left alone — out of scope, but it's wrong or misnamed.
- A null `value` still stores a row, and `get()` still falls back to the default for it. Unchanged, and pinned by a test now.

**Screenshot**

n/a, backend.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`) — unit 454/454. Integration 905 tests, 2 pre-existing errors in `PasswordEmailTokensTest` (a local memory limit in `FinfoMimeTypeDetector`, identical with this change reverted).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — SQL checked on all four; behaviour run against MySQL 8.4 and SQLite.
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
