### PR TITLE
[2.x] fix: rebuild a compiled catalogue when the translations behind it change

### DIFF
--- a/framework/core/src/Locale/CatalogueCache.php
+++ b/framework/core/src/Locale/CatalogueCache.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Locale;
+
+use Symfony\Component\Config\ConfigCacheInterface;
+
+/**
+ * Decides whether a compiled catalogue still reflects the translations this
+ * instance has been given.
+ *
+ * Symfony names a catalogue after its fallback locales alone, and outside debug
+ * mode considers it fresh if the file simply exists — so once written, nothing
+ * detects that the translations behind it changed. Enabling an extension on one
+ * instance leaves every other instance serving a catalogue that predates it,
+ * with no mtime, TTL or revision that would ever say otherwise.
+ *
+ * The revision recorded beside a catalogue is compared against the current one
+ * on every request for that locale. It is derived from what the instance can
+ * see for itself, so an instance that was never told anything still works out
+ * that its catalogue is stale and rebuilds it.
+ *
+ * Freshness is decided per locale, because Symfony compiles catalogues lazily
+ * per locale: a request for `de` never touches `en`. A locale nobody asks for
+ * therefore costs nothing, and rebuilds the moment it is first requested —
+ * where previously it would have stayed stale indefinitely.
+ *
+ * Registered resources are never asked whether they are fresh. Doing so would
+ * run third-party {@see \Symfony\Component\Config\Resource\SelfCheckingResourceInterface}
+ * implementations that have never executed outside debug mode, some of which
+ * resolve services and query the database on every request.
+ */
+class CatalogueCache implements ConfigCacheInterface
+{
+    public function __construct(
+        private readonly string $file,
+        private readonly string $revision
+    ) {
+    }
+
+    public function getPath(): string
+    {
+        return $this->file;
+    }
+
+    public function isFresh(): bool
+    {
+        if (! is_file($this->file)) {
+            return false;
+        }
+
+        return @file_get_contents($this->revisionPath()) === $this->revision;
+    }
+
+    public function write(string $content, ?array $metadata = null): void
+    {
+        // The catalogue first, then its revision: a process that dies between
+        // the two leaves a catalogue whose revision does not match, so the next
+        // request rebuilds it. Writing the revision first would mark a
+        // catalogue that was never written as current.
+        file_put_contents($this->file, $content);
+        file_put_contents($this->revisionPath(), $this->revision);
+    }
+
+    /**
+     * Beside the catalogue, and swept by the same `storage/locale/*` glob that
+     * clears it.
+     */
+    private function revisionPath(): string
+    {
+        return $this->file.'.revision';
+    }
+}

--- a/framework/core/src/Locale/CatalogueCacheFactory.php
+++ b/framework/core/src/Locale/CatalogueCacheFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Locale;
+
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+
+/**
+ * Hands the translator a cache that knows which translations its catalogue was
+ * built from. See {@see CatalogueCache}.
+ *
+ * The revision is resolved lazily, per call: the translator initialises a
+ * catalogue the first time one is needed, by which point every extension has
+ * registered its translation files — asking any earlier would describe a
+ * smaller set than the catalogue is actually built from.
+ */
+class CatalogueCacheFactory implements ConfigCacheFactoryInterface
+{
+    /**
+     * @param \Closure(): string $revision
+     */
+    public function __construct(
+        private readonly \Closure $revision
+    ) {
+    }
+
+    public function cache(string $file, callable $callback): ConfigCacheInterface
+    {
+        $cache = new CatalogueCache($file, ($this->revision)());
+
+        if (! $cache->isFresh()) {
+            $callback($cache);
+        }
+
+        return $cache;
+    }
+}

--- a/framework/core/src/Locale/LocaleManager.php
+++ b/framework/core/src/Locale/LocaleManager.php
@@ -9,19 +9,74 @@
 
 namespace Flarum\Locale;
 
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Support\Arr;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 
 class LocaleManager
 {
+    /**
+     * A setting any extension can bump to declare that translations have
+     * changed somewhere the registered files cannot show — the database, most
+     * obviously. Its value is opaque: only whether it differs matters.
+     */
+    public const REVISION_STAMP_KEY = 'locale_revision';
+
     protected array $locales = [];
     protected array $js = [];
     protected array $css = [];
 
+    /**
+     * Every translation file registered on this instance, as
+     * `<locale>|<prefix>|<file>`.
+     *
+     * @var list<string>
+     */
+    protected array $registered = [];
+
     public function __construct(
         protected Translator $translator,
-        protected ?string $cacheDir = null
+        protected ?string $cacheDir = null,
+        protected ?SettingsRepositoryInterface $settings = null
     ) {
+    }
+
+    /**
+     * Identifies the translations this instance has been given.
+     *
+     * A compiled catalogue's filename covers only the fallback locales, and in
+     * production `ConfigCache::isFresh()` answers `is_file()` — so once a
+     * catalogue exists nothing detects that the translations behind it have
+     * changed. Enabling an extension on one instance therefore leaves every
+     * other instance serving a catalogue that predates it, indefinitely: no
+     * mtime, no TTL and no revision would ever say otherwise, and only deleting
+     * the file forces a rebuild.
+     *
+     * This is derived from what an instance can see for itself — the files it
+     * was given, plus a stamp for translations that live elsewhere — so an
+     * instance that has been told nothing still works out that its catalogue is
+     * stale. Two instances given the same translations arrive at the same
+     * value, which is what keeps them from rebuilding in turn forever.
+     *
+     * Deliberately not derived from the contents or timestamps of those files:
+     * that would mean asking each registered resource whether it is fresh,
+     * which runs third-party code that has never executed in production — some
+     * of it resolving services and querying the database on every request. A
+     * file edited in place, with nothing added or removed and no stamp bumped,
+     * is the one change this does not see; clearing the cache covers it, which
+     * a deployment does anyway.
+     */
+    public function revision(): string
+    {
+        $registered = $this->registered;
+        sort($registered);
+
+        return hash('xxh128', implode("\n", $registered)."\0".$this->revisionStamp());
+    }
+
+    protected function revisionStamp(): string
+    {
+        return (string) ($this->settings?->get(static::REVISION_STAMP_KEY) ?? '');
     }
 
     public function getLocale(): string
@@ -56,6 +111,9 @@ class LocaleManager
         // `messages` is the default domain, and we want to support MessageFormat
         // for all translations.
         $domain = 'messages'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+
+        // Recorded so revision() can tell what this instance was given.
+        $this->registered[] = $locale.'|'.$prefix.'|'.$file;
 
         $this->translator->addResource('prefixed_yaml', compact('file', 'prefix'), $locale, $domain);
     }

--- a/framework/core/src/Locale/LocaleServiceProvider.php
+++ b/framework/core/src/Locale/LocaleServiceProvider.php
@@ -9,10 +9,14 @@
 
 namespace Flarum\Locale;
 
+use Flarum\Extension\Event\Disabled;
+use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Symfony\Contracts\Translation\TranslatorInterface as SymfonyTranslatorInterface;
 
@@ -23,7 +27,8 @@ class LocaleServiceProvider extends AbstractServiceProvider
         $this->container->singleton(LocaleManager::class, function (Container $container) {
             $locales = new LocaleManager(
                 $container->make('translator'),
-                $this->getCacheDir($container)
+                $this->getCacheDir($container),
+                $container->make(SettingsRepositoryInterface::class)
             );
 
             $locales->addLocale($this->getDefaultLocale($container), 'Default');
@@ -46,6 +51,14 @@ class LocaleServiceProvider extends AbstractServiceProvider
             $translator->setFallbackLocales(['en']);
             $translator->addLoader('prefixed_yaml', new PrefixedYamlFileLoader());
 
+            // Symfony would otherwise treat a compiled catalogue as current for
+            // as long as the file exists, whatever has changed behind it.
+            // Resolved lazily: the manager is built from this translator, and
+            // the files are registered on it afterwards.
+            $translator->setConfigCacheFactory(new CatalogueCacheFactory(
+                fn () => $container->make(LocaleManager::class)->revision()
+            ));
+
             return $translator;
         });
 
@@ -53,6 +66,26 @@ class LocaleServiceProvider extends AbstractServiceProvider
         $this->container->alias('translator', TranslatorContract::class);
         $this->container->alias('translator', SymfonyTranslatorInterface::class);
         $this->container->alias('translator', TranslatorInterface::class);
+    }
+
+    public function boot(Container $container, Dispatcher $events): void
+    {
+        // Bump the locale revision whenever translations may have changed in a
+        // way the registered files cannot show.
+        //
+        // Toggling an extension changes the file list, so every instance works
+        // that out for itself. Clearing the cache does not: it deletes the
+        // catalogues on the instance that ran it and leaves every other
+        // instance with files it still considers fresh. The stamp is what
+        // carries "rebuild these" to instances that were never told anything —
+        // they compare it on their next request and rebuild then.
+        $events->listen(
+            [Enabled::class, Disabled::class, ClearingCache::class],
+            function () use ($container) {
+                $container->make(SettingsRepositoryInterface::class)
+                    ->set(LocaleManager::REVISION_STAMP_KEY, (string) microtime(true));
+            }
+        );
     }
 
     private function getDefaultLocale(Container $container): string

--- a/framework/core/tests/unit/Locale/LocaleRevisionTest.php
+++ b/framework/core/tests/unit/Locale/LocaleRevisionTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Locale;
+
+use Flarum\Locale\LocaleManager;
+use Flarum\Locale\Translator;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A compiled catalogue's filename is derived from the fallback locales alone,
+ * and in production `ConfigCache::isFresh()` answers `is_file()` — so nothing
+ * detects that the translations behind it have changed. Enabling an extension
+ * on one instance leaves every other instance serving a catalogue that predates
+ * it, indefinitely, with no signal that would ever refresh it.
+ *
+ * The revision below is that signal: it is computed from what an instance can
+ * see for itself, so an instance that has never been told anything still
+ * notices its catalogue is stale.
+ */
+class LocaleRevisionTest extends TestCase
+{
+    private function settings(array $rows = []): SettingsRepositoryInterface
+    {
+        return new class($rows) implements SettingsRepositoryInterface {
+            public function __construct(public array $rows)
+            {
+            }
+
+            public function all(): array
+            {
+                return $this->rows;
+            }
+
+            public function get(string $key, mixed $default = null): mixed
+            {
+                return $this->rows[$key] ?? $default;
+            }
+
+            public function set(string $key, mixed $value): void
+            {
+                $this->rows[$key] = $value;
+            }
+
+            public function delete(string $keyLike): void
+            {
+                unset($this->rows[$keyLike]);
+            }
+        };
+    }
+
+    private function manager(?SettingsRepositoryInterface $settings = null): LocaleManager
+    {
+        $translator = m::mock(Translator::class);
+        $translator->shouldReceive('addResource');
+
+        return new LocaleManager($translator, null, $settings ?? $this->settings());
+    }
+
+    #[Test]
+    public function the_revision_is_stable_while_nothing_changes()
+    {
+        $locales = $this->manager();
+        $locales->addTranslations('en', '/core/locale/core.yml');
+
+        $first = $locales->revision();
+
+        $this->assertSame($first, $locales->revision());
+        $this->assertNotSame('', $first);
+    }
+
+    /**
+     * The case that matters: enabling an extension adds its locale files, so an
+     * instance that merely boots afterwards computes a different revision — no
+     * message from the instance that performed the toggle required.
+     */
+    #[Test]
+    public function adding_a_translation_file_changes_the_revision()
+    {
+        $before = $this->manager();
+        $before->addTranslations('en', '/core/locale/core.yml');
+
+        $after = $this->manager();
+        $after->addTranslations('en', '/core/locale/core.yml');
+        $after->addTranslations('en', '/ext/flarum-tags/locale/en.yml');
+
+        $this->assertNotSame($before->revision(), $after->revision());
+    }
+
+    #[Test]
+    public function removing_a_translation_file_changes_the_revision()
+    {
+        $with = $this->manager();
+        $with->addTranslations('en', '/core/locale/core.yml');
+        $with->addTranslations('en', '/ext/flarum-tags/locale/en.yml');
+
+        $without = $this->manager();
+        $without->addTranslations('en', '/core/locale/core.yml');
+
+        $this->assertNotSame($with->revision(), $without->revision());
+    }
+
+    #[Test]
+    public function the_revision_ignores_the_order_files_were_registered_in()
+    {
+        $one = $this->manager();
+        $one->addTranslations('en', '/a.yml');
+        $one->addTranslations('en', '/b.yml');
+
+        $two = $this->manager();
+        $two->addTranslations('en', '/b.yml');
+        $two->addTranslations('en', '/a.yml');
+
+        $this->assertSame($one->revision(), $two->revision());
+    }
+
+    #[Test]
+    public function a_files_locale_is_part_of_the_revision()
+    {
+        $en = $this->manager();
+        $en->addTranslations('en', '/locale/x.yml');
+
+        $de = $this->manager();
+        $de->addTranslations('de', '/locale/x.yml');
+
+        $this->assertNotSame($en->revision(), $de->revision());
+    }
+
+    /**
+     * A language pack registers the same paths under a module prefix, which
+     * changes which keys the catalogue ends up with.
+     */
+    #[Test]
+    public function a_modules_prefix_is_part_of_the_revision()
+    {
+        $bare = $this->manager();
+        $bare->addTranslations('en', '/locale/x.yml');
+
+        $prefixed = $this->manager();
+        $prefixed->addTranslations('en', '/locale/x.yml', 'flarum-tags');
+
+        $this->assertNotSame($bare->revision(), $prefixed->revision());
+    }
+
+    /**
+     * Translations that live somewhere other than a registered file — the
+     * database, in fof/linguist's case — cannot show up in the file list. A
+     * stamp any extension can bump covers them, without core having to ask a
+     * resource whether it is fresh: doing that would run third-party code that
+     * has never executed in production, some of which resolves services and
+     * queries the database.
+     */
+    #[Test]
+    public function bumping_the_stamp_changes_the_revision()
+    {
+        $settings = $this->settings();
+
+        $locales = $this->manager($settings);
+        $locales->addTranslations('en', '/core/locale/core.yml');
+
+        $before = $locales->revision();
+
+        $settings->set(LocaleManager::REVISION_STAMP_KEY, '1757400000');
+
+        $this->assertNotSame($before, $this->managerWith($settings)->revision());
+    }
+
+    #[Test]
+    public function two_instances_with_the_same_files_and_stamp_agree()
+    {
+        $settings = $this->settings([LocaleManager::REVISION_STAMP_KEY => '1757400000']);
+
+        $podA = $this->manager($settings);
+        $podA->addTranslations('en', '/core/locale/core.yml');
+        $podA->addTranslations('de', '/pack/de.yml');
+
+        $podB = $this->manager($settings);
+        $podB->addTranslations('de', '/pack/de.yml');
+        $podB->addTranslations('en', '/core/locale/core.yml');
+
+        $this->assertSame(
+            $podA->revision(),
+            $podB->revision(),
+            'instances seeing the same translations must agree, or they would rebuild forever'
+        );
+    }
+
+    #[Test]
+    public function the_revision_works_without_a_settings_repository()
+    {
+        $translator = m::mock(Translator::class);
+        $translator->shouldReceive('addResource');
+
+        $locales = new LocaleManager($translator, null);
+        $locales->addTranslations('en', '/core/locale/core.yml');
+
+        $this->assertNotSame('', $locales->revision());
+    }
+
+    private function managerWith(SettingsRepositoryInterface $settings): LocaleManager
+    {
+        $locales = $this->manager($settings);
+        $locales->addTranslations('en', '/core/locale/core.yml');
+
+        return $locales;
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

A compiled catalogue is named after its fallback locales alone:

```php
return $this->cacheDir.'/catalogue.'.$locale.'.'.strtr(substr(base64_encode(hash('xxh128', serialize($this->cacheVary), true)), 0, 7), '/', '_').'.php';
```

and outside debug mode `ConfigCache::isFresh()` answers `is_file()`:

```php
if (!$this->debug && is_file($this->getPath())) {
    return true;
}
```

So once a catalogue exists, nothing detects that the translations behind it changed. Enabling an extension deletes the catalogues on the instance that did it, and every other instance keeps serving one that predates the extension — no mtime, TTL or revision would ever say otherwise. On dev with `debug` off: an instance held a 447,563-byte catalogue and returned the raw key `fof-pages.admin.edit_page.delete_page_button` across three boots and a page load. It never recovers.

`LocaleManager` now records the files it was given and derives a revision from them, plus a stamp for translations that live elsewhere. The revision is written beside a catalogue and compared on each request for that locale, through a `ConfigCacheFactory` set with the public `setConfigCacheFactory()`. Same instance, same stale catalogue, with this: rebuilt to 449,593 bytes and the key resolves.

Registered resources are never asked whether they are fresh. That would run `SelfCheckingResourceInterface` implementations which have never executed outside debug mode — fof/linguist's queries the database through `resolve()` on every call — so this deliberately doesn't wake them.

**Reviewers should focus on:**

- **Freshness is per locale, because Symfony compiles catalogues per locale.** A request for `de` never touches `en`. So after a revision change an admin working in `de` rebuilds `de` and leaves `en` alone until a forum user asks for it. That's the historical complaint about admin locales not rebuilding the default, and this doesn't remove it — it bounds it at "until that locale is next requested" instead of "never". Rebuilding every locale eagerly was the alternative; on a six-locale forum that is five YAML merges nobody asked for.
- **`cache:clear` bumps the stamp**, and it has to. Clearing the cache deletes the catalogues on one instance and changes nothing another instance can see — same file list, same stamp — so without the bump the others would never rebuild. Toggling an extension needs no help: the file list changes, so each instance works it out alone.
- **The residual.** A YAML edited in place, with nothing added or removed and no stamp bumped, is not detected. Clearing the cache covers it, which a deploy does anyway. Catching it would mean stat-ing every registered file per request.
- **What this does not claim.** fof/redis already propagates these invalidations and I watched it work: enabling an extension on one ECS task left the other serving the raw key, then its epoch landed and the catalogue rebuilt. This isn't a fix for that being broken. It's that the locale deletion is the only part of that apply where a missed message means permanently wrong output — the formatter and settings caches both self-heal — and `pubsub.enabled` defaults to `false`. This makes the propagation an optimisation rather than the guarantee.

**Screenshot**

n/a, backend.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — enabling resource checking in production (wakes third-party `isFresh()`); content-keying the filename (`resources`, `cacheVary` and `getCatalogueCachePath()` are all private); seeding `cacheVary` at construction (files register afterwards).
- [x] For core PRs, does this need to be in core, or could it be in an extension? — it is core's own catalogue cache, and nothing outside core can reach the private state involved.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`) — unit 493/493. Integration 905, with the same 3 pre-existing failures as `2.x` (`PasswordEmailTokensTest` ×2, `ThemeTest`). PHPStan clean over `framework/core/src`.
- [x] Backend changes: tests have been added, or are not appropriate here. — 9, covering a file added and removed, registration order, locale and module prefix, the stamp, two instances agreeing, and no settings repository.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — one settings read, no schema change.
- [x] Core developer confirmed locally this works as intended — red and green for all four scenarios on a `debug`-off install, plus steady state: twenty `getCatalogue()` calls rebuild nothing, and `revision()` costs 0.01ms.
