### PR TITLE
[2.x] chore(deps): hold larastan below 3.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -182,7 +182,7 @@
     },
     "require-dev": {
         "flarum/testing-tests": "*@dev",
-        "larastan/larastan": "^3.8",
+        "larastan/larastan": "^3.8 <3.12",
         "mockery/mockery": "^1.5",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^12.5.22",

--- a/php-packages/phpstan/composer.json
+++ b/php-packages/phpstan/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "flarum/testing": "^2.0",
         "phpstan/phpstan": "^2.1",
-        "larastan/larastan": "^3.8"
+        "larastan/larastan": "^3.8 <3.12"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
**Fixes #0000**

PHPStan started failing on every branch, including 2.x itself, with an internal error rather than a rule violation:

```
Internal error: Call to undefined function view() while analysing file
  framework/core/src/Install/Controller/IndexController.php
[ERROR] Found 1 error
```

Nothing in the tree changed. `larastan/larastan` v3.12.0 was released at 09:32 UTC today, our constraint is `^3.8`, and CI resolves dependencies on every run, so it was picked up automatically. This holds larastan below 3.12 until the crash is fixed upstream.

**Changes proposed in this pull request:**

`larastan/larastan` goes from `^3.8` to `^3.8 <3.12`, in the root `composer.json` and in `php-packages/phpstan` (which carries its own constraint, so pinning only the root would still resolve 3.12 for anyone depending on `flarum/phpstan`).

Temporary. It should be reverted once a fixed larastan is out.

**Reviewers should focus on:**

Whether `<3.12` is the right shape, or whether this should pin harder (`3.11.*`) or use a `conflict` entry instead. I went with an upper bound so a patch release in the 3.11 line is still picked up.

How the failure was isolated, in case the diagnosis is worth double-checking: I pushed an empty commit on the same base commit and it failed identically, then diffed the resolved package versions between the last passing run and the failure. All 588 locked packages matched except larastan, v3.11.0 → v3.12.0. Locally, `composer analyse:phpstan` reports `[OK] No errors` across 1002 files with v3.11.0 installed.

**Screenshot**

n/a — CI-only change.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
