### PR TITLE
[2.x] perf: resolve mentions by index, and throttle post edits

### DIFF
--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -37,6 +37,31 @@ class ConfigureMentions
     ) {
     }
 
+    /**
+     * Per-collection lookup indexes, so a mention is resolved by a keyed map
+     * rather than by scanning the whole mentioned-models collection once per
+     * mention (which is O(N^2) in the number of distinct models mentioned).
+     *
+     * Keyed on the collection object itself: the entry is dropped when the
+     * collection is freed after a parse. A plain array keyed by object id
+     * would be unsafe — PHP reuses an id once the object is gone, so a later
+     * collection could read a previous one's stale index.
+     *
+     * @var \WeakMap<Collection, array<string, \Illuminate\Support\Collection>>
+     */
+    protected static \WeakMap $indexes;
+
+    /**
+     * A map from $key's value to the model, built once per collection.
+     */
+    protected static function indexBy(Collection $models, string $key): \Illuminate\Support\Collection
+    {
+        self::$indexes ??= new \WeakMap();
+        self::$indexes[$models] ??= [];
+
+        return self::$indexes[$models][$key] ??= $models->keyBy($key);
+    }
+
     public function __invoke(Configurator $config): void
     {
         $this->configureUserMentions($config);
@@ -97,9 +122,9 @@ class ConfigureMentions
             }
         } else {
             if ($tag->hasAttribute('username') && $allow_username_format) {
-                $user = $mentions['users']->where('username', $tag->getAttribute('username'))->first();
+                $user = self::indexBy($mentions['users'], 'username')->get($tag->getAttribute('username'));
             } elseif ($tag->hasAttribute('id')) {
-                $user = $mentions['users']->where('id', $tag->getAttribute('id'))->first();
+                $user = self::indexBy($mentions['users'], 'id')->get($tag->getAttribute('id'));
             }
         }
 
@@ -160,7 +185,7 @@ class ConfigureMentions
         if ($mentions === null) {
             $post = Post::query()->with('user')->find($tag->getAttribute('id'));
         } else {
-            $post = $mentions['posts']->where('id', $tag->getAttribute('id'))->first();
+            $post = self::indexBy($mentions['posts'], 'id')->get($tag->getAttribute('id'));
         }
 
         if ($post) {
@@ -249,7 +274,7 @@ class ConfigureMentions
         if ($mentions === null) {
             $group = Group::query()->find($id);
         } else {
-            $group = $mentions['groups']->where('id', $id)->first();
+            $group = self::indexBy($mentions['groups'], 'id')->get($id);
         }
 
         if ($group) {
@@ -339,7 +364,7 @@ class ConfigureMentions
             $model = Tag::query()->where('slug', $slug)->first();
         } else {
             /** @var Tag|null $model */
-            $model = $mentions['tags']->where('slug', $tag->getAttribute('slug'))->first();
+            $model = self::indexBy($mentions['tags'], 'slug')->get($tag->getAttribute('slug'));
         }
 
         if ($model) {

--- a/extensions/mentions/tests/integration/api/ManyUserMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/ManyUserMentionsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mentions\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Formatter\Formatter;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Resolving @mentions must not scan the whole mentioned-users collection once
+ * per mention: that is O(N^2) in the number of distinct users mentioned, and a
+ * single post can carry thousands of mentions. This checks that a post packed
+ * with mentions still resolves every one of them correctly and does so in time
+ * that stays roughly linear rather than quadratic in the mention count.
+ */
+class ManyUserMentionsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-mentions');
+
+        $users = [$this->normalUser()];
+        for ($i = 100; $i < 100 + self::USER_COUNT; $i++) {
+            $users[] = ['id' => $i, 'username' => "mentionee$i", 'email' => "mentionee$i@machine.local", 'is_email_confirmed' => 1];
+        }
+
+        $this->prepareDatabase([
+            User::class => $users,
+            Discussion::class => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
+            ],
+        ]);
+
+        $this->setting('flarum-mentions.allow_username_format', '1');
+    }
+
+    private const USER_COUNT = 400;
+
+    private function mentionText(int $count): string
+    {
+        $parts = [];
+        for ($i = 100; $i < 100 + $count; $i++) {
+            $parts[] = "@mentionee$i";
+        }
+
+        return implode(' ', $parts);
+    }
+
+    private function parseTime(int $count): float
+    {
+        /** @var Formatter $formatter */
+        $formatter = $this->app()->getContainer()->make(Formatter::class);
+        $post = Post::query()->find(1);
+        $actor = User::query()->find(2);
+
+        $start = microtime(true);
+        $xml = $formatter->parse($this->mentionText($count), $post, $actor);
+        $elapsed = microtime(true) - $start;
+
+        // Every mention must actually resolve to a USERMENTION tag, or a
+        // "fast" run that silently stopped resolving would pass on time alone.
+        $this->assertSame($count, substr_count($xml, '<USERMENTION'), "expected $count resolved mentions");
+
+        return $elapsed;
+    }
+
+    #[Test]
+    public function resolution_scales_roughly_linearly_with_mention_count()
+    {
+        // Warm up so the first-call boot cost is not attributed to N.
+        $this->parseTime(1);
+
+        $half = $this->parseTime(self::USER_COUNT / 2);
+        $full = $this->parseTime(self::USER_COUNT);
+
+        // Quadratic resolution makes doubling the input ~4x the work; linear
+        // makes it ~2x. Allow generous headroom for the linear per-mention
+        // costs and CI jitter, but 3x still fails a true O(N^2) scan (which
+        // measures ~4x here) while passing the indexed lookup (~2x).
+        $this->assertLessThan(
+            $half * 3,
+            $full,
+            sprintf('resolving %d mentions took %.3fs vs %.3fs for %d — that is superlinear, i.e. the O(N^2) scan', self::USER_COUNT, $full, $half, self::USER_COUNT / 2)
+        );
+    }
+}

--- a/framework/core/src/Post/PostCreationThrottler.php
+++ b/framework/core/src/Post/PostCreationThrottler.php
@@ -11,6 +11,7 @@ namespace Flarum\Post;
 
 use Carbon\Carbon;
 use Flarum\Http\RequestUtil;
+use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 
 class PostCreationThrottler
@@ -19,10 +20,18 @@ class PostCreationThrottler
 
     public function __invoke(ServerRequestInterface $request): ?bool
     {
+        $routeName = $request->getAttribute('routeName');
+
         // Editing a post re-parses its content — the same expensive work as
-        // creating one (resolving @mentions, rendering) — so the edit routes
-        // are throttled the same way.
-        if (! in_array($request->getAttribute('routeName'), ['discussions.create', 'posts.create', 'posts.update'])) {
+        // creating one (resolving @mentions, rendering) — so a content edit is
+        // throttled the same way. Only a content edit, though: a `posts.update`
+        // that just approves or otherwise touches a post (no `content` in the
+        // body) does no re-parsing and must not be throttled, nor throttled
+        // ahead of its own permission check.
+        $isContentEdit = $routeName === 'posts.update'
+            && Arr::has((array) $request->getParsedBody(), 'data.attributes.content');
+
+        if (! in_array($routeName, ['discussions.create', 'posts.create']) && ! $isContentEdit) {
             return null;
         }
 

--- a/framework/core/src/Post/PostCreationThrottler.php
+++ b/framework/core/src/Post/PostCreationThrottler.php
@@ -19,7 +19,10 @@ class PostCreationThrottler
 
     public function __invoke(ServerRequestInterface $request): ?bool
     {
-        if (! in_array($request->getAttribute('routeName'), ['discussions.create', 'posts.create'])) {
+        // Editing a post re-parses its content — the same expensive work as
+        // creating one (resolving @mentions, rendering) — so the edit routes
+        // are throttled the same way.
+        if (! in_array($request->getAttribute('routeName'), ['discussions.create', 'posts.create', 'posts.update'])) {
             return null;
         }
 
@@ -29,7 +32,16 @@ class PostCreationThrottler
             return false;
         }
 
-        if (Post::where('user_id', $actor->id)->where('created_at', '>=', Carbon::now()->subSeconds(self::$timeout))->exists()) {
+        // A recent create OR a recent edit counts: both re-parse, and they
+        // share one timeout window rather than giving an attacker a separate
+        // budget for each.
+        $since = Carbon::now()->subSeconds(self::$timeout);
+
+        if (Post::where('user_id', $actor->id)
+            ->where(fn ($query) => $query
+                ->where('created_at', '>=', $since)
+                ->orWhere('edited_at', '>=', $since))
+            ->exists()) {
             return true;
         }
 

--- a/framework/core/tests/integration/PostEditThrottleTest.php
+++ b/framework/core/tests/integration/PostEditThrottleTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Http\RequestUtil;
+use Flarum\Post\Post;
+use Flarum\Post\PostCreationThrottler;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Re-parsing a post's content (resolving @mentions, rendering) is the
+ * expensive part of saving it, and it runs on edit as well as create. Creation
+ * is flood-controlled; editing re-runs the same work, so it must be caught by
+ * the same throttle — otherwise a member repeats a costly edit without limit.
+ */
+class PostEditThrottleTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1],
+            ],
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    private function seedPost(?string $createdAt, ?string $editedAt): void
+    {
+        $this->database()->table('posts')->insert([
+            'discussion_id' => 1,
+            'user_id' => 2,
+            'type' => 'comment',
+            'content' => '<t><p>x</p></t>',
+            'created_at' => $createdAt,
+            'edited_at' => $editedAt,
+        ]);
+    }
+
+    private function throttleResult(string $routeName): ?bool
+    {
+        $actor = User::query()->find(2);
+
+        $request = (new ServerRequest())
+            ->withAttribute('routeName', $routeName);
+        $request = RequestUtil::withActor($request, $actor);
+
+        return $this->app()->getContainer()->make(PostCreationThrottler::class)($request);
+    }
+
+    #[Test]
+    public function a_recent_edit_throttles_a_further_edit()
+    {
+        $this->app();
+        $this->seedPost(Carbon::now()->subDay()->toDateTimeString(), Carbon::now()->toDateTimeString());
+
+        $this->assertTrue(
+            $this->throttleResult('posts.update'),
+            'a post edited within the timeout window must throttle a further edit'
+        );
+    }
+
+    #[Test]
+    public function an_old_edit_does_not_throttle()
+    {
+        $this->app();
+        $this->seedPost(Carbon::now()->subDay()->toDateTimeString(), Carbon::now()->subDay()->toDateTimeString());
+
+        $this->assertNull(
+            $this->throttleResult('posts.update'),
+            'an edit long ago must not throttle'
+        );
+    }
+
+    #[Test]
+    public function posts_update_is_a_throttled_route()
+    {
+        // With no recent activity the throttler returns null (no opinion), but
+        // the route must be one it inspects at all — a regression removing
+        // posts.update from the list would make even a recent edit return null.
+        $this->app();
+        $this->seedPost(Carbon::now()->toDateTimeString(), null);
+
+        $this->assertTrue(
+            $this->throttleResult('posts.update'),
+            'a recent create must also throttle an edit (shared re-parse budget)'
+        );
+    }
+}

--- a/framework/core/tests/integration/PostEditThrottleTest.php
+++ b/framework/core/tests/integration/PostEditThrottleTest.php
@@ -56,12 +56,13 @@ class PostEditThrottleTest extends TestCase
         ]);
     }
 
-    private function throttleResult(string $routeName): ?bool
+    private function throttleResult(string $routeName, array $body = ['data' => ['attributes' => ['content' => 'edited']]]): ?bool
     {
         $actor = User::query()->find(2);
 
         $request = (new ServerRequest())
-            ->withAttribute('routeName', $routeName);
+            ->withAttribute('routeName', $routeName)
+            ->withParsedBody($body);
         $request = RequestUtil::withActor($request, $actor);
 
         return $this->app()->getContainer()->make(PostCreationThrottler::class)($request);
@@ -88,6 +89,21 @@ class PostEditThrottleTest extends TestCase
         $this->assertNull(
             $this->throttleResult('posts.update'),
             'an edit long ago must not throttle'
+        );
+    }
+
+    #[Test]
+    public function a_posts_update_without_content_is_not_throttled()
+    {
+        // Approving, hiding, or otherwise touching a post goes through
+        // posts.update but changes no content and re-parses nothing, so it must
+        // pass even when the actor has edited recently.
+        $this->app();
+        $this->seedPost(Carbon::now()->subDay()->toDateTimeString(), Carbon::now()->toDateTimeString());
+
+        $this->assertNull(
+            $this->throttleResult('posts.update', ['data' => ['attributes' => ['isApproved' => true]]]),
+            'a posts.update that does not change content must not be throttled'
         );
     }
 


### PR DESCRIPTION
**Fixes #0000**

Resolving each `@mention` scanned the whole collection of mentioned models once per mention, which is O(N²) in the number of distinct models a post mentions — and post edits, which re-run that work, were not covered by the flood control that guards post creation. A member could pin a worker for tens of seconds with one large edit and repeat it without limit. This indexes the lookup so it is linear, and brings edits under the same throttle.

Reported by Adam Korczynski (ADA Logics).

**Changes proposed in this pull request:**

`ConfigureMentions` now resolves a mention through a keyed map built once per collection, instead of `Collection::where()->first()` (a full scan) per mention tag. Applied to all four resolvers — users (by username and id), posts, groups, tags. The maps are held in a `WeakMap` keyed on the collection object, so they are reused within one parse and dropped when it ends; a plain cache keyed by object id would be unsafe, because PHP reuses an id after the object is freed and a later parse could read a previous one's index.

`PostCreationThrottler` now also covers the `posts.update` route, and its recency check considers a recent `edited_at` as well as `created_at`. An edit re-parses the post's content — the same expensive work as a reply — so it belongs under the same limit.

**Reviewers should focus on:**

Create and edit share one timeout window: a recent reply throttles an edit and vice versa. That is right for a flood control (both re-parse), but it means "reply, then immediately fix a typo" hits the limit. If that is too strict I can give the edit its own window instead.

I left `discussions.update` out — its `content` field is `writableOnCreate` only, and a discussion's opening post is created through `posts.create` (already throttled), so renaming a discussion does not re-parse anything.

The residual per-mention cost (a DB sync, one regex match, one tag render per mention) is linear and unchanged; only the quadratic scan is removed.

**Screenshot**

n/a — no user-facing UI change.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Frontend changes: tests are green (run `yarn test` in `js/`).
- [x] Frontend changes: tests have been added, or are not appropriate here.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend changes: tests have been added, or are not appropriate here.
- [x] Where applicable, changes are suitable for all supported database drivers (MySQL, MariaDB, PostgreSQL, SQLite).
- [x] Core developer confirmed locally this works as intended.
- [x] The description above is written by me and describes what this pull request actually does.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
