### PR TITLE
[2.x] fix: record asset revisions a row at a time

### DIFF
--- a/framework/core/migrations/2026_09_09_000000_create_asset_revisions_table.php
+++ b/framework/core/migrations/2026_09_09_000000_create_asset_revisions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * One row per compiled asset, replacing the map that rev-manifest.json held in
+ * a single JSON value. A revision can then be written on its own, so two
+ * instances recording different assets cannot overwrite each other's work.
+ *
+ * The table starts empty on an existing install: nothing reads the manifest
+ * file any more, so the first request finds no revision for an asset and
+ * commits one, exactly as it would after a cache clear.
+ */
+return Migration::createTable(
+    'asset_revisions',
+    function (Blueprint $table) {
+        // The asset's path as the compilers name it — 'forum.js', or a
+        // code-split chunk like 'js/<extension>/forum/components/Foo.js',
+        // whose length is bounded only by what extensions register. The
+        // natural primary key, which is what makes a single-row upsert atomic.
+        $table->string('file', 255)->primary();
+
+        // A hash of the compiled output, or RevisionCompiler::EMPTY_REVISION
+        // for a bundle that legitimately has no file. Never null: absence of a
+        // revision is absence of the row.
+        $table->string('revision', 32);
+    }
+);

--- a/framework/core/src/Api/Middleware/AddAssetsRevisionHeader.php
+++ b/framework/core/src/Api/Middleware/AddAssetsRevisionHeader.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Middleware;
 
 use Flarum\Frontend\Compiler\AssetsRevision;
+use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -59,7 +60,8 @@ class AddAssetsRevisionHeader implements Middleware
                 $this->container->make(LocaleManager::class),
                 $this->container->make('events'),
                 $this->container->make(SettingsRepositoryInterface::class),
-                $this->container->make(CacheRepository::class)
+                $this->container->make(CacheRepository::class),
+                $this->container->make(VersionerInterface::class)
             ))->recompileIfDirty();
         }
     }

--- a/framework/core/src/Frontend/Compiler/DatabaseVersioner.php
+++ b/framework/core/src/Frontend/Compiler/DatabaseVersioner.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Frontend\Compiler;
+
+use Illuminate\Database\ConnectionInterface;
+
+/**
+ * Records asset revisions one row at a time, so several instances can record
+ * different assets at once.
+ *
+ * {@see FileVersioner} keeps the whole map in a single JSON value, which means
+ * every write is a read-modify-write of all of it: a writer carrying a snapshot
+ * taken before someone else's write silently erases that write when it saves.
+ * Measured across two ECS tasks writing twenty assets each, half the writes
+ * were lost; across six local processes, 83% were. Because
+ * {@see RevisionCompiler::getUrl()} only recompiles when a revision is
+ * *missing*, a lost revision is not noticed — it simply stays wrong until the
+ * next admin action.
+ *
+ * Here each revision is its own row, keyed by the asset's path, so a write
+ * touches nothing else and there is no shared value to clobber.
+ *
+ * Reads are memoised for the lifetime of the instance, matching FileVersioner:
+ * rendering a page reads the map around thirty times and individual revisions
+ * around sixty-five times through one shared instance, and every one of those
+ * would otherwise be a query.
+ */
+class DatabaseVersioner implements VersionerInterface
+{
+    public const TABLE = 'asset_revisions';
+
+    /**
+     * @var array<string, string>|null
+     */
+    private ?array $revisions = null;
+
+    /**
+     * Revisions recorded since deferWrites(), awaiting a single statement.
+     *
+     * @var array<string, string|null>|null
+     */
+    private ?array $deferred = null;
+
+    public function __construct(
+        protected ConnectionInterface $database
+    ) {
+    }
+
+    public function putRevision(string $file, ?string $revision): void
+    {
+        // Writing what is already recorded must not touch the database at all.
+        // JsDirectoryCompiler::pruneStaleRevisions() calls this once per stale
+        // chunk and runs from getUrl() — on ordinary page renders, not only on
+        // rebuilds — so a render that prunes nothing has to be free.
+        //
+        // Read the map without settling the buffer: allRevisions() stores
+        // anything deferred before answering, which would defeat the batching
+        // this method is feeding.
+        if (($this->loadRevisions()[$file] ?? null) === $revision) {
+            return;
+        }
+
+        // Keep the memo in step with what was just recorded, rather than
+        // dropping it and paying for another read.
+        if ($this->revisions !== null) {
+            if ($revision === null) {
+                unset($this->revisions[$file]);
+            } else {
+                $this->revisions[$file] = $revision;
+            }
+        }
+
+        if ($this->deferred !== null) {
+            $this->deferred[$file] = $revision;
+
+            return;
+        }
+
+        $this->write([$file => $revision]);
+    }
+
+    public function deferWrites(): void
+    {
+        $this->deferred ??= [];
+    }
+
+    /**
+     * A batch left open — a caller that never flushed, or a rebuild that threw
+     * past its own flush — must still be stored. Reads are answered from the
+     * memo while a batch is open, so nothing else would notice the omission
+     * until the revisions were missing on the next request.
+     */
+    public function __destruct()
+    {
+        try {
+            $this->flushWrites();
+        } catch (\Throwable $e) {
+            // Shutdown is too late to do anything useful about a failed write,
+            // and throwing here would mask whatever is really going on.
+        }
+    }
+
+    public function flushWrites(): void
+    {
+        $deferred = $this->deferred;
+        $this->deferred = null;
+
+        if (! empty($deferred)) {
+            $this->write($deferred);
+        }
+    }
+
+    /**
+     * Store a batch: one upsert for the revisions being set, one delete for
+     * those being forgotten.
+     *
+     * @param array<string, string|null> $revisions
+     */
+    private function write(array $revisions): void
+    {
+        $set = array_filter($revisions, fn (?string $revision) => $revision !== null);
+        $forget = array_keys(array_filter($revisions, fn (?string $revision) => $revision === null));
+
+        if ($set !== []) {
+            // An upsert on the primary key, so two instances recording the same
+            // asset at the same moment cannot collide, and neither disturbs any
+            // other asset's row.
+            $this->database->table(static::TABLE)->upsert(
+                array_map(
+                    fn (string $file, string $revision) => compact('file', 'revision'),
+                    array_keys($set),
+                    $set
+                ),
+                ['file'],
+                ['revision']
+            );
+        }
+
+        if ($forget !== []) {
+            $this->database->table(static::TABLE)->whereIn('file', $forget)->delete();
+        }
+    }
+
+    public function getRevision(string $file): ?string
+    {
+        return $this->allRevisions()[$file] ?? null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function allRevisions(): array
+    {
+        // Deferred writes are already reflected in the memo, so a read during a
+        // batch sees them without the batch having to be stored — which is what
+        // lets getUrl() read back the revision it just recorded while the batch
+        // is still open.
+        return $this->loadRevisions();
+    }
+
+    /**
+     * The memoised map, fetched once per instance.
+     *
+     * Rendering a page reads the map around thirty times and individual
+     * revisions around sixty-five, all through one shared instance, so every
+     * one of those would otherwise be a query.
+     *
+     * @return array<string, string>
+     */
+    private function loadRevisions(): array
+    {
+        if ($this->revisions !== null) {
+            return $this->revisions;
+        }
+
+        return $this->revisions = $this->database->table(static::TABLE)
+            ->pluck('revision', 'file')
+            ->all();
+    }
+}

--- a/framework/core/src/Frontend/Compiler/FileVersioner.php
+++ b/framework/core/src/Frontend/Compiler/FileVersioner.php
@@ -36,6 +36,18 @@ class FileVersioner implements VersionerInterface
         $this->cachedManifest = $manifest;
     }
 
+    /**
+     * No-ops: every write here already rewrites the whole manifest, so there is
+     * nothing for a batch to save.
+     */
+    public function deferWrites(): void
+    {
+    }
+
+    public function flushWrites(): void
+    {
+    }
+
     public function getRevision(string $file): ?string
     {
         return $this->readManifest()[$file] ?? null;

--- a/framework/core/src/Frontend/Compiler/VersionerInterface.php
+++ b/framework/core/src/Frontend/Compiler/VersionerInterface.php
@@ -9,11 +9,80 @@
 
 namespace Flarum\Frontend\Compiler;
 
+/**
+ * Records which revision of each compiled asset is current, so that a URL can
+ * be cache-busted and a client can tell when what it loaded was superseded.
+ *
+ * Implementations are swappable — pointing the assets disk at S3 or sharing it
+ * between instances are both reasons to store revisions somewhere other than
+ * beside the files. What follows is what the compilers rely on, and what any
+ * replacement therefore has to provide.
+ *
+ * **A write must not disturb another file's revision.** Several instances
+ * record revisions at once — every one of them rebuilds a dirty asset set on
+ * its next request — and {@see JsDirectoryCompiler::pruneStaleRevisions()}
+ * writes once per stale chunk from `getUrl()`, so writes happen during ordinary
+ * page renders too. An implementation that saves the whole map back on every
+ * write loses whichever revisions were recorded since it last read: the writes
+ * report success, and because {@see RevisionCompiler::getUrl()} only recompiles
+ * when a revision is *missing*, nothing notices the loss until the next admin
+ * action. Store each revision independently, or serialise the read-modify-write.
+ *
+ * **Writing an unchanged value must not write at all.** Pruning runs on
+ * renders, so a render that prunes nothing has to cost nothing.
+ *
+ * **Errors must propagate.** A read that fails but reports "no revision" makes
+ * `getUrl()` recompile on every request and then return null, dropping the
+ * stylesheet or bundle from the page; a write that fails but reports success
+ * leaves the old revision in place with nothing to trigger a retry.
+ *
+ * **Reads may be memoised for the lifetime of the instance, and no longer.**
+ * Rendering a page reads the map around thirty times and individual revisions
+ * around sixty-five, all through one shared instance, so caching within a
+ * request is expected. Caching beyond it would serve revisions that another
+ * instance has since replaced. A write must leave the memo agreeing with
+ * storage, so `getRevision()` returns what was just written.
+ *
+ * **`allRevisions()` must agree with `getRevision()`** for every file it
+ * contains: the map is inlined into the page for the client, and hashed into
+ * the asset revision token, so a disagreement shows up as a spurious reload
+ * prompt or a chunk the client cannot resolve.
+ */
 interface VersionerInterface
 {
+    /**
+     * Record the current revision of a file, or forget it when null.
+     */
     public function putRevision(string $file, ?string $revision): void;
 
+    /**
+     * Collect writes until {@see flushWrites()} instead of storing each one as
+     * it arrives, so a rebuild that records every asset in turn can store them
+     * together.
+     *
+     * Buffered writes are still visible to this instance's own reads, and a
+     * read of anything buffered stores the buffer first, so nothing can observe
+     * a revision that has been recorded but not saved. An implementation with
+     * nothing to gain from batching may treat both methods as no-ops.
+     */
+    public function deferWrites(): void;
+
+    /**
+     * Store anything {@see deferWrites()} collected, and stop deferring.
+     *
+     * Safe to call when nothing was deferred.
+     */
+    public function flushWrites(): void;
+
+    /**
+     * The recorded revision, or null when there is none.
+     */
     public function getRevision(string $file): ?string;
 
+    /**
+     * Every recorded revision, keyed by file.
+     *
+     * @return array<string, string>
+     */
     public function allRevisions(): array;
 }

--- a/framework/core/src/Frontend/Content/Assets.php
+++ b/framework/core/src/Frontend/Content/Assets.php
@@ -12,6 +12,7 @@ namespace Flarum\Frontend\Content;
 use Flarum\Foundation\Config;
 use Flarum\Frontend\Assets as FrontendAssets;
 use Flarum\Frontend\Compiler\CompilerInterface;
+use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Frontend\Document;
 use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Locale\LocaleManager;
@@ -62,11 +63,24 @@ class Assets
 
         $compilers = $this->assembleCompilers($locale);
 
-        if ($this->config->inDebugMode()) {
-            $this->recompile(Arr::flatten($compilers));
-        }
+        // Assembling the URLs compiles anything with no revision yet — a first
+        // render after a cache clear does so for every asset — and each of
+        // those records a revision. Collect them so they are stored together
+        // rather than one statement per asset. getUrl() reads back the
+        // revision it just recorded, which the versioner answers from the
+        // pending batch.
+        $versioner = $this->container->make(VersionerInterface::class);
+        $versioner->deferWrites();
 
-        $this->addAssetsToDocument($document, $compilers);
+        try {
+            if ($this->config->inDebugMode()) {
+                $this->recompile(Arr::flatten($compilers));
+            }
+
+            $this->addAssetsToDocument($document, $compilers);
+        } finally {
+            $versioner->flushWrites();
+        }
     }
 
     protected function recompileIfDirty(FrontendAssets $assets): void
@@ -76,7 +90,8 @@ class Assets
             $this->container->make(LocaleManager::class),
             $this->container->make('events'),
             $this->container->make(SettingsRepositoryInterface::class),
-            $this->container->make(CacheRepository::class)
+            $this->container->make(CacheRepository::class),
+            $this->container->make(VersionerInterface::class)
         ))->recompileIfDirty();
     }
 

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -15,6 +15,7 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\FontAwesome;
 use Flarum\Foundation\Paths;
+use Flarum\Frontend\Compiler\DatabaseVersioner;
 use Flarum\Frontend\Compiler\FileVersioner;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
 use Flarum\Frontend\Compiler\VersionerInterface;
@@ -28,15 +29,23 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Database\ConnectionInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class FrontendServiceProvider extends AbstractServiceProvider
 {
     public function register(): void
     {
+        // Revisions live in their own table, a row per asset, rather than in a
+        // single JSON value beside the compiled files. Every instance rebuilds
+        // a dirty asset set on its next request, and pruning stale chunks
+        // writes during ordinary renders, so revisions are recorded
+        // concurrently — and saving the whole map back on each write silently
+        // drops whatever was recorded in the meantime. {@see FileVersioner}
+        // remains for anyone who needs the manifest file itself.
         $this->container->singleton(VersionerInterface::class, function (Container $container) {
-            return new FileVersioner(
-                $container->make('filesystem')->disk('flarum-assets')
+            return new DatabaseVersioner(
+                $container->make(ConnectionInterface::class)
             );
         });
 

--- a/framework/core/src/Frontend/RecompileFrontendAssets.php
+++ b/framework/core/src/Frontend/RecompileFrontendAssets.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Frontend;
 
+use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Frontend\Event\AssetsRecompiled;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -43,7 +44,8 @@ class RecompileFrontendAssets
         protected LocaleManager $locales,
         protected ?Dispatcher $events = null,
         protected ?SettingsRepositoryInterface $settings = null,
-        protected ?CacheRepository $cache = null
+        protected ?CacheRepository $cache = null,
+        protected ?VersionerInterface $versioner = null
     ) {
     }
 
@@ -185,15 +187,25 @@ class RecompileFrontendAssets
 
     protected function commitAll(): void
     {
-        $this->assets->makeCss()->commit();
-        $this->assets->makeJs()->commit();
+        // Each compiler records its own revision, and pruning stale chunks
+        // records one removal per chunk — around eighteen writes on a plain
+        // forum, many more with code splitting. Collect them so the versioner
+        // can store them together instead of once per asset.
+        $this->versioner?->deferWrites();
 
-        foreach ($this->locales->getLocales() as $locale => $name) {
-            $this->assets->makeLocaleCss($locale)->commit();
-            $this->assets->makeLocaleJs($locale)->commit();
+        try {
+            $this->assets->makeCss()->commit();
+            $this->assets->makeJs()->commit();
+
+            foreach ($this->locales->getLocales() as $locale => $name) {
+                $this->assets->makeLocaleCss($locale)->commit();
+                $this->assets->makeLocaleJs($locale)->commit();
+            }
+
+            $this->assets->makeJsDirectory()->commit();
+        } finally {
+            $this->versioner?->flushWrites();
         }
-
-        $this->assets->makeJsDirectory()->commit();
     }
 
     public function flush(): void

--- a/framework/core/tests/unit/Frontend/Compiler/DatabaseVersionerTest.php
+++ b/framework/core/tests/unit/Frontend/Compiler/DatabaseVersionerTest.php
@@ -1,0 +1,466 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend\Compiler;
+
+use Flarum\Frontend\Compiler\DatabaseVersioner;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Events\Dispatcher;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Runs against a real SQLite database rather than a mocked connection: the
+ * whole point of this class is what the storage does under concurrent writes,
+ * and a mock would only replay whatever assumption was written into it.
+ */
+class DatabaseVersionerTest extends TestCase
+{
+    private Capsule $capsule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->capsule = new Capsule();
+        $this->capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+        // Without a dispatcher, Connection::listen() is a silent no-op and the
+        // query-count assertions below would pass on any implementation.
+        $this->capsule->setEventDispatcher(new Dispatcher());
+
+        $schema = $this->connection()->getSchemaBuilder();
+        $schema->create('asset_revisions', function ($table) {
+            $table->string('file', 255)->primary();
+            $table->string('revision', 32);
+        });
+    }
+
+    private function connection(): ConnectionInterface
+    {
+        return $this->capsule->getConnection();
+    }
+
+    private function versioner(): DatabaseVersioner
+    {
+        return new DatabaseVersioner($this->connection());
+    }
+
+    private function rowCount(): int
+    {
+        return $this->connection()->table('asset_revisions')->count();
+    }
+
+    #[Test]
+    public function it_round_trips_a_revision()
+    {
+        $versioner = $this->versioner();
+
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $this->assertSame('abc12345', $versioner->getRevision('forum.js'));
+        $this->assertSame(['forum.js' => 'abc12345'], $versioner->allRevisions());
+        $this->assertSame(1, $this->rowCount());
+    }
+
+    #[Test]
+    public function a_missing_revision_reads_as_null()
+    {
+        $this->assertNull($this->versioner()->getRevision('nope.js'));
+    }
+
+    #[Test]
+    public function overwriting_a_revision_keeps_one_row()
+    {
+        $versioner = $this->versioner();
+
+        $versioner->putRevision('forum.js', 'aaaaaaaa');
+        $versioner->putRevision('forum.js', 'bbbbbbbb');
+
+        $this->assertSame('bbbbbbbb', $versioner->getRevision('forum.js'));
+        $this->assertSame(1, $this->rowCount(), 'an update must not insert a second row');
+    }
+
+    #[Test]
+    public function a_null_revision_removes_the_row()
+    {
+        $versioner = $this->versioner();
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $versioner->putRevision('forum.js', null);
+
+        $this->assertNull($versioner->getRevision('forum.js'));
+        $this->assertSame(0, $this->rowCount());
+    }
+
+    /**
+     * The defect this class removes. Holding the whole map in one value means
+     * each writer reads it, edits its own key and writes the lot back — so a
+     * writer carrying a snapshot from before someone else's write silently
+     * erases it. Measured at 50% loss across two real ECS tasks writing 20
+     * keys each, and 83% across six local processes.
+     *
+     * Two instances stand in for two pods. Both read the map first, so each
+     * holds a pre-write snapshot; both writes must still survive.
+     */
+    #[Test]
+    public function concurrent_writers_do_not_erase_each_other()
+    {
+        $podA = $this->versioner();
+        $podB = $this->versioner();
+
+        $podA->allRevisions();
+        $podB->allRevisions();
+
+        $podA->putRevision('forum.js', 'aaaaaaaa');
+        $podB->putRevision('admin.js', 'bbbbbbbb');
+
+        $fresh = $this->versioner();
+
+        $this->assertSame('aaaaaaaa', $fresh->getRevision('forum.js'), "pod B's write erased pod A's");
+        $this->assertSame('bbbbbbbb', $fresh->getRevision('admin.js'), "pod A's write erased pod B's");
+        $this->assertSame(2, $this->rowCount());
+    }
+
+    /**
+     * Interleaved the other way round: A reads, B writes and A then writes.
+     * A's stale snapshot must not resurrect what B removed.
+     */
+    #[Test]
+    public function a_stale_snapshot_does_not_resurrect_a_removed_revision()
+    {
+        $seed = $this->versioner();
+        $seed->putRevision('chunk.js', 'aaaaaaaa');
+
+        $podA = $this->versioner();
+        $podA->allRevisions();          // snapshot includes chunk.js
+
+        $podB = $this->versioner();
+        $podB->putRevision('chunk.js', null);   // B prunes it
+
+        $podA->putRevision('forum.js', 'bbbbbbbb');   // A writes something else
+
+        $fresh = $this->versioner();
+
+        $this->assertNull($fresh->getRevision('chunk.js'), "A's snapshot resurrected a pruned chunk");
+        $this->assertSame('bbbbbbbb', $fresh->getRevision('forum.js'));
+    }
+
+    /**
+     * JsDirectoryCompiler::pruneStaleRevisions() calls putRevision() once per
+     * stale chunk, and it runs from getUrl() — on ordinary page renders, not
+     * only on rebuilds. A render that prunes nothing must write nothing.
+     */
+    #[Test]
+    public function writing_an_unchanged_revision_touches_no_storage()
+    {
+        $versioner = $this->versioner();
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $writes = 0;
+        $this->connection()->listen(function () use (&$writes) {
+            $writes++;
+        });
+
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $this->assertSame(0, $writes, 'an unchanged revision must not be rewritten');
+    }
+
+    #[Test]
+    public function removing_an_already_absent_revision_touches_no_storage()
+    {
+        $versioner = $this->versioner();
+        $versioner->allRevisions();
+
+        $queries = 0;
+        $this->connection()->listen(function () use (&$queries) {
+            $queries++;
+        });
+
+        $versioner->putRevision('forum.js', null);
+
+        $this->assertSame(0, $queries, 'nothing to delete means no query');
+    }
+
+    /**
+     * Frontend rendering reads the map ~31 times and individual revisions ~65
+     * times per page, all through one shared instance. Reading storage each
+     * time would put a query on every one of those.
+     */
+    #[Test]
+    public function the_map_is_read_from_storage_once_per_instance()
+    {
+        $seed = $this->versioner();
+        $seed->putRevision('forum.js', 'abc12345');
+
+        $versioner = $this->versioner();
+
+        $queries = 0;
+        $this->connection()->listen(function () use (&$queries) {
+            $queries++;
+        });
+
+        $versioner->allRevisions();
+        $versioner->allRevisions();
+        $versioner->getRevision('forum.js');
+        $versioner->getRevision('admin.js');
+
+        $this->assertSame(1, $queries, 'the map must be fetched once and memoised');
+    }
+
+    #[Test]
+    public function a_write_keeps_the_memo_in_step()
+    {
+        $versioner = $this->versioner();
+        $versioner->allRevisions();
+
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $queries = 0;
+        $this->connection()->listen(function () use (&$queries) {
+            $queries++;
+        });
+
+        $this->assertSame('abc12345', $versioner->getRevision('forum.js'));
+        $this->assertSame(0, $queries, 'a write must update the memo, not invalidate it');
+    }
+
+    /**
+     * Code-split chunks carry slashes and dots and make up the bulk of a real
+     * manifest — 87 of 109 keys on a working forum.
+     */
+    #[Test]
+    public function it_handles_code_split_chunk_names()
+    {
+        $versioner = $this->versioner();
+
+        $chunk = 'js/fof-profile-image-crop/forum/components/ProfileImageCropModal.js';
+        $versioner->putRevision($chunk, '0cb639f4');
+
+        $this->assertSame('0cb639f4', $versioner->getRevision($chunk));
+        $this->assertSame([$chunk => '0cb639f4'], $versioner->allRevisions());
+    }
+
+    /**
+     * A bundle with no sources legitimately has no file, and records
+     * RevisionCompiler::EMPTY_REVISION rather than being absent — 13 of the
+     * 109 rows on a working forum.
+     */
+    #[Test]
+    public function it_stores_the_empty_revision_marker()
+    {
+        $versioner = $this->versioner();
+
+        $versioner->putRevision('admin-en.css', 'empty');
+
+        $this->assertSame('empty', $versioner->getRevision('admin-en.css'));
+    }
+
+    /**
+     * A rebuild records every asset in turn — around eighteen on a plain forum,
+     * and pruning stale chunks can remove dozens more. One row per statement
+     * turns that into a round trip per asset, which is what the file-backed
+     * versioner avoided by writing the map once.
+     */
+    #[Test]
+    public function deferred_writes_are_stored_in_a_single_statement()
+    {
+        $versioner = $this->versioner();
+
+        $queries = [];
+        $this->connection()->listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        $versioner->deferWrites();
+
+        for ($i = 0; $i < 18; $i++) {
+            $versioner->putRevision("chunk$i.js", sprintf('%08x', $i));
+        }
+
+        $versioner->flushWrites();
+
+        $writes = array_values(array_filter($queries, fn (string $sql) => ! str_starts_with($sql, 'select')));
+
+        $this->assertCount(1, $writes, 'eighteen revisions must be stored together');
+        $this->assertSame(18, $this->rowCount());
+    }
+
+    #[Test]
+    public function deferred_removals_are_stored_in_a_single_statement()
+    {
+        $seed = $this->versioner();
+        $seed->deferWrites();
+        for ($i = 0; $i < 10; $i++) {
+            $seed->putRevision("chunk$i.js", sprintf('%08x', $i));
+        }
+        $seed->flushWrites();
+
+        $versioner = $this->versioner();
+
+        $queries = [];
+        $this->connection()->listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        $versioner->deferWrites();
+        for ($i = 0; $i < 10; $i++) {
+            $versioner->putRevision("chunk$i.js", null);
+        }
+        $versioner->flushWrites();
+
+        $deletes = array_values(array_filter($queries, fn (string $sql) => str_starts_with($sql, 'delete')));
+
+        $this->assertCount(1, $deletes, 'stale chunks must be pruned together');
+        $this->assertSame(0, $this->rowCount());
+    }
+
+    #[Test]
+    public function a_deferred_write_is_visible_to_this_instance_before_it_is_stored()
+    {
+        $versioner = $this->versioner();
+
+        $versioner->deferWrites();
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $this->assertSame('abc12345', $versioner->getRevision('forum.js'));
+        $this->assertSame(['forum.js' => 'abc12345'], $versioner->allRevisions());
+    }
+
+    /**
+     * Reading during a batch must NOT store it: getUrl() records a revision and
+     * then reads it straight back, so a read that settled the batch would drain
+     * it once per asset and defeat the batching entirely. The memo already
+     * carries deferred writes, so the read is answered without them.
+     */
+    #[Test]
+    public function reading_during_a_batch_does_not_store_it()
+    {
+        $versioner = $this->versioner();
+
+        $versioner->deferWrites();
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $queries = [];
+        $this->connection()->listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        $this->assertSame('abc12345', $versioner->getRevision('forum.js'), 'a read must see the pending write');
+        $versioner->allRevisions();
+
+        $writes = array_filter($queries, fn (string $sql) => ! str_starts_with($sql, 'select'));
+
+        $this->assertSame([], array_values($writes), 'a read must not drain the batch');
+    }
+
+    /**
+     * The one way buffering could lose data is a batch that is never flushed —
+     * a caller that forgets, or a rebuild that throws past its own flush.
+     * Discarding the instance stores whatever is outstanding.
+     */
+    #[Test]
+    public function an_abandoned_batch_is_stored_when_the_instance_goes_away()
+    {
+        $versioner = $this->versioner();
+
+        $versioner->deferWrites();
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        unset($versioner);
+
+        $this->assertSame('abc12345', $this->versioner()->getRevision('forum.js'), 'an abandoned batch was lost');
+    }
+
+    #[Test]
+    public function writes_are_stored_immediately_when_nothing_is_deferred()
+    {
+        $versioner = $this->versioner();
+
+        $versioner->putRevision('forum.js', 'abc12345');
+
+        $this->assertSame('abc12345', $this->versioner()->getRevision('forum.js'));
+    }
+
+    #[Test]
+    public function flushing_without_deferring_anything_is_harmless()
+    {
+        $versioner = $this->versioner();
+
+        $queries = 0;
+        $this->connection()->listen(function () use (&$queries) {
+            $queries++;
+        });
+
+        $versioner->flushWrites();
+        $versioner->flushWrites();
+
+        $this->assertSame(0, $queries);
+    }
+
+    #[Test]
+    public function deferring_still_skips_writes_that_change_nothing()
+    {
+        $seed = $this->versioner();
+        $seed->putRevision('forum.js', 'abc12345');
+
+        $versioner = $this->versioner();
+
+        $queries = [];
+        $this->connection()->listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        $versioner->deferWrites();
+        $versioner->putRevision('forum.js', 'abc12345');
+        $versioner->flushWrites();
+
+        $writes = array_filter($queries, fn (string $sql) => ! str_starts_with($sql, 'select'));
+
+        $this->assertSame([], array_values($writes), 'an unchanged revision must not be stored');
+    }
+
+    #[Test]
+    public function a_mixed_batch_stores_and_removes_correctly()
+    {
+        $seed = $this->versioner();
+        $seed->putRevision('stale.js', 'aaaaaaaa');
+        $seed->putRevision('kept.js', 'bbbbbbbb');
+
+        $versioner = $this->versioner();
+        $versioner->deferWrites();
+        $versioner->putRevision('stale.js', null);
+        $versioner->putRevision('fresh.js', 'cccccccc');
+        $versioner->putRevision('kept.js', 'dddddddd');
+        $versioner->flushWrites();
+
+        $fresh = $this->versioner();
+
+        $this->assertNull($fresh->getRevision('stale.js'));
+        $this->assertSame('cccccccc', $fresh->getRevision('fresh.js'));
+        $this->assertSame('dddddddd', $fresh->getRevision('kept.js'));
+    }
+
+    #[Test]
+    public function it_reads_a_full_manifest_back_in_one_query()
+    {
+        $seed = $this->versioner();
+
+        foreach (['forum.js' => 'aaaaaaaa', 'forum.css' => 'bbbbbbbb', 'admin.js' => 'cccccccc'] as $file => $rev) {
+            $seed->putRevision($file, $rev);
+        }
+
+        $this->assertSame([
+            'forum.js' => 'aaaaaaaa',
+            'forum.css' => 'bbbbbbbb',
+            'admin.js' => 'cccccccc',
+        ], $this->versioner()->allRevisions());
+    }
+}

--- a/framework/core/tests/unit/Frontend/Content/AssetsTest.php
+++ b/framework/core/tests/unit/Frontend/Content/AssetsTest.php
@@ -14,6 +14,7 @@ use Flarum\Frontend\Assets as FrontendAssets;
 use Flarum\Frontend\Compiler\JsCompiler;
 use Flarum\Frontend\Compiler\JsDirectoryCompiler;
 use Flarum\Frontend\Compiler\LessCompiler;
+use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Frontend\Content\Assets;
 use Flarum\Frontend\Document;
 use Flarum\Testing\unit\TestCase;
@@ -57,9 +58,16 @@ class AssetsTest extends TestCase
         $commonAssets = m::mock(FrontendAssets::class);
         $commonAssets->shouldReceive('makeJsDirectory')->andReturn($makeCompiler(JsDirectoryCompiler::class));
 
+        // Assembling the URLs records a revision for anything compiled, and
+        // those are collected into one write rather than stored per asset.
+        $versioner = m::mock(VersionerInterface::class);
+        $versioner->shouldReceive('deferWrites')->once();
+        $versioner->shouldReceive('flushWrites')->once();
+
         $container = m::mock(Container::class);
         $container->shouldReceive('make')->with('flarum.assets.forum')->andReturn($frontendAssets);
         $container->shouldReceive('make')->with('flarum.assets.common')->andReturn($commonAssets);
+        $container->shouldReceive('make')->with(VersionerInterface::class)->andReturn($versioner);
 
         // Config is a readonly class and can't be mocked — use the real thing.
         $config = new Config(['url' => 'http://localhost', 'debug' => true]);


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

`FileVersioner` keeps every asset revision in one JSON value, so each write is a read-modify-write of all of them:

```php
$manifest = $this->readManifest();
$manifest[$file] = $revision;
$this->filesystem->put(static::REV_MANIFEST, json_encode($manifest));
```

Every instance rebuilds a dirty asset set on its next request, and `JsDirectoryCompiler::pruneStaleRevisions()` records a removal per stale chunk from `getUrl()` — during ordinary renders, not just rebuilds. So revisions are written concurrently, and a writer carrying a snapshot from before someone else's write erases it on save. `RevisionCompiler::getUrl()` only recompiles when a revision is *missing*, so a lost one isn't noticed: the asset just stays wrong until the next admin action.

I measured it on two ECS tasks writing twenty assets each — **half the writes vanished**, both tasks reporting success. Six local processes lost 83%.

Revisions now live in an `asset_revisions` table, a row per asset, written with an upsert on the primary key. Same test: **120 of 120 survive**.

`FileVersioner` stays for anyone who wants the manifest file. The table starts empty on upgrade, so the first request recompiles each asset once — a cache clear during an upgrade is standard practice anyway.

Writes during a rebuild or a render are collected and stored together, so recording 65 revisions is one statement rather than 65. Without that this trips core's own N+1 guard, which is how I found it.

One behaviour change worth calling out: `cache:clear` used to delete `rev-manifest.json` along with the rest of `storage`, leaving no revisions at all. Revisions are now rows, so they survive it — `ClearingCache` still marks the assets dirty and the next request rebuilds over them in place, which removes the window where an asset had no revision and the revision token flickered. Warming that rebuild into `cache:clear` itself, the way it already pre-builds the formatter, is a follow-up: on remote storage a cold rebuild is tens of seconds, and that belongs on the CLI rather than on whichever visitor arrives first.

**Reviewers should focus on:**

- **The destructor on `DatabaseVersioner`.** It stores a batch that was never flushed. Both call sites flush in a `finally`, so it only fires if someone forgets — but I argued against destructors doing database work when we discussed the rebuild lock, and here I've used one. It swallows throwables, so the worst case is a silently dropped write rather than an error during shutdown. Happy to drop it and let the tests be the guarantee.
- **Reads don't settle an open batch.** They can't: `getUrl()` records a revision and reads it straight back, so a read that flushed would drain the batch once per asset. The memo carries pending writes instead. That's the subtlety most likely to break if this is refactored, and there's a test on it.
- **`varchar(255)` for `file`.** The longest key on my forum is 67 characters, but chunk paths are `js/<extension>/<frontend>/…` and extensions choose their own names, so there's no real bound. 255 × 4 bytes fits under InnoDB's index limit.
- The contract is now written down on `VersionerInterface` — atomicity, error propagation, how long a memo may live. Four separate installs have hand-rolled a versioner to get revisions off the local disk, and all four reproduced this bug, because nothing said not to.

**Screenshot**

n/a, backend.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — a lock around the existing read-modify-write; one settings row per asset (a prefix `LIKE`, ~2× the read cost); conditional writes, which Flysystem drops before they reach S3.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the broken implementation is core's default, and an extension shipping a correct one leaves everyone else with the bug.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`) — unit 483/483. Integration 905, with the same 3 pre-existing failures as `2.x` (`PasswordEmailTokensTest` ×2, `ThemeTest`). PHPStan clean over `framework/core/src`.
- [x] Backend changes: tests have been added, or are not appropriate here. — 22, including the interleave that `FileVersioner` fails, batching, no-op writes, and the read/batch interaction.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — CI runs the migration and the versioner green against MySQL 5.7/8.4/9.7, MariaDB 10.3/11.8/12.3, PostgreSQL 10/15/18 and SQLite, each also with a table prefix.
- [x] Core developer confirmed locally this works as intended. — dev forum renders 200 with 80 revisions recorded and values matching the old manifest.
- [x] The description above is written by me and describes what this pull request actually does.
