### PR TITLE
fix(extension-manager): stop re-checking for updates in the same process that ran composer update (#4764)

### DIFF
--- a/extensions/package-manager/src/Listener/ReCheckForUpdates.php
+++ b/extensions/package-manager/src/Listener/ReCheckForUpdates.php
@@ -13,7 +13,6 @@ use Flarum\Bus\Dispatcher;
 use Flarum\ExtensionManager\Command\CheckForUpdates;
 use Flarum\ExtensionManager\Event\FlarumUpdated;
 use Flarum\ExtensionManager\Extension\Event\Updated;
-use Flarum\ExtensionManager\Settings\LastUpdateCheck;
 use Flarum\ExtensionManager\Settings\LastUpdateRun;
 
 class ReCheckForUpdates
@@ -23,19 +22,13 @@ class ReCheckForUpdates
      */
     private $lastUpdateRun;
     /**
-     * @var LastUpdateCheck
-     */
-    private $lastUpdateCheck;
-
-    /**
      * @var Dispatcher
      */
     private $bus;
 
-    public function __construct(LastUpdateRun $lastUpdateRun, LastUpdateCheck $lastUpdateCheck, Dispatcher $bus)
+    public function __construct(LastUpdateRun $lastUpdateRun, Dispatcher $bus)
     {
         $this->lastUpdateRun = $lastUpdateRun;
-        $this->lastUpdateCheck = $lastUpdateCheck;
         $this->bus = $bus;
     }
 
@@ -44,25 +37,19 @@ class ReCheckForUpdates
      */
     public function handle($event): void
     {
-        $previousUpdateCheck = $this->lastUpdateCheck->get();
-
-        $lastUpdateCheck = $this->bus->dispatch(
-            new CheckForUpdates($event->actor)
-        );
-
         if ($event instanceof FlarumUpdated) {
-            $mapPackageName = function (array $package) {
-                return $package['name'];
-            };
-
-            $previousPackages = array_map($mapPackageName, $previousUpdateCheck['updates']['installed']);
-            $lastPackages = array_map($mapPackageName, $lastUpdateCheck['updates']['installed']);
-
+            // Composer replaced vendor files, so this process's stale autoloader cannot safely load new dependency classes.
             $this->lastUpdateRun
                 ->for($event->type)
                 ->with('status', LastUpdateRun::SUCCESS)
-                ->with('limitedPackages', array_intersect($previousPackages, $lastPackages))
+                ->with('limitedPackages', [])
                 ->save();
+
+            return;
         }
+
+        $this->bus->dispatch(
+            new CheckForUpdates($event->actor)
+        );
     }
 }

--- a/extensions/package-manager/tests/integration/api/MinorUpdateTest.php
+++ b/extensions/package-manager/tests/integration/api/MinorUpdateTest.php
@@ -81,14 +81,12 @@ class MinorUpdateTest extends TestCase
 
         /** @var LastUpdateRun $lastUpdateRun */
         $lastUpdateRun = $this->app()->getContainer()->make(LastUpdateRun::class);
+        $lastMinorUpdateRun = $lastUpdateRun->for(FlarumUpdated::MINOR)->get();
 
         $this->assertEquals(201, $response->getStatusCode());
         $this->assertPackageVersion('flarum/tags', '*');
         $this->assertPackageVersion('flarum/dummy-extension', '*');
-        $this->assertEquals([
-            'flarum/core',
-            'flarum/lang-english',
-            'flarum/tags'
-        ], $lastUpdateRun->for(FlarumUpdated::MINOR)->get()['limitedPackages']);
+        $this->assertEquals(LastUpdateRun::SUCCESS, $lastMinorUpdateRun['status']);
+        $this->assertEquals([], $lastMinorUpdateRun['limitedPackages']);
     }
 }

--- a/extensions/package-manager/tests/unit/ReCheckForUpdatesTest.php
+++ b/extensions/package-manager/tests/unit/ReCheckForUpdatesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\ExtensionManager\Tests\unit;
+
+use Flarum\Bus\Dispatcher;
+use Flarum\Extension\Extension;
+use Flarum\ExtensionManager\Command\CheckForUpdates;
+use Flarum\ExtensionManager\Event\FlarumUpdated;
+use Flarum\ExtensionManager\Extension\Event\Updated;
+use Flarum\ExtensionManager\Listener\ReCheckForUpdates;
+use Flarum\ExtensionManager\Settings\LastUpdateRun;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ReCheckForUpdatesTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('coreUpdateTypes')]
+    public function core_update_records_success_without_rechecking_for_updates(string $updateType): void
+    {
+        $settings = $this->createMock(SettingsRepositoryInterface::class);
+        $settings->expects($this->once())
+            ->method('set')
+            ->with(LastUpdateRun::key(), $this->callback(function (string $value) use ($updateType): bool {
+                $lastUpdateRun = json_decode($value, true)[$updateType];
+
+                return $lastUpdateRun['status'] === LastUpdateRun::SUCCESS
+                    && $lastUpdateRun['limitedPackages'] === [];
+            }));
+
+        $bus = $this->createMock(Dispatcher::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $listener = new ReCheckForUpdates(new LastUpdateRun($settings), $bus);
+        $listener->handle(new FlarumUpdated(new User(), $updateType));
+    }
+
+    public static function coreUpdateTypes(): array
+    {
+        return [
+            'global update' => [FlarumUpdated::GLOBAL],
+            'minor update' => [FlarumUpdated::MINOR],
+            'major update' => [FlarumUpdated::MAJOR],
+        ];
+    }
+
+    #[Test]
+    public function extension_update_still_rechecks_for_updates(): void
+    {
+        $actor = new User();
+        $bus = $this->createMock(Dispatcher::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (CheckForUpdates $command) use ($actor): bool {
+                return $command->actor === $actor;
+            }))
+            ->willReturn([]);
+
+        $listener = new ReCheckForUpdates(
+            $this->createStub(LastUpdateRun::class),
+            $bus
+        );
+        $listener->handle(new Updated($actor, new Extension(__DIR__, ['name' => 'acme/example'])));
+    }
+}


### PR DESCRIPTION
Fixes #4764.

`GlobalUpdateHandler`, `MinorUpdateHandler`, and `MajorUpdateHandler` all run `composer update` in-process — `ComposerAdapter::run()` calls Composer's own `Application::run()` directly rather than shelling out — then synchronously dispatch `FlarumUpdated`. `ReCheckForUpdates` responds to that by immediately dispatching `CheckForUpdates`, whose handler constructor-injects a Guzzle `Client`. Constructing that client touches whatever HTTP handler class Guzzle picks, and if the update just bumped Guzzle itself onto a version with a new class — `GuzzleHttp\Handler\CurlVersion`, added in 7.12.0 — the still-running process's autoloader has no idea that class exists yet, and it fatals mid-request. That's exactly the reported crash upgrading to v2.0.0-rc.4.

I looked at just queuing the recheck instead, since `Job\Dispatcher` already exists and is used for the outer `GlobalUpdate`/`CheckForUpdates` commands. It doesn't actually solve this: `Job\Dispatcher::dispatch()` only defers to the queue when the configured queue isn't `SyncQueue`, and Flarum defaults to `SyncQueue` for any install that hasn't set up Redis or a database queue — which just runs the job immediately, in the same process, identical to today. So for the common case (no queue configured), queuing wouldn't have changed anything.

The one process boundary that's reliable regardless of queue configuration is a fresh HTTP request. The frontend already does a full `window.location.reload()` after a synchronous global update succeeds (`ControlSectionState.ts`, `updateGlobally()`), which is a genuinely new PHP-FPM/php-cgi worker in essentially every real deployment.

So this skips the recheck entirely when handling `FlarumUpdated` — global, minor, and major core updates all share the identical in-process-composer-then-synchronous-dispatch shape, confirmed by reading all three handlers. The `Updated` event (single-extension installs) is untouched; that path wasn't reported broken and is a narrower composer operation on its own. `LastUpdateRun` still records the run as successful; the `limitedPackages` diff it used to compute by comparing before/after update-check results is left empty, since there's no safe way to get that comparison without constructing the Guzzle client in this same process. Happy to revisit if there's a way to compute it I'm missing, or if you'd rather see this handled differently — e.g. an explicit "recovery/recheck" action surfaced in the panel after a global update, or genuinely running composer in a subprocess instead of in-process, which would be a much bigger change.

Added a unit test covering all three `FlarumUpdated` types (asserting the bus is never dispatched for any of them, while `LastUpdateRun` still records success) and confirming the `Updated` path is untouched, and updated the one existing integration test that asserted on the old `limitedPackages` behavior.

Verified with a disposable `php:8.3-cli` container: the new unit test suite passes (4 tests, 14 assertions), and `php -l` on all three changed files. I couldn't get the actual integration-level "run composer update against a live fixture" test working in this environment — its fixture pins dependencies that only declare support through PHP 8.1, and Composer's current security-advisory check blocks installing that combination under PHP 8.3 here. That's a pre-existing limitation of the test fixture/environment, not something this change introduces, but I want to flag it rather than claim more verification than I actually got.
