### PR TITLE
[2.x] fix: scope relations that are eager-loaded before serialisation

### DIFF
--- a/extensions/messages/tests/integration/api/dialog_messages/MentionedPostVisibilityTest.php
+++ b/extensions/messages/tests/integration/api/dialog_messages/MentionedPostVisibilityTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Messages\Tests\integration\api\dialog_messages;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Messages\Dialog;
+use Flarum\Messages\DialogMessage;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+
+/**
+ * The Index endpoint eager-loads all four mention relations, which used to
+ * bypass the visibility scope applied by EloquentBuffer::load(): a post the
+ * reader cannot see, mentioned in a dialog message, was serialised in full.
+ */
+class MentionedPostVisibilityTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'flarum-messages', 'flarum-mentions');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 4, 'username' => 'bob', 'email' => 'bob@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 50, 'title' => 'Hidden discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 50, 'comment_count' => 1, 'is_private' => 1],
+            ],
+            Post::class => [
+                ['id' => 50, 'number' => 1, 'discussion_id' => 50, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>restricted staff content</p></t>'],
+            ],
+            Dialog::class => [
+                ['id' => 200, 'type' => 'direct'],
+            ],
+            DialogMessage::class => [
+                ['id' => 200, 'dialog_id' => 200, 'user_id' => 4, 'content' => 'see this', 'number' => 1],
+            ],
+            'dialog_user' => [
+                ['dialog_id' => 200, 'user_id' => 2, 'joined_at' => Carbon::now()],
+                ['dialog_id' => 200, 'user_id' => 4, 'joined_at' => Carbon::now()],
+            ],
+            'dialog_message_mentions_post' => [
+                ['dialog_message_id' => 200, 'mentions_post_id' => 50],
+            ],
+        ]);
+    }
+
+    public function test_a_mentioned_post_the_reader_cannot_see_is_not_serialised(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/dialog-messages?filter[dialog]=200&include=mentionsPosts', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertStringNotContainsString('restricted staff content', (string) $response->getBody());
+    }
+}

--- a/framework/core/src/Api/Endpoint/Concerns/HasEagerLoading.php
+++ b/framework/core/src/Api/Endpoint/Concerns/HasEagerLoading.php
@@ -13,8 +13,11 @@ use Closure;
 use Flarum\Api\Resource\AbstractDatabaseResource;
 use Flarum\Api\Schema\Relationship\ToMany;
 use Flarum\Api\Schema\Relationship\ToOne;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use Tobyz\JsonApiServer\Context;
 
@@ -123,11 +126,16 @@ trait HasEagerLoading
         }
 
         if (! empty($whereRelations)) {
-            $models->loadMissing($whereRelations);
+            $models->loadMissing($this->scopeEagerLoads(
+                array_keys($whereRelations),
+                $context,
+                $resource,
+                $whereRelations
+            ));
         }
 
         if (! empty($simpleRelations)) {
-            $models->loadMissing($simpleRelations);
+            $models->loadMissing($this->scopeEagerLoads($simpleRelations, $context, $resource));
         }
 
         $this->setInverseRelations(
@@ -136,6 +144,133 @@ trait HasEagerLoading
             $resource,
             array_merge(array_keys($whereRelations), $simpleRelations)
         );
+    }
+
+    /**
+     * Apply each related resource's scope() to the relations pre-loaded here.
+     *
+     * Relations loaded lazily at serialisation time are scoped by
+     * EloquentBuffer::load(), which is the only place a related resource's
+     * scope() (i.e. whereVisibleTo) is applied to a relationship query. A
+     * relation pre-loaded here never reaches that code — the serialiser skips
+     * the buffer for anything already loaded — so without scoping it here, a
+     * relation named in an endpoint's eagerLoad() list is serialised with no
+     * visibility check: the discussion Show endpoint's `firstPost.user.groups`
+     * handed a moderator-hidden opening post to anyone who could see the
+     * discussion.
+     *
+     * Note that loadMissing() binds a path's callback to its LAST segment only,
+     * so 'firstPost.user.groups' => $scope would scope `groups` and leave
+     * `firstPost` unscoped. Each path is expanded into its prefixes, each
+     * scoped by the resource that owns it.
+     *
+     * @param string[] $relations
+     * @return array<string, callable>
+     */
+    private function scopeEagerLoads(array $relations, Context $context, AbstractDatabaseResource $resource, array $callbacks = []): array
+    {
+        $scoped = [];
+
+        foreach ($relations as $relation) {
+            $owner = $resource;
+            $path = '';
+
+            foreach (explode('.', $relation) as $segment) {
+                $path = $path === '' ? $segment : "$path.$segment";
+
+                $field = $owner ? $this->relationshipField($owner, $segment, $context) : null;
+                $related = $field ? $this->singleResourceFor($field, $context) : null;
+
+                // A segment we cannot resolve to a single database resource has
+                // no scope to apply. Keep loading it — dropping the path would
+                // reintroduce the N+1 this eager load exists to prevent — and
+                // leave it to the serialiser, which still authorises each field.
+                // loadMissing() hands the callback the Relation, while scope()
+                // takes the Eloquent builder underneath it.
+                // A relation registered through eagerLoadWhere() carries its own
+                // query modification; it is applied alongside the scope, not
+                // instead of it.
+                $callback = $callbacks[$path] ?? null;
+
+                // Polymorphic relations span several resources, so the scope has
+                // to be applied per concrete model class through constrain() --
+                // the same shape EloquentBuffer::load() uses. Calling scope() on
+                // a MorphTo's own builder would resolve the related model's
+                // scopes against the wrong model.
+                $constrain = $field ? $this->morphConstraints($field, $context) : [];
+
+                $scoped[$path] = function (Relation|Builder $query) use ($related, $context, $callback, $constrain) {
+                    if ($query instanceof MorphTo && $constrain) {
+                        $query->constrain($constrain);
+                    } elseif ($related) {
+                        $related->scope($query instanceof Relation ? $query->getQuery() : $query, $context);
+                    }
+
+                    if ($callback) {
+                        $callback($query, $context);
+                    }
+                };
+
+                $owner = $related;
+            }
+        }
+
+        return $scoped;
+    }
+
+    /**
+     * The relationship field a relation path segment refers to, if any.
+     */
+    private function relationshipField(AbstractDatabaseResource $resource, string $segment, Context $context): ToOne|ToMany|null
+    {
+        return collect($context->fields($resource))
+            ->first(fn ($field) => ($field instanceof ToOne || $field instanceof ToMany)
+                && (($field->property ?? $field->name) === $segment || $field->name === $segment));
+    }
+
+    /**
+     * The database resource behind a relationship field, when it resolves to
+     * exactly one. Polymorphic relations return null and are scoped through
+     * morphConstraints() instead.
+     */
+    private function singleResourceFor(ToOne|ToMany $field, Context $context): ?AbstractDatabaseResource
+    {
+        $types = (array) ($field->collections ?? []);
+
+        if (count($types) !== 1) {
+            return null;
+        }
+
+        $related = $context->api->resources[$types[0]] ?? null;
+
+        return $related instanceof AbstractDatabaseResource ? $related : null;
+    }
+
+    /**
+     * A model class => scoping closure map for a polymorphic relationship, for
+     * MorphTo::constrain().
+     *
+     * @return array<class-string, callable>
+     */
+    private function morphConstraints(ToOne|ToMany $field, Context $context): array
+    {
+        $constrain = [];
+
+        foreach ((array) ($field->collections ?? []) as $type) {
+            $resource = $context->api->resources[$type] ?? null;
+
+            if (! $resource instanceof AbstractDatabaseResource) {
+                continue;
+            }
+
+            $modelClass = get_class($resource->newModel($context));
+
+            if (! isset($constrain[$modelClass])) {
+                $constrain[$modelClass] = fn (Builder $query) => $resource->scope($query, $context);
+            }
+        }
+
+        return $constrain;
     }
 
     /**

--- a/framework/core/src/Api/Endpoint/Concerns/HasEagerLoading.php
+++ b/framework/core/src/Api/Endpoint/Concerns/HasEagerLoading.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Endpoint\Concerns;
 
 use Closure;
+use Flarum\Api\Context as FlarumContext;
 use Flarum\Api\Resource\AbstractDatabaseResource;
 use Flarum\Api\Schema\Relationship\ToMany;
 use Flarum\Api\Schema\Relationship\ToOne;
@@ -169,6 +170,14 @@ trait HasEagerLoading
      */
     private function scopeEagerLoads(array $relations, Context $context, AbstractDatabaseResource $resource, array $callbacks = []): array
     {
+        // Resource scopes are declared against Flarum's context. Without one
+        // there is nothing to apply, so fall back to what each route would
+        // have loaded: its own callbacks where it has them, bare names
+        // otherwise.
+        if (! $context instanceof FlarumContext) {
+            return $callbacks ?: $relations;
+        }
+
         $scoped = [];
 
         foreach ($relations as $relation) {
@@ -223,9 +232,11 @@ trait HasEagerLoading
      */
     private function relationshipField(AbstractDatabaseResource $resource, string $segment, Context $context): ToOne|ToMany|null
     {
-        return collect($context->fields($resource))
+        $field = collect($context->fields($resource))
             ->first(fn ($field) => ($field instanceof ToOne || $field instanceof ToMany)
                 && (($field->property ?? $field->name) === $segment || $field->name === $segment));
+
+        return $field instanceof ToOne || $field instanceof ToMany ? $field : null;
     }
 
     /**
@@ -252,7 +263,7 @@ trait HasEagerLoading
      *
      * @return array<class-string, callable>
      */
-    private function morphConstraints(ToOne|ToMany $field, Context $context): array
+    private function morphConstraints(ToOne|ToMany $field, FlarumContext $context): array
     {
         $constrain = [];
 

--- a/framework/core/tests/integration/api/EagerLoadedRelationsAreScopedTest.php
+++ b/framework/core/tests/integration/api/EagerLoadedRelationsAreScopedTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Api\Endpoint;
+use Flarum\Api\Endpoint\Concerns\HasEagerLoading;
+use Flarum\Api\JsonApi;
+use Flarum\Api\Resource\AbstractDatabaseResource;
+use Flarum\Api\Resource\DiscussionResource;
+use Flarum\Api\Schema\Relationship\ToMany;
+use Flarum\Api\Schema\Relationship\ToOne;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+
+/**
+ * A relation named in an endpoint's eager-load list is pre-loaded with
+ * loadMissing(), which bypasses EloquentBuffer::load() — the only place a
+ * related resource's scope() (whereVisibleTo) would otherwise be applied. If
+ * such a relation is also serialisable, it reaches the client with no
+ * visibility check at all.
+ *
+ * HasEagerLoading::scopeEagerLoads() closes that for every path it loads. This
+ * test guards the invariant rather than the two relations that were reported:
+ * a newly added eager load — in core or in an extension — is covered the moment
+ * it is registered, and fails here if the mechanism is ever bypassed.
+ */
+class EagerLoadedRelationsAreScopedTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * Every relationship path any endpoint eager-loads, as
+     * "resource type => endpoint => path".
+     *
+     * @return array<string, string[]>
+     */
+    private function eagerLoadedPaths(JsonApi $api): array
+    {
+        $paths = [];
+
+        foreach ($api->resources as $type => $resource) {
+            if (! $resource instanceof AbstractDatabaseResource) {
+                continue;
+            }
+
+            foreach ($resource->endpoints() as $endpoint) {
+                if (! in_array(HasEagerLoading::class, class_uses_recursive($endpoint), true)) {
+                    continue;
+                }
+
+                foreach ($this->declaredRelations($endpoint) as $relation) {
+                    $paths[$type][] = $relation;
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * The statically declared eager loads of an endpoint. Closure-valued
+     * entries are skipped: they depend on the request's includes, and the
+     * relations they return are covered by the same scoping code path.
+     *
+     * @return string[]
+     */
+    private function declaredRelations(object $endpoint): array
+    {
+        $relations = [];
+
+        foreach (['loadRelations', 'loadRelationWhere'] as $property) {
+            if (! property_exists($endpoint, $property)) {
+                continue;
+            }
+
+            $reflection = new ReflectionProperty($endpoint, $property);
+            $reflection->setAccessible(true);
+            $value = $reflection->getValue($endpoint);
+
+            foreach ($value as $key => $entry) {
+                // eagerLoadWhere() keys by relation name; eagerLoad() appends
+                // either a path or a closure.
+                $relation = is_string($key) ? $key : $entry;
+
+                if (is_string($relation)) {
+                    $relations[] = $relation;
+                }
+            }
+        }
+
+        return array_unique($relations);
+    }
+
+    /**
+     * Both eager-load routes — eagerLoad() and eagerLoadWhere() — must apply
+     * the related resource's scope.
+     *
+     * Proved end to end: an endpoint is given an eager load of a relation
+     * whose resource scope excludes everything, and the relation must come
+     * back empty. A bare loadMissing() would return the record regardless,
+     * which is the defect this guards.
+     */
+    #[Test]
+    public function an_eager_loaded_relation_honours_its_resource_scope()
+    {
+        // A relation that is eager-loaded but NOT in defaultInclude: it reaches
+        // the response only through the eager-load path, so if that path is
+        // unscoped the hidden post is disclosed.
+        $this->extend(
+            (new Extend\ApiResource(DiscussionResource::class))
+                ->endpoint(Endpoint\Show::class, fn (Endpoint\Show $endpoint) => $endpoint->eagerLoad(['firstPost']))
+        );
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 80, 'title' => 'scoped', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 80, 'comment_count' => 1, 'is_private' => 0],
+            ],
+            Post::class => [
+                ['id' => 80, 'number' => 1, 'discussion_id' => 80, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>EXCLUDED-BY-SCOPE</p></t>', 'hidden_at' => Carbon::now()->toDateTimeString()],
+            ],
+            User::class => [$this->normalUser()],
+        ]);
+
+        $response = $this->send($this->request('GET', '/api/discussions/80'));
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+        $this->assertStringNotContainsString(
+            'EXCLUDED-BY-SCOPE',
+            $body,
+            'an eager-loaded relation was serialised without its resource scope'
+        );
+    }
+
+    /**
+     * Every eager-loaded path must resolve, segment by segment, to a
+     * relationship the scoping code can find a resource for. A path it cannot
+     * resolve is loaded unscoped, so this is the signal that a new relation
+     * has slipped outside the mechanism.
+     */
+    #[Test]
+    public function every_eager_loaded_relation_resolves_to_a_scopable_resource()
+    {
+        $api = $this->app()->getContainer()->make(JsonApi::class);
+
+        $unresolved = [];
+
+        foreach ($this->eagerLoadedPaths($api) as $type => $paths) {
+            $resource = $api->resources[$type];
+
+            foreach ($paths as $path) {
+                $owner = $resource;
+
+                foreach (explode('.', $path) as $segment) {
+                    if (! $owner instanceof AbstractDatabaseResource) {
+                        break;
+                    }
+
+                    $field = collect($this->fieldsOf($api, $owner))
+                        ->first(fn ($field) => ($field instanceof ToOne || $field instanceof ToMany)
+                            && (($field->property ?? $field->name) === $segment || $field->name === $segment));
+
+                    if (! $field) {
+                        // A segment that is not a relationship field is not
+                        // serialised, so nothing is disclosed by loading it:
+                        // `state` is read for isUnread and is already scoped to
+                        // the actor by the relation itself. Only a serialisable
+                        // relation can leak, and those must resolve.
+                        break;
+                    }
+
+                    $types = (array) ($field->collections ?? []);
+
+                    // A serialisable relation must resolve to at least one
+                    // database resource, or scopeEagerLoads() has nothing to
+                    // apply and it is loaded unscoped.
+                    if ($this->isSerialisable($field)) {
+                        $scopable = array_filter(
+                            $types,
+                            fn ($t) => ($api->resources[$t] ?? null) instanceof AbstractDatabaseResource
+                        );
+
+                        if (! $scopable) {
+                            $unresolved[] = "$type: $path (at '$segment')";
+                            break;
+                        }
+                    }
+
+                    $owner = count($types) === 1 ? ($api->resources[$types[0]] ?? null) : null;
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $unresolved,
+            "These eager-loaded relations could not be resolved to a resource, so they are "
+            ."loaded without a visibility scope:\n\n  ".implode("\n  ", $unresolved)."\n\n"
+            ."Either expose the relationship on the resource, or drop it from the eager-load list."
+        );
+    }
+
+    /**
+     * @return array<object>
+     */
+    private function fieldsOf(JsonApi $api, AbstractDatabaseResource $resource): array
+    {
+        return $resource->fields();
+    }
+
+    /**
+     * Whether a relationship can reach the client, and so can disclose the
+     * records it is loaded with.
+     */
+    private function isSerialisable(ToOne|ToMany $field): bool
+    {
+        return ($field->includable ?? false) || ($field->visible ?? true) !== false;
+    }
+}

--- a/framework/core/tests/integration/api/EagerLoadedRelationsAreScopedTest.php
+++ b/framework/core/tests/integration/api/EagerLoadedRelationsAreScopedTest.php
@@ -208,9 +208,9 @@ class EagerLoadedRelationsAreScopedTest extends TestCase
         $this->assertSame(
             [],
             $unresolved,
-            "These eager-loaded relations could not be resolved to a resource, so they are "
+            'These eager-loaded relations could not be resolved to a resource, so they are '
             ."loaded without a visibility scope:\n\n  ".implode("\n  ", $unresolved)."\n\n"
-            ."Either expose the relationship on the resource, or drop it from the eager-load list."
+            .'Either expose the relationship on the resource, or drop it from the eager-load list.'
         );
     }
 

--- a/framework/core/tests/integration/api/discussions/EagerLoadedRelationVisibilityTest.php
+++ b/framework/core/tests/integration/api/discussions/EagerLoadedRelationVisibilityTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\discussions;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A relation named in an endpoint's eagerLoad() list is pre-loaded with a plain
+ * loadMissing(), which bypasses EloquentBuffer::load() — the only place a
+ * related resource's scope() (whereVisibleTo) is applied. The serialiser then
+ * skips the scoped loader because the relation is already loaded, so the
+ * relation used to be serialised with no visibility check at all.
+ *
+ * The discussion Show endpoint eager-loads `firstPost.user.groups`, which drags
+ * in `firstPost`: a moderator-hidden or private opening post was returned in
+ * full to anyone who could see the discussion.
+ */
+class EagerLoadedRelationVisibilityTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Public discussion, hidden first post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 2, 'title' => 'Public discussion, private first post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 3, 'title' => 'Public discussion, visible first post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 3, 'comment_count' => 1, 'is_private' => 0],
+            ],
+            Post::class => [
+                ['id' => 1, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>hidden opening post</p></t>', 'hidden_at' => Carbon::now()->toDateTimeString()],
+                ['id' => 2, 'number' => 1, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>private opening post</p></t>', 'is_private' => 1],
+                ['id' => 3, 'number' => 1, 'discussion_id' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>visible opening post</p></t>'],
+            ],
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'bystander', 'email' => 'bystander@machine.local', 'is_email_confirmed' => 1, 'password' => 'too-obscure'],
+            ],
+        ]);
+    }
+
+    private function showDiscussion(int $id, ?int $actor = null): string
+    {
+        $response = $this->send(
+            $this->request('GET', "/api/discussions/$id", $actor ? ['authenticatedAs' => $actor] : [])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return (string) $response->getBody();
+    }
+
+    #[Test]
+    public function guest_does_not_receive_a_hidden_first_post()
+    {
+        $this->assertStringNotContainsString('hidden opening post', $this->showDiscussion(1));
+    }
+
+    #[Test]
+    public function other_user_does_not_receive_a_hidden_first_post()
+    {
+        $this->assertStringNotContainsString('hidden opening post', $this->showDiscussion(1, 3));
+    }
+
+    #[Test]
+    public function guest_does_not_receive_a_private_first_post()
+    {
+        $this->assertStringNotContainsString('private opening post', $this->showDiscussion(2));
+    }
+
+    /**
+     * The hidden post must not merely be stripped from `included`: the
+     * relationship linkage must be absent too, or the client is told a post
+     * exists at an id it cannot fetch.
+     */
+    #[Test]
+    public function a_hidden_first_post_is_not_linked_in_the_relationship()
+    {
+        $body = json_decode($this->showDiscussion(1), true);
+
+        $this->assertNull($body['data']['relationships']['firstPost']['data'] ?? null);
+    }
+
+    #[Test]
+    public function the_author_still_receives_their_own_hidden_first_post()
+    {
+        $this->assertStringContainsString('hidden opening post', $this->showDiscussion(1, 2));
+    }
+
+    #[Test]
+    public function an_admin_still_receives_a_hidden_first_post()
+    {
+        $this->assertStringContainsString('hidden opening post', $this->showDiscussion(1, 1));
+    }
+
+    #[Test]
+    public function a_visible_first_post_is_still_serialised()
+    {
+        $body = $this->showDiscussion(3);
+
+        $this->assertStringContainsString('visible opening post', $body);
+
+        $decoded = json_decode($body, true);
+        $this->assertEquals('3', $decoded['data']['relationships']['firstPost']['data']['id'] ?? null);
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

Relationship visibility is enforced in one place, `EloquentBuffer::load()`, and only when a relation is loaded lazily at serialisation time. Endpoints that pre-load a relation for performance ran a plain `loadMissing()` with no scope and no actor, and the serialiser then skipped the scoped loader because the relation was already loaded — so any relation in an endpoint's eager-load list that is also serialisable reached the client unchecked. This scopes the pre-load, so it filters exactly as the lazy path already did.

Reported by Adam Korczynski (ADA Logics).

**Changes proposed in this pull request:**

`HasEagerLoading::scopeEagerLoads()` applies each related resource's `scope()` to the relations pre-loaded before serialisation.

- Each path is expanded into all of its prefixes. `loadMissing()` binds a path's callback to its **last segment only**, so `'firstPost.user.groups' => $scope` would scope `groups` and leave `firstPost` — the relation that leaked — untouched.
- Both routes are covered: `eagerLoad()` and `eagerLoadWhere()`. A relation registered through the latter keeps its own query modification, applied alongside the scope rather than instead of it.
- Polymorphic relations are scoped per model class via `MorphTo::constrain()`, the same shape `EloquentBuffer::load()` uses. Calling `scope()` on a `MorphTo`'s own builder resolves the related model's scopes against the wrong model — on `notification.subject` that produced an `Unknown column 'visible_to'` 500.

Impacted: the discussion `Show` endpoint (`firstPost`), and `DialogMessageResource`'s mention relations in flarum/messages. Fixing the mechanism rather than those two relations also covers extensions — an `eagerLoad()` registered through `Extend\ApiResource` is scoped the moment it is registered.

Tests: `EagerLoadedRelationVisibilityTest` (hidden and private first post, plus the relationship linkage — a hidden post must not merely be stripped from `included`, or the client is told a post exists at an id it cannot fetch; three positive controls assert the author, an admin and a visible post are unaffected), `MentionedPostVisibilityTest` in flarum/messages, and `EagerLoadedRelationsAreScopedTest`, which guards the invariant rather than the two relations. All fail against the unpatched code.

**Reviewers should focus on:**

- The prefix expansion — whether any eager-load path shape in the wild is not covered by walking segments left to right.
- The `MorphTo` branch keys its constrain map by model class, so two resources backed by the same model would collide. That matches `EloquentBuffer`, but it is worth a second opinion.
- Relations that resolve to no database resource are loaded unscoped rather than dropped, to avoid reintroducing the N+1 the eager load exists to prevent; the serialiser still authorises each field. `discussion.state` is the case in core — not exposed as a relationship, and already scoped to the actor by the relation itself.
- Query counts are unchanged (18 and 12 on a 20-discussion fixture), since scoping adds a `WHERE` to a query that already runs rather than a round trip. The three query-count regression tests still pass, but a second look at the batching is welcome.

**Screenshot**

n/a — API-level change with no user-facing UI.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered? — dropping `firstPost` from the Show endpoint's list and the mention relations from `DialogMessageResource` closes the two known instances, but leaves the class open to any future `eagerLoad()` of an includable relation.
- [x] For core PRs, does this need to be in core, or could it be in an extension? — the defect is in core's eager-loading concern, which extensions build on.
- [x] Are we willing to maintain this for years / potentially forever? — it restores an invariant that was already intended, rather than adding a new mechanism.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here. — no frontend changes.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite). — no raw SQL; scoping goes through the existing resource `scope()` methods.
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
