### PR TITLE
[2.x] fix: rebuild dirty assets once, not once per request

### DIFF
--- a/framework/core/src/Api/Middleware/AddAssetsRevisionHeader.php
+++ b/framework/core/src/Api/Middleware/AddAssetsRevisionHeader.php
@@ -13,6 +13,7 @@ use Flarum\Frontend\Compiler\AssetsRevision;
 use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Container\Container;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -43,7 +44,8 @@ class AddAssetsRevisionHeader implements Middleware
         // not-yet-rebuilt manifest and never move for API-only clients, and no
         // reload prompt would appear until some unrelated visitor happened to
         // load a full page. The rebuild is in place and a no-op when the output
-        // is unchanged, so only the first request after a toggle pays for it.
+        // is unchanged, and it is guarded by an atomic lock, so one request
+        // pays for it while the rest keep serving the recorded revision.
         $this->recompileDirtyAssets();
 
         return $handler->handle($request)->withHeader(self::HEADER_NAME, $this->revision->token());
@@ -56,7 +58,8 @@ class AddAssetsRevisionHeader implements Middleware
                 $this->container->make($assets),
                 $this->container->make(LocaleManager::class),
                 $this->container->make('events'),
-                $this->container->make(SettingsRepositoryInterface::class)
+                $this->container->make(SettingsRepositoryInterface::class),
+                $this->container->make(CacheRepository::class)
             ))->recompileIfDirty();
         }
     }

--- a/framework/core/src/Frontend/Content/Assets.php
+++ b/framework/core/src/Frontend/Content/Assets.php
@@ -16,6 +16,7 @@ use Flarum\Frontend\Document;
 use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -74,7 +75,8 @@ class Assets
             $assets,
             $this->container->make(LocaleManager::class),
             $this->container->make('events'),
-            $this->container->make(SettingsRepositoryInterface::class)
+            $this->container->make(SettingsRepositoryInterface::class),
+            $this->container->make(CacheRepository::class)
         ))->recompileIfDirty();
     }
 

--- a/framework/core/src/Frontend/RecompileFrontendAssets.php
+++ b/framework/core/src/Frontend/RecompileFrontendAssets.php
@@ -12,6 +12,8 @@ namespace Flarum\Frontend;
 use Flarum\Frontend\Event\AssetsRecompiled;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use LogicException;
 
@@ -20,11 +22,28 @@ use LogicException;
  */
 class RecompileFrontendAssets
 {
+    /**
+     * How long one request may hold the rebuild lock.
+     *
+     * A process killed mid-rebuild — OOM, an evicted container, a deploy —
+     * never releases the lock, so this is also the longest anything can go
+     * un-rebuilt after a crash. Sixty seconds is roughly twice the slowest
+     * full rebuild measured against remote storage, where every compiled file
+     * costs a network round trip.
+     *
+     * Both failure modes degrade to the behaviour that existed before this
+     * lock, never to anything worse: the dirty flag outlives the lock, so
+     * after a crash the next request past the TTL rebuilds, and a rebuild that
+     * legitimately outruns the TTL simply lets a second request start one.
+     */
+    public const REBUILD_LOCK_SECONDS = 60;
+
     public function __construct(
         protected Assets $assets,
         protected LocaleManager $locales,
         protected ?Dispatcher $events = null,
-        protected ?SettingsRepositoryInterface $settings = null
+        protected ?SettingsRepositoryInterface $settings = null,
+        protected ?CacheRepository $cache = null
     ) {
     }
 
@@ -67,15 +86,68 @@ class RecompileFrontendAssets
             return;
         }
 
+        $store = $this->cache?->getStore();
+
+        if (! $store instanceof LockProvider) {
+            // No atomic lock available (a custom cache driver). Rebuild
+            // unguarded, exactly as before locking existed: losing the
+            // de-duplication is far better than never rebuilding.
+            $this->rebuildAndClear();
+
+            return;
+        }
+
+        // The flag is only cleared once the rebuild has finished, so without a
+        // lock every request arriving during it — page renders and API calls
+        // alike — sees the set as dirty and starts its own rebuild of the same
+        // output. A full rebuild is seconds, so a busy forum runs a stampede of
+        // them. One request does the work; the rest return and serve the
+        // revision already recorded, which stays valid because markDirty()
+        // deletes neither the compiled files nor their revisions.
+        $lock = $store->lock($this->rebuildLockKey(), static::REBUILD_LOCK_SECONDS);
+
+        if (! $lock->get()) {
+            return;
+        }
+
+        try {
+            // Re-read the flag now the lock is held: a request that queued
+            // behind the winner would otherwise immediately rebuild the very
+            // output that winner just committed.
+            if (! $this->settings()->get($this->dirtyKey())) {
+                return;
+            }
+
+            $this->rebuildAndClear();
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * Rebuild the set, clear the flag, then announce.
+     *
+     * The flag is cleared before announcing: if the process dies mid-rebuild
+     * the flag survives and the next request simply rebuilds again (a cheap
+     * no-op when the output already matches), while the event only ever fires
+     * once everything — including the bookkeeping — has settled.
+     */
+    protected function rebuildAndClear(): void
+    {
         $this->commitAll();
 
-        // Clear the flag before announcing: if the process dies mid-rebuild the
-        // flag survives and the next request simply rebuilds again (a cheap
-        // no-op when the output already matches), while the event only ever
-        // fires once everything — including the bookkeeping — has settled.
         $this->settings()->delete($this->dirtyKey());
 
         $this->events?->dispatch(new AssetsRecompiled());
+    }
+
+    /**
+     * Scoped to this asset set: the sets are independent, so forum, admin and
+     * common rebuild concurrently rather than queueing behind one another.
+     */
+    protected function rebuildLockKey(): string
+    {
+        return 'flarum.assets.recompile.'.$this->assets->getName();
     }
 
     protected function dirtyKey(): string

--- a/framework/core/src/Settings/SettingsRepositoryInterface.php
+++ b/framework/core/src/Settings/SettingsRepositoryInterface.php
@@ -18,7 +18,13 @@ interface SettingsRepositoryInterface
      * You may still need to use the `$default` parameters here in cases where you need to
      * access the default value of a dynamic setting.
      *
+     * Reads shared, mutable state: another process can change a setting between
+     * two calls, so re-reading the same key may legitimately return a different
+     * value.
+     *
      * @see Settings::default()
+     *
+     * @phpstan-impure
      */
     public function get(string $key, mixed $default = null): mixed;
 

--- a/framework/core/tests/unit/Frontend/RecompileFrontendAssetsTest.php
+++ b/framework/core/tests/unit/Frontend/RecompileFrontendAssetsTest.php
@@ -18,6 +18,10 @@ use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Events\Dispatcher;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
@@ -199,5 +203,292 @@ class RecompileFrontendAssetsTest extends TestCase
         $this->assertGreaterThan(0, count(array_keys($order, 'commit', true)), 'compilers must be committed');
         $this->assertContains('clear', $order, 'the dirty flag must be cleared');
         $this->assertSame('event', end($order), 'AssetsRecompiled must fire last, after the rebuild settles');
+    }
+
+    /**
+     * The dirty flag is only cleared once the rebuild has finished, so for the
+     * whole of that rebuild every other request still sees the set as dirty and
+     * starts its own. A full rebuild is seconds — measured at ~2s on local disk
+     * with two locales, and far longer on remote storage — so a busy forum runs
+     * N concurrent rebuilds of the same output. An atomic lock lets one request
+     * do the work; the rest carry on and serve the revision already recorded,
+     * which is safe precisely because markDirty() deletes nothing.
+     */
+    #[Test]
+    public function recompile_if_dirty_skips_the_rebuild_when_another_request_holds_the_lock()
+    {
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('getName')->andReturn('forum');
+        $assets->shouldNotReceive('makeCss', 'makeJs', 'makeLocaleCss', 'makeLocaleJs', 'makeJsDirectory');
+
+        $locales = m::mock(LocaleManager::class);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->with('assets_dirty.forum')->andReturn(1);
+        // The winner owns the flag: a loser must not clear it, or a rebuild
+        // that then fails would leave nothing marked for the next request.
+        $settings->shouldNotReceive('delete');
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldNotReceive('dispatch');
+
+        $lock = m::mock(Lock::class);
+        $lock->shouldReceive('get')->once()->andReturn(false);
+        $lock->shouldNotReceive('release');
+
+        $cache = $this->cacheWithLock($lock, 'flarum.assets.recompile.forum');
+
+        (new RecompileFrontendAssets($assets, $locales, $dispatcher, $settings, $cache))->recompileIfDirty();
+    }
+
+    #[Test]
+    public function recompile_if_dirty_releases_the_lock_once_the_rebuild_is_done()
+    {
+        $order = [];
+
+        $css = m::mock(LessCompiler::class);
+        $css->shouldReceive('commit')->andReturnUsing(function () use (&$order) {
+            $order[] = 'commit';
+        });
+        $js = m::mock(JsCompiler::class);
+        $js->shouldReceive('commit')->andReturnUsing(function () use (&$order) {
+            $order[] = 'commit';
+        });
+        $jsDir = m::mock(JsDirectoryCompiler::class);
+        $jsDir->shouldReceive('commit')->andReturnUsing(function () use (&$order) {
+            $order[] = 'commit';
+        });
+
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('getName')->andReturn('forum');
+        $assets->shouldReceive('makeCss')->andReturn($css);
+        $assets->shouldReceive('makeJs')->andReturn($js);
+        $assets->shouldReceive('makeLocaleCss')->andReturn($css);
+        $assets->shouldReceive('makeLocaleJs')->andReturn($js);
+        $assets->shouldReceive('makeJsDirectory')->andReturn($jsDir);
+
+        $locales = m::mock(LocaleManager::class);
+        $locales->shouldReceive('getLocales')->andReturn(['en' => 'English']);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->with('assets_dirty.forum')->andReturn(1);
+        $settings->shouldReceive('delete')->once()->with('assets_dirty.forum');
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(AssetsRecompiled::class));
+
+        $lock = m::mock(Lock::class);
+        $lock->shouldReceive('get')->once()->andReturn(true);
+        // Released even though this rebuild succeeded — and, being in a
+        // finally, released just as surely when a compiler throws.
+        $lock->shouldReceive('release')->once()->andReturnUsing(function () use (&$order) {
+            $order[] = 'release';
+        });
+
+        $cache = $this->cacheWithLock($lock, 'flarum.assets.recompile.forum');
+
+        (new RecompileFrontendAssets($assets, $locales, $dispatcher, $settings, $cache))->recompileIfDirty();
+
+        $this->assertSame('release', end($order), 'the lock must outlive the rebuild');
+    }
+
+    #[Test]
+    public function recompile_if_dirty_releases_the_lock_when_the_rebuild_throws()
+    {
+        $css = m::mock(LessCompiler::class);
+        $css->shouldReceive('commit')->andThrow(new \RuntimeException('compile failed'));
+
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('getName')->andReturn('forum');
+        $assets->shouldReceive('makeCss')->andReturn($css);
+        $assets->shouldReceive('makeJs')->andReturn(m::mock(JsCompiler::class));
+        $assets->shouldReceive('makeLocaleCss')->andReturn($css);
+        $assets->shouldReceive('makeLocaleJs')->andReturn(m::mock(JsCompiler::class));
+        $assets->shouldReceive('makeJsDirectory')->andReturn(m::mock(JsDirectoryCompiler::class));
+
+        $locales = m::mock(LocaleManager::class);
+        $locales->shouldReceive('getLocales')->andReturn(['en' => 'English']);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->with('assets_dirty.forum')->andReturn(1);
+        // The flag must survive a failed rebuild so the next request retries.
+        $settings->shouldNotReceive('delete');
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldNotReceive('dispatch');
+
+        $lock = m::mock(Lock::class);
+        $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('release')->once();
+
+        $cache = $this->cacheWithLock($lock, 'flarum.assets.recompile.forum');
+
+        $this->expectException(\RuntimeException::class);
+
+        try {
+            (new RecompileFrontendAssets($assets, $locales, $dispatcher, $settings, $cache))->recompileIfDirty();
+        } finally {
+            // Mockery verifies release() was called on tearDown.
+        }
+    }
+
+    /**
+     * Each asset set locks on its own key. The sets are independent, so forum
+     * and common must be able to rebuild at the same time rather than queueing
+     * behind one another.
+     */
+    #[Test]
+    public function the_lock_is_scoped_to_the_asset_set()
+    {
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('getName')->andReturn('common');
+
+        $locales = m::mock(LocaleManager::class);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->with('assets_dirty.common')->andReturn(1);
+
+        $lock = m::mock(Lock::class);
+        $lock->shouldReceive('get')->once()->andReturn(false);
+
+        $cache = $this->cacheWithLock($lock, 'flarum.assets.recompile.common');
+
+        (new RecompileFrontendAssets($assets, $locales, m::mock(Dispatcher::class), $settings, $cache))
+            ->recompileIfDirty();
+    }
+
+    /**
+     * A store that cannot take locks (a custom cache driver) must still get a
+     * rebuild — the same behaviour as before locking existed. Losing the
+     * de-duplication is much better than never rebuilding.
+     */
+    #[Test]
+    public function recompile_if_dirty_rebuilds_without_a_lock_when_the_store_cannot_provide_one()
+    {
+        $css = m::mock(LessCompiler::class);
+        $css->shouldReceive('commit');
+        $js = m::mock(JsCompiler::class);
+        $js->shouldReceive('commit');
+        $jsDir = m::mock(JsDirectoryCompiler::class);
+        $jsDir->shouldReceive('commit');
+
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('getName')->andReturn('forum');
+        $assets->shouldReceive('makeCss')->andReturn($css);
+        $assets->shouldReceive('makeJs')->andReturn($js);
+        $assets->shouldReceive('makeLocaleCss')->andReturn($css);
+        $assets->shouldReceive('makeLocaleJs')->andReturn($js);
+        $assets->shouldReceive('makeJsDirectory')->andReturn($jsDir);
+
+        $locales = m::mock(LocaleManager::class);
+        $locales->shouldReceive('getLocales')->andReturn(['en' => 'English']);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->with('assets_dirty.forum')->andReturn(1);
+        $settings->shouldReceive('delete')->once()->with('assets_dirty.forum');
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(AssetsRecompiled::class));
+
+        // A Store that is NOT a LockProvider.
+        $cache = m::mock(CacheRepository::class);
+        $cache->shouldReceive('getStore')->andReturn(m::mock(Store::class));
+
+        (new RecompileFrontendAssets($assets, $locales, $dispatcher, $settings, $cache))->recompileIfDirty();
+    }
+
+    /**
+     * No cache passed at all — the two call sites in core both provide one, but
+     * the argument is optional for backwards compatibility, and third-party
+     * callers constructing this class must keep working.
+     */
+    #[Test]
+    public function recompile_if_dirty_rebuilds_when_no_cache_is_provided()
+    {
+        $css = m::mock(LessCompiler::class);
+        $css->shouldReceive('commit');
+        $js = m::mock(JsCompiler::class);
+        $js->shouldReceive('commit');
+        $jsDir = m::mock(JsDirectoryCompiler::class);
+        $jsDir->shouldReceive('commit');
+
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('getName')->andReturn('forum');
+        $assets->shouldReceive('makeCss')->andReturn($css);
+        $assets->shouldReceive('makeJs')->andReturn($js);
+        $assets->shouldReceive('makeLocaleCss')->andReturn($css);
+        $assets->shouldReceive('makeLocaleJs')->andReturn($js);
+        $assets->shouldReceive('makeJsDirectory')->andReturn($jsDir);
+
+        $locales = m::mock(LocaleManager::class);
+        $locales->shouldReceive('getLocales')->andReturn(['en' => 'English']);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->with('assets_dirty.forum')->andReturn(1);
+        $settings->shouldReceive('delete')->once()->with('assets_dirty.forum');
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(AssetsRecompiled::class));
+
+        (new RecompileFrontendAssets($assets, $locales, $dispatcher, $settings))->recompileIfDirty();
+    }
+
+    /**
+     * A request that waited on the lock and then acquired it — because the
+     * winner had just finished and released — must not rebuild the same output
+     * again. The flag is re-read after acquiring, not just before.
+     */
+    #[Test]
+    public function recompile_if_dirty_rechecks_the_flag_after_acquiring_the_lock()
+    {
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('getName')->andReturn('forum');
+        $assets->shouldNotReceive('makeCss', 'makeJs', 'makeLocaleCss', 'makeLocaleJs', 'makeJsDirectory');
+
+        $locales = m::mock(LocaleManager::class);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        // Dirty on the first read, clean by the time the lock is held.
+        $settings->shouldReceive('get')->with('assets_dirty.forum')->twice()
+            ->andReturn(1, null);
+        $settings->shouldNotReceive('delete');
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldNotReceive('dispatch');
+
+        $lock = m::mock(Lock::class);
+        $lock->shouldReceive('get')->once()->andReturn(true);
+        $lock->shouldReceive('release')->once();
+
+        $cache = $this->cacheWithLock($lock, 'flarum.assets.recompile.forum');
+
+        (new RecompileFrontendAssets($assets, $locales, $dispatcher, $settings, $cache))->recompileIfDirty();
+    }
+
+    /**
+     * The TTL is the longest anything can go un-rebuilt after a process is
+     * killed mid-rebuild, since a dead holder never releases. Keep it close
+     * enough to a real rebuild that a crash costs a minute, not five.
+     */
+    #[Test]
+    public function the_rebuild_lock_expires_soon_enough_to_recover_from_a_crash()
+    {
+        $this->assertLessThanOrEqual(
+            60,
+            RecompileFrontendAssets::REBUILD_LOCK_SECONDS,
+            'a longer lease is a longer stall after a crashed rebuild'
+        );
+    }
+
+    private function cacheWithLock(m\MockInterface $lock, string $expectedKey): CacheRepository
+    {
+        $store = m::mock(Store::class, LockProvider::class);
+        $store->shouldReceive('lock')->once()->with($expectedKey, m::type('int'))->andReturn($lock);
+
+        /** @var CacheRepository&m\MockInterface $cache */
+        $cache = m::mock(CacheRepository::class);
+        $cache->shouldReceive('getStore')->andReturn($store);
+
+        return $cache;
     }
 }


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

`recompileIfDirty()` clears the dirty flag only after the rebuild finishes:

```php
if (! $this->settings()->get($this->dirtyKey())) {
    return;
}

$this->commitAll();                              // seconds

$this->settings()->delete($this->dirtyKey());    // cleared only now
```

So for the whole rebuild every other request still sees the set as dirty and starts its own. Both call sites are per-request — page renders via `Content\Assets`, and every API call via `AddAssetsRevisionHeader` — so after a toggle or a cache clear a busy forum runs a stampede of identical rebuilds. A full rebuild measured ~2s on local disk with two locales, and 3–26s against S3.

Now one request takes an atomic cache lock and does the work; the rest return and serve the revision already recorded. That's safe because `markDirty()` deletes neither the compiled files nor their revisions, so the assets on the page keep resolving throughout.

The lock is keyed per asset set, so forum, admin and common still rebuild concurrently.

**Reviewers should focus on:**

- **Every failure mode has to degrade to the old behaviour, never worse.** A process killed mid-rebuild never releases, so nothing rebuilds until the lease expires — hence 60s, about twice the slowest rebuild I measured. A rebuild that outruns the lease just lets a second request start one. `cache:clear` wipes the lock (it lives in the cache) but not the dirty flag (that's a settings row), and `CacheClearCommand` flushes *before* dispatching `ClearingCache`, so the flag is written after the flush and the next request rebuilds — which also gives operators an escape hatch for a stale lock.
- **`@phpstan-impure` on `SettingsRepositoryInterface::get()`** is the widest part of this. Without it PHPStan calls the post-lock flag re-check `booleanNot.alwaysFalse`, because it assumes `get()` is pure and so cannot return a different value the second time. It isn't — that's the whole point of re-reading. The annotation is a true statement about the interface for every caller, not just this one, but it does cost PHPStan some ability to spot a genuinely redundant double-read of a setting anywhere in core.
- The re-check itself. Drop it and the annotation goes too, at the cost of one redundant rebuild by whoever queued behind the winner. One instead of N, so most of the win survives if you'd rather keep the diff narrow.
- Core's default `FileStore` is a `LockProvider`, so single-instance installs take the locked path too. The unguarded fallback is only for cache drivers that can't lock, and it behaves exactly as before.

**Screenshot**

n/a, backend.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — lease length; whether to re-check the flag; per-set vs global lock.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — it's core's own method, and the stampede is storage-independent.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`) — unit 462/462. Integration 905 tests, 3 pre-existing errors (`PasswordEmailTokensTest` ×2, `ThemeTest`), identical with this change stashed. PHPStan clean across all of `framework/core/src`.
- [x] Backend changes: tests have been added, or are not appropriate here. — 8 new, covering the loser path, release on success and on throw, per-set keying, both fallbacks, the post-lock re-check, and a bound on the lease.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no database involvement.
- [x] Core developer confirmed locally this works as intended. — lock semantics verified against the live Redis store: one winner, losers skip, independent keys don't contend, and the key is cleared by `cache:clear`.
- [x] The description above is written by me and describes what this pull request actually does.
