### PR TITLE
[2.x] fix: safe mode's cut-down assets outlive safe mode

### DIFF
--- a/framework/core/src/Admin/WhenSavingSettings.php
+++ b/framework/core/src/Admin/WhenSavingSettings.php
@@ -19,7 +19,8 @@ use Flarum\Settings\Event\Saving;
 class WhenSavingSettings
 {
     /**
-     * Settings that should trigger JS cache clear when saved.
+     * Settings whose value changes what the compiled JS contains, so saving
+     * one must flag the bundles for a rebuild.
      *
      * @var string[]
      */
@@ -62,7 +63,16 @@ class WhenSavingSettings
             return;
         }
 
-        $this->assets->flushJs();
+        // Flag rather than delete. Deleting leaves already-served pages
+        // pointing at files that no longer exist, and nulls the revisions, so
+        // whichever request arrives first recompiles from its own container —
+        // which for these settings is one booted before the save.
+        //
+        // Entering safe mode is flagged like anything else, and the reduced
+        // bundle it then builds is what safe mode is for. Leaving it saves
+        // maintenance_mode again, which flags the sets again, so the next
+        // request outside safe mode restores the full bundle.
+        $this->assets->markDirty();
     }
 
     public function resetJsCacheFor(string|array $setting): void

--- a/framework/core/src/Forum/ValidateCustomLess.php
+++ b/framework/core/src/Forum/ValidateCustomLess.php
@@ -11,6 +11,7 @@ namespace Flarum\Forum;
 
 use Flarum\Foundation\ValidationException;
 use Flarum\Frontend\Assets;
+use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\Event\Saved;
 use Flarum\Settings\Event\Saving;
@@ -112,11 +113,16 @@ class ValidateCustomLess
             return;
         }
 
-        $this->assets->makeCss()->flush();
-
-        foreach ($this->locales->getLocales() as $locale => $name) {
-            $this->assets->makeLocaleCss($locale)->flush();
-        }
+        // Flag rather than delete, so the stylesheets already referenced by
+        // served pages keep resolving until their replacements exist. The
+        // rebuild happens on the next request, and only rewrites a file whose
+        // compiled output actually differs.
+        (new RecompileFrontendAssets(
+            $this->assets,
+            $this->locales,
+            $this->container->make('events'),
+            $this->settings
+        ))->markDirty();
     }
 
     protected function hasDirtyCustomLessSettings(Saved|Saving $event): bool

--- a/framework/core/src/Frontend/AssetManager.php
+++ b/framework/core/src/Frontend/AssetManager.php
@@ -10,6 +10,7 @@
 namespace Flarum\Frontend;
 
 use Flarum\Locale\LocaleManager;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
@@ -55,6 +56,39 @@ class AssetManager
         $this->assets[$frontend] = $abstract;
     }
 
+    /**
+     * Flag every frontend as needing a rebuild, without touching the compiled
+     * files or their manifest revisions.
+     *
+     * The rebuild is deferred to the next freshly-booted request. That matters
+     * for the settings this is called for: they change which extensions boot,
+     * so a rebuild in the saving request — whose container booted before the
+     * save — would compile the old extension set and record it as current.
+     *
+     * @see \Flarum\Frontend\RecompileFrontendAssets::markDirty()
+     */
+    public function markDirty(): void
+    {
+        foreach ($this->all() as $assets) {
+            (new RecompileFrontendAssets(
+                $assets,
+                $this->locales,
+                $this->container->make('events'),
+                $this->container->make(SettingsRepositoryInterface::class)
+            ))->markDirty();
+        }
+    }
+
+    /**
+     * @deprecated 2.1 Use {@see markDirty()} instead, which defers the rebuild
+     * to a freshly-booted request rather than deleting the compiled files.
+     *
+     * Deleting them leaves already-served pages pointing at files that no
+     * longer exist, and clears the revisions that tell the next request what
+     * to rebuild — so whichever request arrives first recompiles from its own
+     * container, which for a safe-mode save is the admin's own browser running
+     * a reduced extension set.
+     */
     public function flushJs(): void
     {
         foreach ($this->all() as $assets) {

--- a/framework/core/src/Frontend/RecompileFrontendAssets.php
+++ b/framework/core/src/Frontend/RecompileFrontendAssets.php
@@ -208,6 +208,15 @@ class RecompileFrontendAssets
         }
     }
 
+    /**
+     * @deprecated 2.1 Use {@see markDirty()} instead.
+     *
+     * Deleting the compiled files leaves already-served pages pointing at
+     * files that no longer exist, and nulls the revisions that would otherwise
+     * tell the next request what to rebuild. {@see recompile()} overwrites in
+     * place and only where the output differs, and {@see markDirty()} defers
+     * that to a request whose container reflects the change.
+     */
     public function flush(): void
     {
         $this->flushCss();
@@ -216,6 +225,9 @@ class RecompileFrontendAssets
         $this->events?->dispatch(new AssetsRecompiled());
     }
 
+    /**
+     * @deprecated 2.1 See {@see flush()}.
+     */
     protected function flushCss(): void
     {
         $this->assets->makeCss()->flush();
@@ -225,6 +237,9 @@ class RecompileFrontendAssets
         }
     }
 
+    /**
+     * @deprecated 2.1 See {@see flush()}.
+     */
     protected function flushJs(): void
     {
         $this->assets->makeJs()->flush();

--- a/framework/core/tests/unit/Frontend/AssetManagerTest.php
+++ b/framework/core/tests/unit/Frontend/AssetManagerTest.php
@@ -12,8 +12,10 @@ namespace Flarum\Tests\unit\Frontend;
 use Flarum\Frontend\AssetManager;
 use Flarum\Frontend\Assets;
 use Flarum\Locale\LocaleManager;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\unit\TestCase;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
@@ -107,5 +109,57 @@ class AssetManagerTest extends TestCase
         $manager->register('admin', 'flarum.assets.admin');
 
         $this->assertSame(['forum' => $forum, 'admin' => $admin], $manager->all());
+    }
+
+    /**
+     * The settings that trigger this — maintenance_mode, safe_mode_extensions
+     * — decide which extensions boot, so the compiled bundles have to be
+     * rebuilt when one changes.
+     *
+     * Flagging, rather than deleting the files as this used to: deleting them
+     * meant the only request that could rebuild during safe mode was an
+     * admin's (they alone get past CheckForMaintenanceMode), so the reduced
+     * safe-mode bundle was recorded as the canonical revision with nothing
+     * left to mark it stale. The forum then served that cut-down JS to
+     * everyone, even after safe mode ended. Flagging leaves the file and its
+     * revision alone, so leaving safe mode flags the sets again and the next
+     * normal request restores the full bundle.
+     */
+    #[Test]
+    public function mark_dirty_flags_every_registered_frontend_without_touching_the_compilers()
+    {
+        $flagged = [];
+
+        $makeAssets = function (string $name) {
+            $assets = m::mock(Assets::class);
+            $assets->shouldReceive('getName')->andReturn($name);
+            // Nothing may be compiled or deleted here.
+            $assets->shouldNotReceive('makeCss', 'makeJs', 'makeLocaleCss', 'makeLocaleJs', 'makeJsDirectory');
+
+            return $assets;
+        };
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('flarum.assets.forum')->andReturn($makeAssets('forum'));
+        $container->shouldReceive('make')->with('flarum.assets.admin')->andReturn($makeAssets('admin'));
+        $container->shouldReceive('make')->with('events')->andReturn(m::mock(Dispatcher::class));
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('set')->andReturnUsing(function (string $key) use (&$flagged) {
+            $flagged[] = $key;
+        });
+        $settings->shouldNotReceive('delete');
+        $container->shouldReceive('make')->with(SettingsRepositoryInterface::class)->andReturn($settings);
+
+        $locales = m::mock(LocaleManager::class);
+        $locales->shouldReceive('clearCache');
+
+        $manager = new AssetManager($container, $locales);
+        $manager->register('forum', 'flarum.assets.forum');
+        $manager->register('admin', 'flarum.assets.admin');
+
+        $manager->markDirty();
+
+        $this->assertEquals(['assets_dirty.forum', 'assets_dirty.admin'], $flagged);
     }
 }


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

Turning safe mode off leaves the forum serving the cut-down JS bundle that safe mode built, and only a manual `cache:clear` restores the real one.

Safe mode boots a reduced extension set and its bundle is *supposed* to be cut down. The problem is that the bundle has the same filename and the same revision slot as the normal one, so it overwrites it and claims its revision — after which nothing considers it stale.

`flushJs()` is what forced that to happen. Saving `maintenance_mode` or `safe_mode_extensions` called it, which **deletes** every JS bundle and nulls its revision. Safe mode is on by then, and `CheckForMaintenanceMode` exempts admins, so the admin who just saved is the only person who can reach the forum — their own next pageview is the only thing that can rebuild the deleted files, and it rebuilds them under safe mode. Turning safe mode back off saves `maintenance_mode` again, but by then the reduced bundle's revision matches the file on disk, so nothing is dirty and nothing rebuilds. Every visitor gets it, on a forum with all extensions enabled.

The fix is to flag the asset sets instead of deleting them — the `markDirty()` mechanism #5044 added for extension toggles. `maintenance_mode` is already in `resetJsCacheFor`, so leaving safe mode flags the sets exactly as entering it does; with the file and revision left intact, the flag is what carries "needs rebuild" across the mode change, and the first request outside safe mode rebuilds the full bundle.

Proven on a forum with 84 extensions (debug off, real admin session):

| step | `forum.js` | size | dirty |
|---|---|---|---|
| baseline | `4a7ace08` | 1.7MB | – |
| admin saves safe mode | `4a7ace08` | 1.7MB | `1` |
| admin browses in safe mode | `9b6de46d` | 651KB | – |
| admin saves normal mode | `9b6de46d` | 651KB | `1` |
| first visitor | `4a7ace08` | **1.7MB** | – |

Before, the last row stayed at 651KB indefinitely. Row 3 is unchanged and deliberate — safe mode still gets its reduced bundle.

`ValidateCustomLess` gets the same treatment for the CSS path, which had the identical shape (`makeCss()->flush()`). It isn't affected by the safe-mode trap, but deleting a stylesheet that is about to be recompiled to the same bytes only creates a window where served pages point at a file that no longer exists.

Deprecated rather than removed, since extensions may call them: `AssetManager::flushJs()`, `RecompileFrontendAssets::flush()`/`flushCss()`/`flushJs()`. `RevisionCompiler::flush()` is untouched — `cache:clear` legitimately deletes.

**Reviewers should focus on:**

- The fix relies on `maintenance_mode` being in `resetJsCacheFor`, so *leaving* safe mode flags the sets. That's what makes a separate "on exit" hook unnecessary, and it's the part worth checking: if a deployment leaves safe mode by some route that doesn't save that setting (editing `config.php`'s `safe_mode_extensions` key, say), the flag is never set and the reduced bundle persists exactly as before. `Config` can override the setting, and I have not tested that path.
- `AssetManager::markDirty()` constructs `RecompileFrontendAssets` per frontend, which calls `LocaleManager::clearCache()` each time (3×). After the first the directory is empty, so it's two cheap syscalls — and the existing `Enabled`/`Disabled` listeners in the three service providers already do exactly this.
- `RevisionCompiler::getUrl()` still compiles lazily when a revision is genuinely absent — a fresh install, or post-`cache:clear` whose first request is an admin in safe mode. Not covered here: with revisions intact `getUrl()` never reaches `commit()`, so this change removes the common case, and closing the rest would mean threading `MaintenanceMode` into every compiler. Deliberately left.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.
