### PR TITLE
[2.x] fix: contain custom LESS to Flarum's own import directories

### DIFF
--- a/framework/core/src/Forum/ValidateCustomLess.php
+++ b/framework/core/src/Forum/ValidateCustomLess.php
@@ -57,7 +57,14 @@ class ValidateCustomLess
         );
 
         foreach ($lessFeatureKeys as $key) {
-            if (is_string($event->settings[$key]) && preg_match('/@import|data-uri\s*\(/i', $event->settings[$key])) {
+            // The file system is taken away from the compiler by
+            // LessCompiler::containImports(), which is what actually stops a
+            // custom-LESS file read. This check stays so the administrator is
+            // told at save time rather than silently getting a stylesheet with
+            // the import dropped. `@impor` is matched as well as `@import`,
+            // because less.php matches the directive as `@import?` and so
+            // parses both the same way.
+            if (is_string($event->settings[$key]) && preg_match('/@impor|data-uri\s*\(/i', $event->settings[$key])) {
                 $translator = $this->container->make(TranslatorInterface::class);
 
                 throw new ValidationException([

--- a/framework/core/src/Frontend/Compiler/LessCompiler.php
+++ b/framework/core/src/Frontend/Compiler/LessCompiler.php
@@ -12,7 +12,7 @@ namespace Flarum\Frontend\Compiler;
 use Flarum\Frontend\Compiler\Source\FileSource;
 use Illuminate\Support\Collection;
 use Less_Cache;
-use Less_Exception_Compiler;
+use Less_Exception_Parser;
 use Less_Parser;
 
 /**
@@ -72,6 +72,58 @@ class LessCompiler extends RevisionCompiler
     }
 
     /**
+     * Resolve an `@import` against the permitted directories, and refuse it
+     * otherwise.
+     *
+     * Raw LESS can read any file the process can reach — `@import (inline)`
+     * pastes it in verbatim, and `data-uri()` encodes it into the stylesheet —
+     * and custom LESS is written by an administrator but compiled into the
+     * *public* stylesheet. That has to be contained here rather than by
+     * rejecting spellings in the setting: less.php's import directive is
+     * matched as `@import?`, so `@impor` parses identically, and any blocklist
+     * only ever chases the parser's grammar.
+     *
+     * Registered as the sole entry in less.php's `import_dirs`. A closure there
+     * is asked to resolve the path and may decline by returning null — but
+     * declining lets less.php fall back to reading the raw path, so an import
+     * we will not resolve has to throw instead.
+     *
+     * @return array{0: string, 1: null}
+     *
+     * @throws \Less_Exception_Parser
+     */
+    protected function containImports(string $path): array
+    {
+        foreach ($this->importDirs as $dir => $uri) {
+            // An entry may be given as a bare path with a numeric key, or as
+            // `path => uri` for URL rewriting.
+            $dir = is_string($dir) ? $dir : $uri;
+
+            if (! is_string($dir) || $dir === '') {
+                continue;
+            }
+
+            $root = realpath($dir);
+
+            if ($root === false) {
+                continue;
+            }
+
+            $resolved = realpath($root.'/'.ltrim($path, '/\\'));
+
+            // realpath() has followed `..` and any symlink, so a path that
+            // still starts with the directory really is inside it.
+            if ($resolved !== false && str_starts_with($resolved, $root.DIRECTORY_SEPARATOR)) {
+                return [$resolved, null];
+            }
+        }
+
+        throw new Less_Exception_Parser(
+            sprintf('Importing "%s" is not allowed.', $path)
+        );
+    }
+
+    /**
      * @throws \Less_Exception_Parser
      */
     protected function compile(array $sources): string
@@ -93,7 +145,9 @@ class LessCompiler extends RevisionCompiler
                 'compress' => true,
                 'strictMath' => false,
                 'cache_dir' => $this->cacheDir,
-                'import_dirs' => $this->importDirs,
+                // Resolve every `@import` ourselves, so one cannot reach a file
+                // outside the directories below. See containImports().
+                'import_dirs' => [$this->containImports(...)],
                 // less.php's built-in `serialize` cache writes each per-import
                 // cache file non-atomically and reads it back with an unguarded
                 // unserialize(). Concurrent compiles racing on the same file
@@ -137,7 +191,11 @@ class LessCompiler extends RevisionCompiler
                 }
 
                 return $compiled;
-            } catch (Less_Exception_Compiler $e) {
+            // Less_Exception_Compiler extends Less_Exception_Parser, so this
+            // covers both: a refused import (containImports()) raises the
+            // latter, and must drop the offending custom LESS like any other
+            // bad value rather than taking the whole forum down with it.
+            } catch (Less_Exception_Parser $e) {
                 if (isset($sources['custom_less'])) {
                     unset($sources['custom_less']);
 

--- a/framework/core/src/Frontend/Compiler/LessCompiler.php
+++ b/framework/core/src/Frontend/Compiler/LessCompiler.php
@@ -191,10 +191,10 @@ class LessCompiler extends RevisionCompiler
                 }
 
                 return $compiled;
-            // Less_Exception_Compiler extends Less_Exception_Parser, so this
-            // covers both: a refused import (containImports()) raises the
-            // latter, and must drop the offending custom LESS like any other
-            // bad value rather than taking the whole forum down with it.
+                // Less_Exception_Compiler extends Less_Exception_Parser, so this
+                // covers both: a refused import (containImports()) raises the
+                // latter, and must drop the offending custom LESS like any other
+                // bad value rather than taking the whole forum down with it.
             } catch (Less_Exception_Parser $e) {
                 if (isset($sources['custom_less'])) {
                     unset($sources['custom_less']);

--- a/framework/core/tests/integration/forum/CustomLessFileAccessTest.php
+++ b/framework/core/tests/integration/forum/CustomLessFileAccessTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\forum;
+
+use Flarum\Frontend\Compiler\Source\SourceCollector;
+use Flarum\Frontend\Compiler\Source\StringSource;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Raw LESS can read arbitrary files through `@import (inline)` and `data-uri()`,
+ * so custom LESS — which an administrator supplies and which is compiled into
+ * the public stylesheet — must not be able to reach outside Flarum's own LESS
+ * directories.
+ *
+ * This was previously enforced by rejecting the literal strings `@import` and
+ * `data-uri(`. The parser accepts `@impor` as well (its directive regex makes
+ * the trailing `t` optional), so that spelling passed validation and inlined
+ * the file. A blocklist can only ever chase the parser's grammar, so the file
+ * system is taken away from the compiler instead.
+ */
+class CustomLessFileAccessTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Compiling the full stylesheet (and its source map) needs more than
+        // the default limit an isolated test process gets.
+        ini_set('memory_limit', '512M');
+
+        $this->prepareDatabase([
+            'users' => [$this->normalUser()],
+        ]);
+    }
+
+    private function secretFile(): string
+    {
+        $path = sys_get_temp_dir().'/flarum-less-secret.txt';
+        file_put_contents($path, 'SECRET-LESS-FILE-READ db_password=hunter2');
+
+        return $path;
+    }
+
+    private function saveCustomLess(string $less): int
+    {
+        return $this->send($this->request('POST', '/api/settings', [
+            'authenticatedAs' => 1,
+            'json' => ['custom_less' => $less],
+        ]))->getStatusCode();
+    }
+
+    private function compiledForumCss(): string
+    {
+        $assets = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets');
+
+        // Drop any stylesheet compiled before the setting was saved, so this
+        // reads the result of a real recompile rather than a cached file.
+        foreach ($assets->allFiles() as $file) {
+            if (str_ends_with($file, '.css')) {
+                $assets->delete($file);
+            }
+        }
+
+        $this->send($this->request('GET', '/'));
+
+        $path = $assets->path('forum.css');
+
+        return file_exists($path) ? file_get_contents($path) : '';
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function fileReadingDirectives(): iterable
+    {
+        // The spelling the blocklist knew about.
+        yield '@import (inline)' => ['@import (inline) "%s";'];
+        // The same directive with the trailing `t` dropped: `@import?` in the
+        // parser makes it optional, so this parses identically.
+        yield '@impor (inline)' => ['@impor (inline) "%s";'];
+        // A second read path, through a function rather than a directive.
+        yield 'data-uri()' => ['body { background: data-uri("%s"); }'];
+    }
+
+    #[Test]
+    #[DataProvider('fileReadingDirectives')]
+    public function custom_less_cannot_read_a_file_outside_flarum(string $template)
+    {
+        $secret = $this->secretFile();
+
+        $status = $this->saveCustomLess(sprintf($template, $secret));
+
+        // Either refusing the setting or compiling it without the file is an
+        // acceptable outcome; disclosing the file is not.
+        $this->assertStringNotContainsString(
+            'SECRET-LESS-FILE-READ',
+            $this->compiledForumCss(),
+            "a file outside Flarum was inlined into the public stylesheet (save returned $status)"
+        );
+    }
+
+    #[Test]
+    public function custom_less_cannot_traverse_out_of_an_allowed_directory()
+    {
+        $secret = $this->secretFile();
+
+        $this->saveCustomLess(sprintf(
+            '@impor (inline) "../../../../../../..%s";',
+            $secret
+        ));
+
+        $this->assertStringNotContainsString('SECRET-LESS-FILE-READ', $this->compiledForumCss());
+    }
+
+    /**
+     * Custom LESS must reach the compiler as a string, with no file of its own.
+     *
+     * less.php resolves a relative import against the importing file's own
+     * directory *before* it consults `import_dirs`, so a source that carries a
+     * file path can walk out of it with `../` without containImports() ever
+     * being asked. Custom LESS escapes that only because it is added with
+     * SourceCollector::addString() and parsed with no file URI.
+     *
+     * That is load-bearing rather than incidental: giving custom LESS a path —
+     * writing it to a temp file, say — would silently reopen the file read this
+     * test class covers. The relative traversal below is the behaviour that
+     * would break, asserted here on its own so the reason is not lost.
+     */
+    #[Test]
+    public function custom_less_is_compiled_without_a_file_of_its_own()
+    {
+        $sources = new SourceCollector();
+
+        $sources->addString(fn () => '.marker { color: red; }', 'custom_less');
+
+        $this->assertInstanceOf(
+            StringSource::class,
+            $sources->getSources()['custom_less'],
+            'custom LESS must stay a StringSource: a source with a path can resolve '
+            .'a relative import against its own directory, bypassing containImports()'
+        );
+    }
+
+    /**
+     * The companion to the assertion above, stated as behaviour: a relative
+     * path must not escape, however the source is plumbed.
+     */
+    #[Test]
+    public function custom_less_cannot_traverse_with_a_relative_path()
+    {
+        $secret = $this->secretFile();
+
+        // Walk up further than any real directory nesting, so this lands at the
+        // filesystem root wherever the compiler happens to be rooted.
+        $this->saveCustomLess(sprintf(
+            '@impor (inline) "%s%s";',
+            str_repeat('../', 40),
+            ltrim($secret, '/')
+        ));
+
+        $this->assertStringNotContainsString('SECRET-LESS-FILE-READ', $this->compiledForumCss());
+    }
+
+    /**
+     * Containment stops the file read, but the administrator should still be
+     * told at save time rather than silently getting a stylesheet with the
+     * import dropped.
+     */
+    #[Test]
+    public function saving_a_file_reading_directive_is_rejected()
+    {
+        $this->assertEquals(422, $this->saveCustomLess('@impor (inline) "/etc/passwd";'));
+        $this->assertEquals(422, $this->saveCustomLess('@import (inline) "/etc/passwd";'));
+        $this->assertEquals(422, $this->saveCustomLess('body { background: data-uri("/etc/passwd"); }'));
+    }
+
+    /**
+     * The point of the change is containment, not breaking theming: ordinary
+     * custom LESS must still compile into the stylesheet.
+     */
+    #[Test]
+    public function ordinary_custom_less_still_compiles()
+    {
+        $status = $this->saveCustomLess('.custom-less-marker { color: #abcdef; }');
+
+        $this->assertEquals(204, $status);
+        $this->assertStringContainsString('.custom-less-marker', $this->compiledForumCss());
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

Custom LESS is compiled into the public stylesheet, and raw LESS can read any file the process can reach with `@import (inline)`. That was guarded by rejecting the strings `@import` and `data-uri(` in the setting, but less.php matches the directive as `@import?` — the trailing `t` is optional — so `@impor (inline) "/etc/passwd";` passed validation and the file was served to everyone in `forum.css`. This resolves every import against Flarum's own LESS directories instead, so no spelling reaches a file outside them.

Reported by Adam Korczynski (ADA Logics).

**Changes proposed in this pull request:**

`LessCompiler::containImports()` becomes the sole entry in less.php's `import_dirs`, resolving each import with `realpath()` and refusing anything outside the permitted directories. It throws rather than returning null, because a closure that declines lets less.php fall back to reading the raw path. `data-uri()` goes through the same resolution, so it is covered too.

The catch that drops bad custom LESS is widened from `Less_Exception_Compiler` to its parent `Less_Exception_Parser`, so a refused import records `custom_less_error` instead of returning 500 on every page.

The blocklist in `ValidateCustomLess` stays, widened to `@impor`. It is no longer the boundary, but it still gives the administrator a 422 at save time, and two CVE-2023-27577 regression tests depend on that.

Impacted: the appearance page's custom LESS, and any setting registered as a LESS config variable.

**Reviewers should focus on:**

Containment is only as tight as the registered import directories. Core registers one (FontAwesome), but an extension calling `setLessImportDirs()` with something broad widens what custom LESS can read inside that tree — with `/var/www`, `@impor (inline) "config.php";` resolves. I have not changed registration here and would like a second opinion on whether it should validate the directory.

Also worth a look: `containImports()` accepts both `['path' => 'uri']` and bare-path entries, since the array shape is not enforced anywhere.

**Screenshot**

n/a — no user-facing UI change.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
