### PR TITLE
[2.x] fix: clearing the cache reports success before the work is done

### DIFF
--- a/framework/core/js/src/admin/components/ClearCacheModal.tsx
+++ b/framework/core/js/src/admin/components/ClearCacheModal.tsx
@@ -1,0 +1,230 @@
+import app from '../../admin/app';
+import Modal, { IInternalModalAttrs } from '../../common/components/Modal';
+import Button from '../../common/components/Button';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Icon from '../../common/components/Icon';
+import type Mithril from 'mithril';
+
+/**
+ * One thing the server did, as it reported it.
+ *
+ * Every step says what happened rather than describing it, so the wording here
+ * comes from the translations — a sentence assembled on the server could only
+ * ever have been in English.
+ */
+interface Step {
+  type: 'cleared' | 'rebuilt' | 'failed' | 'done';
+  name?: string;
+  files?: number | null;
+  frontend?: string;
+  locale?: string | null;
+  localeName?: string | null;
+  bundle?: string;
+  state?: 'unchanged' | 'rebuilt' | 'rewritten' | 'empty' | 'chunks';
+  changed?: number | null;
+  milliseconds?: number;
+  step?: string;
+  message?: string;
+}
+
+export interface IClearCacheModalAttrs extends IInternalModalAttrs {}
+
+/**
+ * Clears the cache, showing each step as the server finishes it.
+ *
+ * The work recompiles every asset bundle for every frontend and locale, which
+ * runs for tens of seconds where the assets live on remote storage. A spinner
+ * alone gives no way to tell that from a request that has died, so the steps
+ * are read from the response as they arrive.
+ *
+ * Nothing reloads on its own at the end: the page is still running on the
+ * assets it booted with, and an admin who has just watched a rebuild should
+ * decide for themselves when to pick up the new ones.
+ */
+export default class ClearCacheModal<ModalAttrs extends IClearCacheModalAttrs = IClearCacheModalAttrs> extends Modal<ModalAttrs> {
+  protected steps: Step[] = [];
+  protected finished = false;
+
+  protected static readonly isDismissibleViaCloseButton: boolean = false;
+  protected static readonly isDismissibleViaEscKey: boolean = false;
+  protected static readonly isDismissibleViaBackdropClick: boolean = false;
+
+  oninit(vnode: Mithril.Vnode<ModalAttrs, this>) {
+    super.oninit(vnode);
+
+    this.clear();
+  }
+
+  className() {
+    return 'ClearCacheModal Modal--medium';
+  }
+
+  title() {
+    return app.translator.trans('core.admin.dashboard.clear_cache_modal.title');
+  }
+
+  content() {
+    return (
+      <div className="Modal-body">
+        <ol className="ClearCacheModal-steps">
+          {this.steps
+            .filter((step) => step.type !== 'done')
+            .map((step, i, steps) => (
+              <li className={'ClearCacheModal-step ClearCacheModal-step--' + this.appearance(step)}>
+                <Icon name={this.icon(step)} className="ClearCacheModal-step-icon" />
+                <span className="ClearCacheModal-step-label">{this.describe(step)}</span>
+                {this.time(step, steps[i - 1])}
+              </li>
+            ))}
+        </ol>
+
+        <div className="ClearCacheModal-footer">
+          {this.finished ? (
+            <Button className="Button Button--primary" icon="fas fa-sync" onclick={() => window.location.reload()}>
+              {app.translator.trans('core.admin.dashboard.clear_cache_modal.reload_button')}
+            </Button>
+          ) : (
+            <p className="ClearCacheModal-working">
+              <LoadingIndicator display="inline" size="small" /> {app.translator.trans('core.admin.dashboard.clear_cache_modal.working')}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * How much of the reader's attention a step deserves.
+   *
+   * Most of a clear is bundles that turned out not to need rebuilding, and on a
+   * forum with several locales those rows are the majority. They are worth
+   * listing — they are how you know nothing was missed — but not worth reading,
+   * so they recede and the handful of things that actually changed stand out.
+   */
+  protected appearance(step: Step): string {
+    if (step.type === 'failed') return 'failed';
+    if (step.state === 'unchanged' || step.state === 'empty') return 'quiet';
+    if (step.state === 'chunks' && !step.changed) return 'quiet';
+
+    return 'changed';
+  }
+
+  /**
+   * How long a step took, where that is worth knowing.
+   *
+   * Bundles compiled together are timed together, so the figure belongs to the
+   * frontend rather than to each of its bundles — repeating it down every row
+   * of a group would read as several slow steps instead of one. Shown against
+   * the first row of each group only, as the console table does it.
+   */
+  protected time(step: Step, previous?: Step): Mithril.Children {
+    if (step.milliseconds === undefined || step.milliseconds < 100) return null;
+
+    const group = (s?: Step) => (s === undefined ? null : `${s.frontend}\u0000${s.locale}`);
+
+    if (group(step) === group(previous)) return null;
+
+    return (
+      <span className="ClearCacheModal-step-detail">
+        {app.translator.trans('core.admin.dashboard.clear_cache_modal.took', { time: step.milliseconds })}
+      </span>
+    );
+  }
+
+  protected icon(step: Step): string {
+    return {
+      failed: 'fas fa-exclamation-triangle',
+      quiet: 'fas fa-minus',
+      changed: 'fas fa-check',
+    }[this.appearance(step)]!;
+  }
+
+  /**
+   * Puts words to a step. Which words depend only on what the server said
+   * happened, never on a string it sent.
+   */
+  protected describe(step: Step): Mithril.Children {
+    const key = (name: string) => `core.admin.dashboard.clear_cache_modal.${name}`;
+
+    switch (step.type) {
+      case 'cleared':
+        return step.files === null || step.files === undefined
+          ? app.translator.trans(key('cleared'), { name: step.name })
+          : app.translator.trans(key('cleared_files'), { name: step.name, count: step.files });
+
+      case 'failed':
+        return app.translator.trans(key('failed'), { step: step.step, message: step.message });
+
+      case 'rebuilt':
+        if (step.state === 'chunks') {
+          return app.translator.trans(key('chunks'), { frontend: step.frontend, count: step.changed });
+        }
+
+        // The bundle's own name is the useful label — `forum-de.js` says both
+        // which frontend and which locale it belongs to.
+        return app.translator.trans(key(step.state ?? 'rebuilt'), { bundle: step.bundle });
+
+      // `done` is the stream's terminator rather than a step, and is filtered
+      // out before rendering. A type added server-side without a case here
+      // lands as a blank row instead of breaking the list.
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Reads the response as it is written.
+   *
+   * `app.request` cannot be used here: it hands back the body once, complete,
+   * so nothing could be shown until the work had finished. Each line is a whole
+   * JSON object, so a step can be rendered the moment its line arrives.
+   */
+  protected async clear() {
+    try {
+      const response = await fetch(app.forum.attribute('apiUrl') + '/cache', {
+        method: 'DELETE',
+        headers: {
+          'X-CSRF-Token': app.session.csrfToken!,
+        },
+        credentials: 'same-origin',
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(String(response.status));
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffered = '';
+
+      for (;;) {
+        const { done, value } = await reader.read();
+
+        if (done) break;
+
+        buffered += decoder.decode(value, { stream: true });
+
+        // Anything up to the last newline is complete; whatever follows it is
+        // half a line and waits for the next chunk.
+        const lines = buffered.split('\n');
+        buffered = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (line.trim() === '') continue;
+
+          this.steps.push(JSON.parse(line));
+        }
+
+        m.redraw();
+      }
+    } catch (e) {
+      app.alerts.show({ type: 'error' }, app.translator.trans('core.admin.dashboard.io_error_message'));
+    }
+
+    // Either way the caches are gone, so the page is running on assets that may
+    // no longer exist — offer the reload rather than leaving a spinner.
+    this.finished = true;
+
+    m.redraw();
+  }
+}

--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -4,7 +4,7 @@ import listItems from '../../common/helpers/listItems';
 import ItemList from '../../common/utils/ItemList';
 import Dropdown from '../../common/components/Dropdown';
 import Button from '../../common/components/Button';
-import LoadingModal from './LoadingModal';
+import ClearCacheModal from './ClearCacheModal';
 import LinkButton from '../../common/components/LinkButton';
 import saveSettings from '../utils/saveSettings';
 import StatusWidgetItem from './StatusWidgetItem';
@@ -110,22 +110,10 @@ export default class StatusWidget extends DashboardWidget {
   }
 
   handleClearCache(e) {
-    app.modal.show(LoadingModal);
-
-    app
-      .request({
-        method: 'DELETE',
-        url: app.forum.attribute('apiUrl') + '/cache',
-      })
-      .then(() => window.location.reload())
-      .catch((e) => {
-        if (e.status === 409) {
-          app.alerts.clear();
-          app.alerts.show({ type: 'error' }, app.translator.trans('core.admin.dashboard.io_error_message'));
-        }
-
-        app.modal.close();
-      });
+    // The modal does the request itself: clearing the cache rebuilds every
+    // asset bundle and reports each step as it finishes, and reading those
+    // needs the response as it is written rather than once it is complete.
+    app.modal.show(ClearCacheModal);
   }
 
   handleShowInfo() {

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -4,6 +4,7 @@
 @import "admin/AdminHeader";
 @import "admin/AdminNav";
 @import "admin/AdvancedPage";
+@import "admin/ClearCacheModal";
 @import "admin/CreateUserModal";
 @import "admin/DashboardPage";
 @import "admin/AlertWidget";

--- a/framework/core/less/admin/ClearCacheModal.less
+++ b/framework/core/less/admin/ClearCacheModal.less
@@ -1,0 +1,92 @@
+.ClearCacheModal {
+  &-steps {
+    list-style: none;
+    margin: 0 0 15px;
+    padding: 0;
+    font-size: 13px;
+    line-height: 1.5;
+
+    // A clear reports a row per bundle per locale, so this is routinely 30+
+    // rows. Scrolling the list rather than the modal keeps the footer — and so
+    // the reload button — where the reader last saw it.
+    max-height: 45vh;
+    overflow-y: auto;
+  }
+
+  &-step {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 3px 0;
+
+    // Steps arrive one at a time over tens of seconds. Without this each new
+    // row appears indistinguishably from the ones already there, and there is
+    // nothing to tell the eye that the list is still moving.
+    animation: ClearCacheModal-step-in 150ms ease-out;
+  }
+
+  &-step-icon {
+    flex-shrink: 0;
+    width: 1em;
+    text-align: center;
+    font-size: 11px;
+  }
+
+  &-step-label {
+    flex: 1;
+    word-break: break-word;
+  }
+
+  &-step-detail {
+    flex-shrink: 0;
+    color: var(--muted-color);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  // Most rows are bundles that turned out not to need rebuilding. They earn
+  // their place by showing nothing was skipped, but they are not what the
+  // admin came to read, so they sit back and let the changes carry the colour.
+  &-step--quiet {
+    color: var(--muted-color);
+  }
+
+  &-step--changed .ClearCacheModal-step-icon {
+    color: var(--primary-color);
+  }
+
+  &-step--failed {
+    color: var(--error-color);
+
+    .ClearCacheModal-step-label {
+      font-weight: 600;
+    }
+  }
+
+  &-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    border-top: 1px solid var(--control-bg);
+    padding-top: 12px;
+  }
+
+  &-working {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    color: var(--muted-color);
+  }
+}
+
+@keyframes ClearCacheModal-step-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -226,6 +226,19 @@ core:
       queue_paused_all_warning: All queue processing is paused. Jobs will accumulate until it is resumed.
       queue_paused_manage: Manage
       clear_cache_button: Clear Cache
+      clear_cache_modal:
+        title: Clearing the Cache
+        working: Rebuilding the compiled assets. This can take a while on larger forums.
+        cleared: "Cleared {name}"
+        cleared_files: "Cleared {name} ({count} files)"
+        rebuilt: "Rebuilt {bundle}"
+        unchanged: "{bundle} was already up to date"
+        rewritten: "Rewrote {bundle}"
+        empty: "{bundle} has nothing to compile"
+        chunks: "Rebuilt the split chunks for {frontend} ({count} changed)"
+        failed: "Could not rebuild {step}: {message}"
+        took: "{time}ms"
+        reload_button: Reload
       description: Your forum at a glance.
       info_button: System Info
       info_modal:

--- a/framework/core/src/Api/Controller/ClearCacheController.php
+++ b/framework/core/src/Api/Controller/ClearCacheController.php
@@ -11,13 +11,30 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Foundation\Console\AssetsPublishCommand;
 use Flarum\Foundation\Console\CacheClearCommand;
-use Flarum\Foundation\IOException;
 use Flarum\Http\RequestUtil;
+use Laminas\Diactoros\CallbackStream;
+use Laminas\Diactoros\Response;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-class ClearCacheController extends AbstractDeleteController
+/**
+ * Clears the cache, reporting each step as it finishes.
+ *
+ * The work recompiles every asset bundle for every frontend and locale, which
+ * is tens of seconds where the assets live on remote storage. Waiting until the
+ * end to answer leaves the admin watching a spinner with no way to tell a slow
+ * clear from a dead request, so the steps are streamed as newline-delimited
+ * JSON — one object per line, each complete in itself.
+ *
+ * Only the body streams. Authorisation, CSRF, throttling and error handling all
+ * still come from the API middleware: those wrap the response object, and it is
+ * the emitter that consumes the body, so a {@see CallbackStream} passes through
+ * them untouched and is streamed by {@see \Flarum\Http\Emitter} at the end.
+ */
+class ClearCacheController implements RequestHandlerInterface
 {
     public function __construct(
         protected CacheClearCommand $command,
@@ -25,29 +42,65 @@ class ClearCacheController extends AbstractDeleteController
     ) {
     }
 
-    /**
-     * @throws IOException|\Flarum\User\Exception\PermissionDeniedException|\Symfony\Component\Console\Exception\ExceptionInterface
-     */
-    protected function delete(ServerRequestInterface $request): void
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         RequestUtil::getActor($request)->assertAdmin();
 
-        $exitCode = $this->command->run(
-            new ArrayInput([]),
-            new NullOutput()
-        );
+        return (new Response())
+            ->withHeader('Content-Type', 'application/x-ndjson')
+            // Nothing downstream may hold the response back while it accumulates
+            // a complete body — which is exactly what a proxy buffering for
+            // compression would do.
+            ->withHeader('Cache-Control', 'no-cache, no-transform')
+            ->withHeader('X-Accel-Buffering', 'no')
+            ->withBody(new CallbackStream($this->steps()));
+    }
 
-        if ($exitCode !== 0) {
-            throw new IOException();
-        }
+    /**
+     * The work itself, run while the response is being written.
+     *
+     * By this point the headers have been sent, so a failure cannot become an
+     * error response: it is written as a step of its own and the stream closes
+     * normally, leaving the client to report it. Everything after the caches are
+     * emptied is best-effort anyway — the render path rebuilds lazily, as it did
+     * before any of this was pre-built.
+     */
+    private function steps(): callable
+    {
+        return function (): string {
+            $write = function (string $type, array $step): void {
+                echo json_encode(['type' => $type] + $step, JSON_UNESCAPED_SLASHES)."\n";
 
-        $exitCode = $this->assetsPublishCommand->run(
-            new ArrayInput([]),
-            new NullOutput()
-        );
+                flush();
+            };
 
-        if ($exitCode !== 0) {
-            throw new IOException();
-        }
+            try {
+                $report = $this->command->clear(false, $write);
+
+                if ($report === null) {
+                    $write('failed', [
+                        'step' => 'cache',
+                        'message' => 'Could not clear contents of `storage/cache`. Please adjust file permissions and try again.',
+                    ]);
+
+                    return '';
+                }
+
+                $exitCode = $this->assetsPublishCommand->run(new ArrayInput([]), new NullOutput());
+
+                $exitCode === 0
+                    ? $write('cleared', ['name' => 'published assets', 'files' => null])
+                    : $write('failed', ['step' => 'assets:publish', 'message' => 'Publishing assets failed.']);
+            } catch (\Throwable $e) {
+                $write('failed', ['step' => 'clear', 'message' => $e->getMessage()]);
+            }
+
+            // The client watches for this rather than inferring completion from
+            // the connection closing, which it cannot distinguish from a
+            // connection that dropped.
+            $write('done', []);
+
+            return '';
+        };
     }
 }

--- a/framework/core/src/Foundation/CacheClearReport.php
+++ b/framework/core/src/Foundation/CacheClearReport.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+/**
+ * What clearing the cache actually did.
+ *
+ * Kept separate from how it is presented: the console renders it as a table,
+ * the API hands it to the admin panel as JSON. Each step records what happened
+ * rather than a sentence about it, so the words can come from the translations
+ * on whichever side is doing the rendering — a formatted string built here
+ * would be English for ever.
+ */
+class CacheClearReport
+{
+    /**
+     * A cache that was emptied, and how many files went with it.
+     *
+     * @var list<array{name: string, files: int|null}>
+     */
+    private array $cleared = [];
+
+    /**
+     * @var list<array{
+     *     frontend: string,
+     *     locale: string|null,
+     *     localeName: string|null,
+     *     bundle: string,
+     *     state: string,
+     *     revision: string|null,
+     *     previousRevision: string|null,
+     *     bytes: int|null,
+     *     changed: int|null,
+     *     milliseconds: int
+     * }>
+     */
+    private array $rebuilt = [];
+
+    /**
+     * @var list<array{step: string, message: string}>
+     */
+    private array $failures = [];
+
+    public const UNCHANGED = 'unchanged';
+    public const REBUILT = 'rebuilt';
+    public const REWRITTEN = 'rewritten';
+    public const EMPTY = 'empty';
+    public const CHUNKS = 'chunks';
+
+    /**
+     * Called with each step as it finishes, for a caller that cannot wait until
+     * the end — clearing the cache recompiles every bundle for every frontend
+     * and locale, which is tens of seconds where the assets live on remote
+     * storage, and an admin watching a spinner has no way to tell that from a
+     * request that has died.
+     *
+     * @var (callable(string, array<string, mixed>): void)|null
+     */
+    private $listener;
+
+    /**
+     * @param (callable(string, array<string, mixed>): void)|null $listener
+     */
+    public function __construct(?callable $listener = null)
+    {
+        $this->listener = $listener;
+    }
+
+    public function cleared(string $name, ?int $files = null): void
+    {
+        $this->announce('cleared', $this->cleared[] = compact('name', 'files'));
+    }
+
+    /**
+     * @param array<string, mixed> $step
+     */
+    private function announce(string $type, array $step): void
+    {
+        if ($this->listener !== null) {
+            ($this->listener)($type, $step);
+        }
+    }
+
+    /**
+     * One compiled bundle.
+     *
+     * `$state` says what happened to it — see the constants above — so a
+     * renderer can decide whether a revision, a size or neither is worth
+     * showing without parsing anything.
+     */
+    public function rebuilt(
+        string $frontend,
+        ?string $locale,
+        ?string $localeName,
+        string $bundle,
+        string $state,
+        ?string $revision,
+        ?string $previousRevision,
+        ?int $bytes,
+        float $seconds
+    ): void {
+        $this->announce('rebuilt', $this->rebuilt[] = [
+            'frontend' => $frontend,
+            'locale' => $locale,
+            'localeName' => $localeName,
+            'bundle' => $bundle,
+            'state' => $state,
+            'revision' => $revision,
+            'previousRevision' => $previousRevision,
+            'bytes' => $bytes,
+            'changed' => null,
+            'milliseconds' => (int) round($seconds * 1000),
+        ]);
+    }
+
+    /**
+     * The split chunks of one frontend, which have a revision each rather than
+     * one between them, so only a count of what moved is meaningful.
+     */
+    public function rebuiltChunks(string $frontend, int $changed, float $seconds): void
+    {
+        $this->announce('rebuilt', $this->rebuilt[] = [
+            'frontend' => $frontend,
+            'locale' => null,
+            'localeName' => null,
+            'bundle' => 'chunks',
+            'state' => static::CHUNKS,
+            'revision' => null,
+            'previousRevision' => null,
+            'bytes' => null,
+            'changed' => $changed,
+            'milliseconds' => (int) round($seconds * 1000),
+        ]);
+    }
+
+    /**
+     * A step that could not be pre-built. The cache is already cleared by the
+     * time any of them run, so these are reported rather than fatal.
+     */
+    public function failed(string $step, string $message): void
+    {
+        $this->announce('failed', $this->failures[] = compact('step', 'message'));
+    }
+
+    /**
+     * @return list<array{name: string, files: int|null}>
+     */
+    public function getCleared(): array
+    {
+        return $this->cleared;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function getRebuilt(): array
+    {
+        return $this->rebuilt;
+    }
+
+    /**
+     * @return list<array{step: string, message: string}>
+     */
+    public function getFailures(): array
+    {
+        return $this->failures;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'cleared' => $this->cleared,
+            'rebuilt' => $this->rebuilt,
+            'failures' => $this->failures,
+        ];
+    }
+}

--- a/framework/core/src/Foundation/Console/CacheClearCommand.php
+++ b/framework/core/src/Foundation/Console/CacheClearCommand.php
@@ -11,6 +11,7 @@ namespace Flarum\Foundation\Console;
 
 use Flarum\Console\AbstractCommand;
 use Flarum\Formatter\Formatter;
+use Flarum\Foundation\CacheClearReport;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
 use Flarum\Frontend\AssetManager;
@@ -57,74 +58,126 @@ class CacheClearCommand extends AbstractCommand
 
     protected function fire(): int
     {
-        $this->info('Clearing the cache...');
+        $report = $this->clear((bool) $this->input->getOption('force'));
 
-        $succeeded = $this->cache->flush();
-
-        if (! $succeeded) {
+        if ($report === null) {
             $this->error('Could not clear contents of `storage/cache`. Please adjust file permissions and try again. This can frequently be fixed by clearing cache via the `Tools` dropdown on the Administration Dashboard page.');
 
             return Command::FAILURE;
         }
 
-        $this->info('  cache store');
-
-        $storagePath = $this->paths->storage;
-
-        foreach (['formatter' => 'formatter classes', 'locale' => 'locale catalogues', 'views' => 'compiled views'] as $dir => $label) {
-            $removed = count(array_filter(glob($storagePath.'/'.$dir.'/*') ?: [], 'unlink'));
-
-            $this->info(sprintf('  %s (%d)', $label, $removed));
-        }
-
-        $this->events->dispatch(new ClearingCache);
-
-        $this->info('Rebuilding...');
-
-        // Rebuild now, while we're here and the memory limit is usually
-        // generous, rather than leaving the work to whichever request happens
-        // to arrive next. Each is best-effort: the cache is already cleared, so
-        // a failure here must not fail the command — the render path still
-        // rebuilds lazily, exactly as it did before any of this was warmed.
-        try {
-            $this->formatter->warm();
-
-            $this->info('  formatter');
-        } catch (\Throwable $e) {
-            $this->error('  formatter could not be pre-built: '.$e->getMessage());
-        }
-
-        try {
-            $this->warmAssets((bool) $this->input->getOption('force'));
-        } catch (\Throwable $e) {
-            $this->error('  assets could not be pre-built: '.$e->getMessage());
-        }
+        $this->render($report);
 
         return Command::SUCCESS;
     }
 
     /**
-     * Rebuild every compiled asset set, reporting each locale as it goes.
+     * Empty the caches and rebuild what can be rebuilt here, describing what
+     * happened.
      *
-     * Clearing the cache flags each set as needing a rebuild, and that flag is
-     * what makes the next request do the work. Recompiling without clearing it
-     * would leave every instance still believing it has a rebuild outstanding,
-     * so the first visitor would pay for it regardless — hence the flag is
-     * settled here once the set has been rebuilt. The compilers are driven
-     * directly rather than through
-     * {@see \Flarum\Frontend\RecompileFrontendAssets::recompileIfDirty()} so
-     * that each locale can be reported as it finishes.
+     * Returns null when the cache store could not be emptied, which is the one
+     * failure that leaves nothing worth reporting. Everything after that point
+     * is best-effort: the caches are already gone, so a step that cannot be
+     * pre-built is recorded and the command still succeeds — the render path
+     * rebuilds lazily, exactly as it did before any of this was warmed.
      *
-     * Locales are listed individually because most of the time goes on them: a
-     * forum with a dozen locales compiles a bundle per locale per frontend, and
-     * without the breakdown a slow rebuild is indistinguishable from a hung one.
+     * Public so the admin panel can clear the cache and show the same detail
+     * the console does. A listener is called with each step as it finishes, for
+     * a caller streaming them to a browser rather than waiting for the lot.
      */
-    protected function warmAssets(bool $force): void
+    public function clear(bool $force = false, ?callable $listener = null): ?CacheClearReport
     {
+        if (! $this->cache->flush()) {
+            return null;
+        }
+
+        $report = new CacheClearReport($listener);
+
+        $report->cleared('cache store');
+
+        foreach (['formatter', 'locale', 'views'] as $dir) {
+            $files = glob($this->paths->storage.'/'.$dir.'/*') ?: [];
+
+            $report->cleared($dir, count(array_filter($files, 'unlink')));
+        }
+
+        $this->events->dispatch(new ClearingCache);
+
+        // Rebuild now, while we're here and the memory limit is usually
+        // generous, rather than leaving the work to whichever request happens
+        // to arrive next.
+        try {
+            $this->formatter->warm();
+        } catch (\Throwable $e) {
+            $report->failed('formatter', $e->getMessage());
+        }
+
+        try {
+            $this->warmAssets($report, $force);
+        } catch (\Throwable $e) {
+            $report->failed('assets', $e->getMessage());
+        }
+
+        return $report;
+    }
+
+    protected function render(CacheClearReport $report): void
+    {
+        $this->info('Cleared');
+
+        foreach ($report->getCleared() as $cleared) {
+            $this->info($cleared['files'] === null
+                ? '  '.$cleared['name']
+                : sprintf('  %s (%d)', $cleared['name'], $cleared['files']));
+        }
+
         $table = (new Table($this->output))
             ->setHeaders([['Rebuilt assets'], ['Frontend', 'Bundle', 'Revision', 'Size', 'Time']])
             ->setStyle((new TableStyle)->setCellHeaderFormat('<info>%s</info>'));
 
+        $previous = null;
+
+        foreach ($report->getRebuilt() as $row) {
+            $frontend = $row['locale'] === null
+                ? $row['frontend']
+                : $row['frontend'].' · '.$row['locale'].' ('.$row['localeName'].')';
+
+            $table->addRow([
+                $frontend,
+                $row['bundle'],
+                $this->describe($row),
+                $row['bytes'] === null ? '' : $this->format($row['bytes']),
+                // Bundles compiled together are timed together, so the time is
+                // shown once against the first of them.
+                $frontend === $previous ? '' : $row['milliseconds'].'ms',
+            ]);
+
+            $previous = $frontend;
+        }
+
+        $table->render();
+
+        foreach ($report->getFailures() as $failure) {
+            $this->error(sprintf('  %s could not be pre-built: %s', $failure['step'], $failure['message']));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    protected function describe(array $row): string
+    {
+        return match ($row['state']) {
+            CacheClearReport::EMPTY => 'nothing to compile',
+            CacheClearReport::CHUNKS => $row['changed'].' changed',
+            CacheClearReport::UNCHANGED => $row['revision'].' unchanged',
+            CacheClearReport::REWRITTEN => $row['revision'].' rewritten',
+            default => ($row['previousRevision'] ?? 'new').' → '.$row['revision'],
+        };
+    }
+
+    protected function warmAssets(CacheClearReport $report, bool $force): void
+    {
         foreach ($this->assets->all() as $name => $assets) {
             // Batched, so the revisions recorded across every compiler below
             // are stored together rather than one statement each.
@@ -133,22 +186,21 @@ class CacheClearCommand extends AbstractCommand
             try {
                 $assetsDir = $assets->getAssetsDir();
 
-                $this->rows($table, $name, [$assets->makeJs(), $assets->makeCss()], $assetsDir, $force);
+                $this->record($report, $name, null, null, [$assets->makeJs(), $assets->makeCss()], $assetsDir, $force);
 
                 foreach ($this->locales->getLocales() as $locale => $display) {
-                    $this->rows(
-                        $table,
-                        $name.' · '.$locale.' ('.$display.')',
+                    $this->record(
+                        $report,
+                        $name,
+                        $locale,
+                        $display,
                         [$assets->makeLocaleJs($locale), $assets->makeLocaleCss($locale)],
                         $assetsDir,
                         $force
                     );
                 }
 
-                // The chunk compiler owns no single filename — it tracks one
-                // revision per split chunk, dozens of them — so there is no one
-                // hash to show. Report how many moved instead.
-                $this->chunkRow($table, $name, $assets->makeJsDirectory(), $force);
+                $this->recordChunks($report, $name, $assets->makeJsDirectory(), $force);
             } finally {
                 $this->versioner->flushWrites();
             }
@@ -158,25 +210,29 @@ class CacheClearCommand extends AbstractCommand
             // outstanding, so the first visitor would pay for it anyway.
             $this->settings->delete('assets_dirty.'.$assets->getName());
         }
-
-        $table->render();
     }
 
     /**
-     * Rebuild some compilers and add a row per bundle.
+     * Rebuild some compilers and record one entry per bundle.
      *
-     * A row per bundle rather than per step: a locale compiles both a js and a
-     * css bundle, and two revisions side by side in one cell read as a single
-     * confusing statement about one file.
+     * Per bundle rather than per step: a locale compiles both a js and a css
+     * bundle, and describing them as one thing hides which of them changed.
      *
-     * The revision is a hash of the compiled output, so an unchanged bundle
-     * keeps the one it had — showing the move is what distinguishes "rebuilt,
-     * same bytes" from "rebuilt, clients will refetch".
+     * The size is read only where a bundle was actually written. On remote
+     * storage that is a round trip, and a bundle whose revision did not move is
+     * byte-identical to the one reported the last time it changed.
      *
      * @param CompilerInterface[] $compilers
      */
-    protected function rows(Table $table, string $set, array $compilers, Cloud $assetsDir, bool $force): void
-    {
+    protected function record(
+        CacheClearReport $report,
+        string $frontend,
+        ?string $locale,
+        ?string $localeName,
+        array $compilers,
+        Cloud $assetsDir,
+        bool $force
+    ): void {
         $before = array_map(
             fn (CompilerInterface $compiler) => $this->versioner->getRevision((string) $compiler->getFilename()),
             $compilers
@@ -188,44 +244,41 @@ class CacheClearCommand extends AbstractCommand
             $compiler->commit($force);
         }
 
-        // Timed together, because that is how they were compiled; shown once.
-        $elapsed = sprintf('%dms', (microtime(true) - $started) * 1000);
+        $elapsed = microtime(true) - $started;
 
         foreach ($compilers as $i => $compiler) {
             $file = (string) $compiler->getFilename();
             $now = $this->versioner->getRevision($file);
 
             // A bundle with no sources at all records EMPTY_REVISION and has no
-            // file, so say so rather than printing the marker as if it were a
-            // hash.
+            // file: there is nothing to size, and nothing to say about a hash.
             if ($now === RevisionCompiler::EMPTY_REVISION) {
-                $table->addRow([$set, $file, 'nothing to compile', '', $i === 0 ? $elapsed : '']);
-
-                continue;
+                $state = CacheClearReport::EMPTY;
+            } elseif ($before[$i] !== $now) {
+                $state = CacheClearReport::REBUILT;
+            } elseif ($force) {
+                $state = CacheClearReport::REWRITTEN;
+            } else {
+                $state = CacheClearReport::UNCHANGED;
             }
 
-            if ($before[$i] === $now && ! $force) {
-                // Byte-identical to what was already there, so nothing was
-                // written and its size is not worth a round trip.
-                $table->addRow([$set, $file, $now.' unchanged', '', $i === 0 ? $elapsed : '']);
-
-                continue;
-            }
-
-            $table->addRow([
-                $set,
+            $report->rebuilt(
+                $frontend,
+                $locale,
+                $localeName,
                 $file,
-                $before[$i] === $now
-                    // Forced: the bytes were rewritten even though they match.
-                    ? $now.' rewritten'
-                    : ($before[$i] ?? 'new').' → '.$now,
-                $this->size($assetsDir, $file),
-                $i === 0 ? $elapsed : '',
-            ]);
+                $state,
+                $state === CacheClearReport::EMPTY ? null : $now,
+                $before[$i],
+                in_array($state, [CacheClearReport::REBUILT, CacheClearReport::REWRITTEN], true)
+                    ? $this->bytes($assetsDir, $file)
+                    : null,
+                $elapsed
+            );
         }
     }
 
-    protected function chunkRow(Table $table, string $set, CompilerInterface $compiler, bool $force): void
+    protected function recordChunks(CacheClearReport $report, string $frontend, CompilerInterface $compiler, bool $force): void
     {
         $before = $this->versioner->allRevisions();
 
@@ -233,21 +286,23 @@ class CacheClearCommand extends AbstractCommand
 
         $compiler->commit($force);
 
-        $elapsed = sprintf('%dms', (microtime(true) - $started) * 1000);
+        $elapsed = microtime(true) - $started;
 
         $after = $this->versioner->allRevisions();
-        $changed = count(array_diff_assoc($after, $before)) + count(array_diff_key($before, $after));
 
-        $table->addRow([$set, 'split chunks', $changed.' changed', '', $elapsed]);
+        $report->rebuiltChunks(
+            $frontend,
+            count(array_diff_assoc($after, $before)) + count(array_diff_key($before, $after)),
+            $elapsed
+        );
     }
 
-    protected function size(Cloud $assetsDir, string $file): string
+    protected function bytes(Cloud $assetsDir, string $file): ?int
     {
         try {
-            return $this->format($assetsDir->size($file));
+            return $assetsDir->size($file);
         } catch (\Throwable $e) {
-            // An empty bundle legitimately has no file.
-            return '';
+            return null;
         }
     }
 

--- a/framework/core/src/Http/Emitter.php
+++ b/framework/core/src/Http/Emitter.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Http;
+
+use Laminas\Diactoros\CallbackStream;
+use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
+use Laminas\HttpHandlerRunner\Emitter\SapiStreamEmitter;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Sends a response, streaming it only where streaming is what was asked for.
+ *
+ * Nearly everything Flarum returns is a complete string that should be sent in
+ * one go, which is what {@see SapiEmitter} does. A handful of things — clearing
+ * the cache, which recompiles every asset and can run for half a minute — need
+ * to reach the browser as they happen, and for those the body is a
+ * {@see CallbackStream} whose callback writes and flushes progressively.
+ *
+ * The distinction is drawn on the body rather than a flag, because
+ * `SapiEmitter` would defeat a callback body anyway: it casts the stream to a
+ * string, which runs the callback to completion before a single byte is sent.
+ */
+class Emitter implements EmitterInterface
+{
+    public function __construct(
+        private readonly EmitterInterface $buffered = new SapiEmitter(),
+        private readonly EmitterInterface $streamed = new SapiStreamEmitter()
+    ) {
+    }
+
+    public function emit(ResponseInterface $response): bool
+    {
+        return $response->getBody() instanceof CallbackStream
+            ? $this->streamed->emit($response)
+            : $this->buffered->emit($response);
+    }
+}

--- a/framework/core/src/Http/Emitter.php
+++ b/framework/core/src/Http/Emitter.php
@@ -10,9 +10,9 @@
 namespace Flarum\Http;
 
 use Laminas\Diactoros\CallbackStream;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\HttpHandlerRunner\Emitter\SapiStreamEmitter;
-use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**

--- a/framework/core/src/Http/Server.php
+++ b/framework/core/src/Http/Server.php
@@ -15,7 +15,6 @@ use Illuminate\Contracts\Container\Container;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\Stratigility\Middleware\ErrorResponseGenerator;
 use Psr\Log\LoggerInterface;
@@ -32,7 +31,7 @@ readonly class Server
     {
         $runner = new RequestHandlerRunner(
             $this->safelyBootAndGetHandler(),
-            new SapiEmitter,
+            new Emitter,
             [ServerRequestFactory::class, 'fromGlobals'],
             function (Throwable $e) {
                 $generator = new ErrorResponseGenerator;

--- a/framework/core/tests/integration/api/ClearCacheTest.php
+++ b/framework/core/tests/integration/api/ClearCacheTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ClearCacheTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function admin_can_clear_the_cache()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/cache', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function the_response_is_not_buffered_downstream()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/cache', ['authenticatedAs' => 1])
+        );
+
+        // A proxy that buffered for compression would hold every step back
+        // until the work had finished, which is the whole thing this avoids.
+        $this->assertStringContainsString('no-transform', $response->getHeaderLine('Cache-Control'));
+        $this->assertSame('no', $response->getHeaderLine('X-Accel-Buffering'));
+    }
+
+    /**
+     * Clearing the cache rebuilds the compiled assets, and on remote storage
+     * that is tens of seconds. The panel showed a spinner and then reloaded,
+     * so it now gets the same detail the console prints — but as data: a
+     * sentence assembled here could only ever be in English.
+     */
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function steps(): array
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/cache', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('application/x-ndjson', $response->getHeaderLine('Content-Type'));
+
+        // The body is a callback: reading it runs the work and captures what it
+        // wrote, which is what the emitter does when serving the request.
+        ob_start();
+        $response->getBody()->getContents();
+        $written = ob_get_clean();
+
+        return array_map(
+            fn (string $line) => json_decode($line, true),
+            array_filter(explode("\n", trim($written)))
+        );
+    }
+
+    #[Test]
+    public function it_reports_what_was_cleared_and_rebuilt()
+    {
+        $types = array_column($this->steps(), 'type');
+
+        $this->assertContains('cleared', $types);
+        $this->assertContains('rebuilt', $types);
+    }
+
+    /**
+     * Each step is a complete JSON object on its own line, so the panel can act
+     * on it the moment it arrives rather than waiting for a whole document to
+     * parse.
+     */
+    #[Test]
+    public function every_step_is_a_line_of_its_own()
+    {
+        $steps = $this->steps();
+
+        $this->assertNotEmpty($steps);
+
+        foreach ($steps as $step) {
+            $this->assertIsArray($step, 'every line must parse on its own');
+            $this->assertArrayHasKey('type', $step);
+        }
+    }
+
+    /**
+     * The client watches for this rather than inferring completion from the
+     * connection closing, which it cannot tell apart from one that dropped.
+     */
+    #[Test]
+    public function the_stream_ends_with_a_done_step()
+    {
+        $steps = $this->steps();
+
+        $this->assertSame('done', end($steps)['type']);
+    }
+
+    /**
+     * Each entry says what happened rather than describing it, so the panel can
+     * put its own words to a bundle that was rebuilt, left alone, or had
+     * nothing to compile.
+     */
+    #[Test]
+    public function each_rebuilt_bundle_carries_its_own_state()
+    {
+        $rebuilt = array_values(array_filter($this->steps(), fn (array $s) => $s['type'] === 'rebuilt'));
+
+        foreach ($rebuilt as $row) {
+            $this->assertArrayHasKey('frontend', $row);
+            $this->assertArrayHasKey('bundle', $row);
+            $this->assertArrayHasKey('state', $row);
+            $this->assertArrayHasKey('milliseconds', $row);
+            $this->assertContains($row['state'], ['unchanged', 'rebuilt', 'rewritten', 'empty', 'chunks']);
+        }
+
+        // Every locale is represented, because that is where a rebuild spends
+        // its time: the translations live in the per-locale bundles.
+        $locales = array_filter(array_column($rebuilt, 'locale'));
+
+        $this->assertContains('en', $locales);
+    }
+
+    #[Test]
+    public function a_normal_user_cannot_clear_the_cache()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/cache', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * Carrying a valid CSRF token but no session, so the request reaches the
+     * controller and is turned away for what it is rather than for a missing
+     * token. Streaming the body does not loosen that: the middleware wraps the
+     * response object, and only the emitter touches the body.
+     */
+    #[Test]
+    public function a_guest_cannot_clear_the_cache()
+    {
+        $response = $this->send(
+            $this->requestWithCsrfToken($this->request('DELETE', '/api/cache'))
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+}

--- a/framework/core/tests/integration/api/ClearCacheTest.php
+++ b/framework/core/tests/integration/api/ClearCacheTest.php
@@ -170,5 +170,4 @@ class ClearCacheTest extends TestCase
 
         $this->assertEquals(403, $response->getStatusCode());
     }
-
 }

--- a/framework/core/tests/unit/Http/EmitterTest.php
+++ b/framework/core/tests/unit/Http/EmitterTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Http;
+
+use Flarum\Http\Emitter;
+use Flarum\Testing\unit\TestCase;
+use Laminas\Diactoros\CallbackStream;
+use Laminas\Diactoros\Response;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+
+class EmitterTest extends TestCase
+{
+    private function emitter(&$sentTo): Emitter
+    {
+        $record = function (string $which) use (&$sentTo) {
+            $emitter = m::mock(EmitterInterface::class);
+            $emitter->shouldReceive('emit')->andReturnUsing(function () use (&$sentTo, $which) {
+                $sentTo = $which;
+
+                return true;
+            });
+
+            return $emitter;
+        };
+
+        return new Emitter($record('buffered'), $record('streamed'));
+    }
+
+    /**
+     * Everything Flarum returns other than the few progressive responses is a
+     * complete string, and must keep being sent in one piece: the streaming
+     * emitter handles content-length and ranges differently, so routing normal
+     * responses through it would change every page on the site.
+     */
+    #[Test]
+    public function an_ordinary_response_is_sent_in_one_piece()
+    {
+        $sentTo = null;
+
+        $this->emitter($sentTo)->emit(new Response());
+
+        $this->assertSame('buffered', $sentTo);
+    }
+
+    #[Test]
+    public function a_response_with_a_string_body_is_sent_in_one_piece()
+    {
+        $sentTo = null;
+
+        $response = new Response();
+        $response->getBody()->write('{"data":[]}');
+
+        $this->emitter($sentTo)->emit($response);
+
+        $this->assertSame('buffered', $sentTo);
+    }
+
+    /**
+     * A callback body is the request to stream. It has to be: the buffered
+     * emitter casts the body to a string, which would run the callback to
+     * completion before anything reached the browser — the opposite of what a
+     * caller asked for by using one.
+     */
+    #[Test]
+    public function a_callback_body_is_streamed()
+    {
+        $sentTo = null;
+
+        $response = (new Response())->withBody(new CallbackStream(fn () => ''));
+
+        $this->emitter($sentTo)->emit($response);
+
+        $this->assertSame('streamed', $sentTo);
+    }
+
+    #[Test]
+    public function it_passes_the_response_through_untouched()
+    {
+        $response = (new Response())->withStatus(418)->withHeader('X-Test', 'yes');
+
+        $seen = null;
+
+        $buffered = m::mock(EmitterInterface::class);
+        $buffered->shouldReceive('emit')->once()->andReturnUsing(function (ResponseInterface $r) use (&$seen) {
+            $seen = $r;
+
+            return true;
+        });
+
+        (new Emitter($buffered, m::mock(EmitterInterface::class)))->emit($response);
+
+        $this->assertSame($response, $seen);
+    }
+
+    #[Test]
+    public function it_reports_what_the_underlying_emitter_reported()
+    {
+        $failing = m::mock(EmitterInterface::class);
+        $failing->shouldReceive('emit')->andReturn(false);
+
+        $this->assertFalse(
+            (new Emitter($failing, m::mock(EmitterInterface::class)))->emit(new Response())
+        );
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

Follows up #5047.

**Changes proposed in this pull request:**

Clearing the cache from the dashboard is not a quick operation — since #5047 it recompiles every asset bundle for every frontend and locale, which is tens of seconds where assets live on remote storage. The old flow handled that badly in two ways:

1. **It reloaded the page onto assets that may not exist.** `ClearCacheController` returned 204 once everything finished, and `StatusWidget` reloaded on any success. But the pre-build steps are best-effort — the caches are already empty by the time they run — so a bundle that failed to compile still returned 204. The admin reloaded straight onto missing assets. Only `IOException` (409) was reported as an error, and only that status was handled in the JS.

2. **A slow clear was indistinguishable from a dead request.** `LoadingModal` is a bare spinner. With no output until the work completed, there was nothing to tell an admin whether a 40-second clear was progressing or the request had died.

This makes the endpoint stream what it is doing, as newline-delimited JSON — one object per line, each complete in itself — and replaces `LoadingModal` with `ClearCacheModal`, which renders each step as its line arrives. Nothing reloads on its own: the page is still running on the assets it booted with, so the admin gets a Reload button and decides when to pick up the new ones. A failed step is now reported as a step rather than being lost behind a 204.

Steps record what happened, not a sentence about it, so the wording comes from the translations on whichever side renders them — the console table (#5047) and the modal share `CacheClearReport`.

`Flarum\Http\Emitter` routes on body type: a `CallbackStream` is streamed, everything else is sent buffered exactly as before. This is the part that keeps the change contained — authorisation, CSRF, throttling and error handling all still come from the API middleware, because those wrap the response object and it is the emitter that consumes the body, so a callback body passes through them untouched.

**Reviewers should focus on:**

- `Emitter`. It sits on every response on the site. Routing normal responses through `SapiStreamEmitter` would change content-length and range handling everywhere, so the test asserts that only a `CallbackStream` body takes the streaming path.
- Whether streaming from inside the API middleware stack is acceptable, versus a route outside it. I checked no API middleware touches the response body, and `EmitterTest` plus `ClearCacheTest` cover it, but this is the design decision I'd most want a second opinion on.
- `ClearCacheController::steps()` runs the work after headers are sent, so a failure cannot become an error response. It is written as a `failed` step and the stream closes normally.
- `X-Accel-Buffering: no` and `Cache-Control: no-transform` are there to stop a proxy buffering the body for compression. I can't test every proxy.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
